### PR TITLE
Set cache update timeout to one day

### DIFF
--- a/app/src/main/kotlin/core/Filters.kt
+++ b/app/src/main/kotlin/core/Filters.kt
@@ -188,7 +188,7 @@ fun newFiltersModule(ctx: Context): Kodein.Module {
                     cacheFile = File(getPersistencePath(ctx).absoluteFile, "filters"),
                     exportFile = getPublicPersistencePath("blokada-export")
                             ?: File(getPersistencePath(ctx).absoluteFile, "blokada-export"),
-                    cacheTTLMillis = 1 * 24 * 60 * 60 * 100L, // A
+                    cacheTTLMillis = 1 * 24 * 60 * 60 * 1000L, // A
                     fetchTimeoutMillis = 10 * 1000
             )
         }


### PR DESCRIPTION
The existing definition of cacheTTLMillis was specified in centiseconds, rather than milliseconds, leading to a cache file update 10 times per day. This updates that to be once a day, which should be sufficient for most people, at least until a tunable parameter can be specified.

This 10x daily refreshing was responsible for some ridiculous data usage. Although not directly the issue for, e.g., #195, this certainly exacerbates those situations.