### PR TITLE
Update App.kt

### DIFF
--- a/app/src/legacy/kotlin/core/App.kt
+++ b/app/src/legacy/kotlin/core/App.kt
@@ -34,7 +34,7 @@ class AUiState(
     )
 
     override val notifications = newPersistedProperty(kctx, APrefsPersistence(ctx, "notifications"),
-            { true }
+            { false } // By default, have notifications off. 
     )
 
     override val dashes = newPersistedProperty(kctx, ADashesPersistence(ctx), { ctx.inject().instance() })


### PR DESCRIPTION
Most users will not want a new notification each time something is blocked. This will annoy the user. By default have notifications off. Permanent notifications are ok because they don't give user impression they have a new message each time something is blocked. But new notifications are not wanted. 