### PR TITLE
Open main activity on QS tile long press

### DIFF
--- a/app/src/legacy/AndroidManifest.xml
+++ b/app/src/legacy/AndroidManifest.xml
@@ -48,6 +48,7 @@
             android:theme="@style/BlokadaColors.Main.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
+                <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>


### PR DESCRIPTION
Update the AndroidManifest so that long-pressing the quick settings tile navigates to the main activity (instead of opening the app info page)