### PR TITLE
Patch for using DNS servers on nonstandard ports

### DIFF
--- a/app/src/legacy/kotlin/core/Dns.kt
+++ b/app/src/legacy/kotlin/core/Dns.kt
@@ -218,7 +218,7 @@ class DnsSerialiser {
                 val servers = entry[4].split(";").filter { it.isNotBlank() }.map {
                     val hostport = it.split(':',limit=2)
                     val host = hostport[0]
-                    val port = hostport[1].toIntOrNull() ?:UdpPort.DOMAIN.valueAsInt()
+                    val port = (if (hostport.size==2) hostport[1] else "").toIntOrNull() ?: UdpPort.DOMAIN.valueAsInt()
                     InetSocketAddress(InetAddress.getByName(host), port)
                 }
                 val credit = if (entry[5].isNotBlank()) entry[5] else null
@@ -572,7 +572,7 @@ class AddDialog(
                 runBlocking { async {
                     val hostport = it.split(':',limit=2)
                     val host = hostport[0]
-                    val port = hostport[1].toIntOrNull() ?:UdpPort.DOMAIN.valueAsInt()
+                    val port = (if (hostport.size==2) hostport[1] else "").toIntOrNull() ?: UdpPort.DOMAIN.valueAsInt()
                     InetSocketAddress(InetAddress.getByName(host), port)
                 }.await() }
             }
@@ -727,8 +727,8 @@ class DnsAddView(
             else -> { try {
                     val hostport = s.split(':',limit=2)
                     val host = hostport[0]
-                    val port = hostport[1].toIntOrNull() ?:UdpPort.DOMAIN.valueAsInt()
-                    InetSocketAddress(InetAddress.getByName(host), port)
+                    val port = (if (hostport.size==2) hostport[1] else "").toIntOrNull() ?: UdpPort.DOMAIN.valueAsInt()
+                InetSocketAddress(InetAddress.getByName(host), port)
                     true
                 } catch (e: Exception) { false }
             }

--- a/app/src/legacy/kotlin/core/Dns.kt
+++ b/app/src/legacy/kotlin/core/Dns.kt
@@ -216,9 +216,9 @@ class DnsSerialiser {
                 val active = entry[2] == "active"
                 val ipv6 = entry[3] == "ipv6"
                 val servers = entry[4].split(";").filter { it.isNotBlank() }.map {
-                    val hostport = it.split(':')
+                    val hostport = it.split(':',limit=2)
                     val host = hostport[0]
-                    val port = (hostport[1] ?: UdpPort.DOMAIN) as Int
+                    val port = hostport[1].toIntOrNull() ?:UdpPort.DOMAIN.valueAsInt()
                     InetSocketAddress(InetAddress.getByName(host), port)
                 }
                 val credit = if (entry[5].isNotBlank()) entry[5] else null
@@ -570,9 +570,9 @@ class AddDialog(
         else {
             val s = listOf(view.appView.server1, view.appView.server2).filter { it.isNotBlank() }.map {
                 runBlocking { async {
-                    val hostport = it.split(':')
+                    val hostport = it.split(':',limit=2)
                     val host = hostport[0]
-                    val port = (hostport[1] ?: UdpPort.DOMAIN) as Int
+                    val port = hostport[1].toIntOrNull() ?:UdpPort.DOMAIN.valueAsInt()
                     InetSocketAddress(InetAddress.getByName(host), port)
                 }.await() }
             }
@@ -725,9 +725,9 @@ class DnsAddView(
             forceNotEmpty && s.isBlank() -> false
             s.isBlank() -> true
             else -> { try {
-                    val hostport = s.split(':')
+                    val hostport = s.split(':',limit=2)
                     val host = hostport[0]
-                    val port = (hostport[1] ?: UdpPort.DOMAIN) as Int
+                    val port = hostport[1].toIntOrNull() ?:UdpPort.DOMAIN.valueAsInt()
                     InetSocketAddress(InetAddress.getByName(host), port)
                     true
                 } catch (e: Exception) { false }

--- a/app/src/legacy/kotlin/core/Dns.kt
+++ b/app/src/legacy/kotlin/core/Dns.kt
@@ -200,7 +200,7 @@ class DnsSerialiser {
         return dns.map {
             val active = if (it.active) "active" else "inactive"
             val ipv6 = if (it.ipv6) "ipv6" else "ipv4"
-            val servers = it.servers.map { it.toString() }.joinToString(";")
+            val servers = it.servers.map { it.getHostString() + ( if(it.getPort()!=53) ":" + it.getPort().toString() else "" ) }.joinToString(";")
             val credit = it.credit ?: ""
             val comment = it.comment ?: ""
 
@@ -450,7 +450,7 @@ class DnsListView(
 }
 
 fun printServers(s: List<InetSocketAddress>): String {
-    return s.map { it.toString() }.joinToString (", ")
+    return s.map { it.getHostString() + ( if(it.getPort()!=53) ":" + it.getPort().toString() else "" ) }.joinToString (", ")
 }
 
 class DnsActor(
@@ -545,7 +545,7 @@ class AddDialog(
     fun show(filter: DnsChoice?) {
         view.appView.reset()
         if (filter != null) {
-            val s = filter.servers.map { it.toString() }.toMutableList()
+            val s = filter.servers.map { it.getHostString() + ( if(it.getPort()!=53) ":" + it.getPort().toString() else "" ) }.toMutableList()
             view.appView.server1 = s.first()
             view.appView.server2 = s.getOrElse(1, {""})
             view.appView.correct = true

--- a/app/src/legacy/kotlin/gs/environment/AConnectivity.kt
+++ b/app/src/legacy/kotlin/gs/environment/AConnectivity.kt
@@ -25,7 +25,7 @@ fun isTethering(ctx: android.content.Context, intent: android.content.Intent? = 
 fun getDnsServers(ctx: android.content.Context): List<java.net.InetSocketAddress> {
     var servers = if (android.os.Build.VERSION.SDK_INT >= 21) gs.environment.getDnsServersMethod1(ctx) else emptyList()
     if (servers.isEmpty()) servers = gs.environment.getDnsServersMethod2()
-    return servers.map { java.net.InetSocketAddress(it, UdpPort.DOMAIN as Int) }
+    return servers.map { java.net.InetSocketAddress(it, UdpPort.DOMAIN.valueAsInt()) }
 }
 
 fun isWifi(ctx: android.content.Context): Boolean {

--- a/app/src/legacy/kotlin/gs/environment/AConnectivity.kt
+++ b/app/src/legacy/kotlin/gs/environment/AConnectivity.kt
@@ -2,6 +2,7 @@ package gs.environment
 
 import android.net.ConnectivityManager
 import android.net.wifi.WifiManager
+import org.pcap4j.packet.namednumber.UdpPort
 
 /**
  * Contains various utility functions related to connectivity on Android.
@@ -21,10 +22,10 @@ fun isTethering(ctx: android.content.Context, intent: android.content.Intent? = 
     return tethering
 }
 
-fun getDnsServers(ctx: android.content.Context): List<java.net.InetAddress> {
+fun getDnsServers(ctx: android.content.Context): List<java.net.InetSocketAddress> {
     var servers = if (android.os.Build.VERSION.SDK_INT >= 21) gs.environment.getDnsServersMethod1(ctx) else emptyList()
     if (servers.isEmpty()) servers = gs.environment.getDnsServersMethod2()
-    return servers
+    return servers.map { java.net.InetSocketAddress(it, UdpPort.DOMAIN as Int) }
 }
 
 fun isWifi(ctx: android.content.Context): Boolean {

--- a/app/src/legacy/res/layout/view_dnsadd.xml
+++ b/app/src/legacy/res/layout/view_dnsadd.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <core.DnsAddView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/colorBackground">
@@ -21,9 +22,8 @@
             android:id="@+id/filter_edit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/dns_edit_name_placeholder"
-            android:digits="0123456789."
-            android:inputType="numberSigned|numberDecimal" />
+            android:digits="0123456789.:"
+            android:hint="@string/dns_edit_name_placeholder" />
 
         <TextView
             android:layout_width="match_parent"

--- a/app/src/tunnel/kotlin/tunnel/Main.kt
+++ b/app/src/tunnel/kotlin/tunnel/Main.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.experimental.newSingleThreadContext
 import kotlinx.coroutines.experimental.runBlocking
 import java.io.FileDescriptor
 import java.net.DatagramSocket
-import java.net.InetAddress
+import java.net.InetSocketAddress
 import java.util.*
 
 object Events {
@@ -42,7 +42,7 @@ class Main(
             onClose = onVpnClose,
             onConfigure = { ktx, tunnel -> 0L }
     )
-    private var currentServers = emptyList<InetAddress>()
+    private var currentServers = emptyList<InetSocketAddress>()
     private var currentUrl: String = ""
 
     private var tunnelThread: Thread? = null
@@ -54,7 +54,7 @@ class Main(
     private var threadCounter = 0
     private var usePausedConfigurator = false
 
-    fun setup(ktx: AndroidKontext, servers: List<InetAddress>, start: Boolean = false) = async(CTRL) {
+    fun setup(ktx: AndroidKontext, servers: List<InetSocketAddress>, start: Boolean = false) = async(CTRL) {
         ktx.v("setup tunnel, start = $start, enabled = $enabled", servers)
         when {
             servers.isEmpty() -> {

--- a/app/src/tunnel/kotlin/tunnel/Proxy.kt
+++ b/app/src/tunnel/kotlin/tunnel/Proxy.kt
@@ -10,6 +10,7 @@ import org.xbill.DNS.*
 import java.io.IOException
 import java.net.*
 import java.util.*
+import org.pcap4j.packet.namednumber.UdpPort
 
 internal class Proxy(
         private val dnsServers: List<InetSocketAddress>,
@@ -116,7 +117,7 @@ internal class Proxy(
 
     private fun resolveActualDestination(packet: IpPacket): InetSocketAddress {
         val servers = dnsServers
-        val current = InetSocketAddress(packet.header.dstAddr, packet.header.dstPort)
+        val current = InetSocketAddress(packet.header.dstAddr, UdpPort.DOMAIN as Int)
         return when {
             servers.isEmpty() -> current
             else -> try {

--- a/app/src/tunnel/kotlin/tunnel/Proxy.kt
+++ b/app/src/tunnel/kotlin/tunnel/Proxy.kt
@@ -117,7 +117,7 @@ internal class Proxy(
 
     private fun resolveActualDestination(packet: IpPacket): InetSocketAddress {
         val servers = dnsServers
-        val current = InetSocketAddress(packet.header.dstAddr, UdpPort.DOMAIN as Int)
+        val current = InetSocketAddress(packet.header.dstAddr, UdpPort.DOMAIN.valueAsInt())
         return when {
             servers.isEmpty() -> current
             else -> try {

--- a/app/src/tunnel/kotlin/tunnel/VpnConfigurator.kt
+++ b/app/src/tunnel/kotlin/tunnel/VpnConfigurator.kt
@@ -60,7 +60,7 @@ internal class VpnConfigurator(
                 ktx.e("failed adding dns server", e)
             }
         }
-        if (dnsServers.none { it is Inet6Address }) {
+        if (dnsServers.none { it.getAddress() is Inet6Address }) {
             // If we add no IPv6 route or DNS server, all IPv6 access is otherwise blocked by default
             builder.allowFamily(OsConstants.AF_INET6)
         }


### PR DESCRIPTION
Working towards a solution for #198.

This PR should pave the way for integrating [dnscrypt-proxy](https://github.com/jedisct1/dnscrypt-proxy) as a local cache/resolver running on the device, controlled by Blokada. To let it run without having root we need to use an unprivileged port (that is, a port >=1024). 