### PR TITLE
Enable basic IPv6 support - DNS results now include AAAA records

### DIFF
--- a/app/src/tunnel/kotlin/tunnel/VpnConfigurator.kt
+++ b/app/src/tunnel/kotlin/tunnel/VpnConfigurator.kt
@@ -61,7 +61,7 @@ internal class VpnConfigurator(
             }
         }
         if (dnsServers.none { it is Inet6Address }) {
-            // If we add no IPv6 route or DNS server, all IPv6 access is blocked by default
+            // If we add no IPv6 route or DNS server, all IPv6 access is otherwise blocked by default
             builder.allowFamily(OsConstants.AF_INET6)
         }
 

--- a/app/src/tunnel/kotlin/tunnel/VpnConfigurator.kt
+++ b/app/src/tunnel/kotlin/tunnel/VpnConfigurator.kt
@@ -1,6 +1,7 @@
 package tunnel
 
 import android.net.VpnService
+import android.system.OsConstants
 import core.Kontext
 import core.Result
 import java.net.Inet4Address
@@ -58,6 +59,10 @@ internal class VpnConfigurator(
             } catch (e: Exception) {
                 ktx.e("failed adding dns server", e)
             }
+        }
+        if (dnsServers.none { it is Inet6Address }) {
+            // If we add no IPv6 route or DNS server, all IPv6 access is blocked by default
+            builder.allowFamily(OsConstants.AF_INET6)
         }
 
         filterManager.getWhitelistedApps(ktx).forEach {


### PR DESCRIPTION
This should resolve issue #94. The issue was that when the `VpnConfigure.Builder` is not given any IPv6 address as a `addRoute` or `addDnsServer` call, it blocks all IPv6 communication by default. This should not break the blocking functionality since dnsjava supports AAAA queries as well and the `question.name` (see `Proxy.kt:55`) remains included in any case, which allows Blokada to block any requests to disallowed hostnames.