### PR TITLE
Permanent notification rework and additional widget

### DIFF
--- a/app/src/flavor-adblocker/kotlin/adblocker/ListWidget.kt
+++ b/app/src/flavor-adblocker/kotlin/adblocker/ListWidget.kt
@@ -1,0 +1,48 @@
+package adblocker
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.content.Intent
+import com.github.salomonbrys.kodein.instance
+import core.Tunnel
+import gs.environment.inject
+import notification.ANotificationsToggleService
+import org.blokada.R
+import android.widget.RemoteViews
+
+
+class ListWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(context: Context?, appWidgetManager: AppWidgetManager?, appWidgetIds: IntArray?) {
+        super.onUpdate(context, appWidgetManager, appWidgetIds)
+        val remoteViews = RemoteViews(context!!.packageName,
+                R.layout.view_list_widget)
+        val t: Tunnel = context.inject().instance()
+
+        remoteViews.setTextViewText(R.id.widget_list_title, context.resources.getString(R.string.notification_keepalive_title, t.tunnelDropCount()))
+        remoteViews.setTextViewText(R.id.widget_list_text, context.getString(R.string.notification_keepalive_content, t.tunnelRecentDropped().lastOrNull()
+                ?: ""))
+
+        var domainList = ""
+        val duplicates = ArrayList<String>(0)
+        t.tunnelRecentDropped().asReversed().forEach { s ->
+            if (!duplicates.contains(s)) {
+                duplicates.add(s)
+                domainList += s + '\n'
+            }
+        }
+        remoteViews.setTextViewText(R.id.widget_list_message, domainList)
+
+        val intent = Intent(context, ANotificationsToggleService::class.java)
+        intent.putExtra("new_state", !t.enabled())
+        remoteViews.setOnClickPendingIntent(R.id.widget_list_button, PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT))
+        if (t.enabled()) {
+            remoteViews.setTextViewText(R.id.widget_list_button, "Deactivate")
+        } else {
+            remoteViews.setTextViewText(R.id.widget_list_button, "Activate")
+        }
+        appWidgetManager?.updateAppWidget(appWidgetIds, remoteViews)
+    }
+}

--- a/app/src/flavor-adblocker/kotlin/flavor/Module.kt
+++ b/app/src/flavor-adblocker/kotlin/flavor/Module.kt
@@ -61,6 +61,14 @@ fun newFlavorModule(ctx: Context): Kodein.Module {
                 else if (ui.notifications()) displayNotification(ctx, s.tunnelRecentDropped().last())
             }
 
+            s.tunnelRecentDropped.doWhenChanged().then{
+                updateListWidget(ctx)
+            }
+            s.enabled.doWhenChanged().then{
+                updateListWidget(ctx)
+            }
+            updateListWidget(ctx)
+
             // Hide notification when disabled
             ui.notifications.doOnUiWhenSet().then {
                 hideNotification(ctx)
@@ -81,6 +89,16 @@ fun newFlavorModule(ctx: Context): Kodein.Module {
             // Initialize default values for properties that need it (async)
             s.tunnelDropCount {}
         }
+
+
     }
 }
 
+fun updateListWidget(ctx: Context){
+    val updateIntent = Intent(ctx.applicationContext, ListWidgetProvider::class.java)
+    updateIntent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+    val widgetManager = AppWidgetManager.getInstance(ctx)
+    val ids = widgetManager.getAppWidgetIds(ComponentName(ctx, ListWidgetProvider::class.java))
+    updateIntent .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+    ctx.sendBroadcast(updateIntent)
+}

--- a/app/src/legacy/AndroidManifest.xml
+++ b/app/src/legacy/AndroidManifest.xml
@@ -63,6 +63,7 @@
 
         <service android:name="notification.ANotificationsOffService"></service>
         <service android:name="notification.ANotificationsWhitelistService"></service>
+        <service android:name="notification.ANotificationsToggleService"></service>
         <service
             android:name="core.QuickSettingsService"
             android:icon="@drawable/ic_blokada"
@@ -112,6 +113,13 @@
         <receiver
             android:name="adblocker.ActiveWidgetProvider"
             android:exported="true">
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/active_widget_info" />
+        </receiver>
+        <receiver
+            android:name="adblocker.ListWidgetProvider"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_ENABLED" />
                 <action android:name="android.appwidget.action.APPWIDGET_DELETED" />
@@ -120,7 +128,7 @@
             </intent-filter>
             <meta-data
                 android:name="android.appwidget.provider"
-                android:resource="@xml/active_widget_info" />
+                android:resource="@xml/list_widget_info" />
         </receiver>
 
         <service android:name="adblocker.RequestLogger" />

--- a/app/src/legacy/kotlin/core/KeepAlive.kt
+++ b/app/src/legacy/kotlin/core/KeepAlive.kt
@@ -65,16 +65,22 @@ fun newKeepAliveModule(ctx: Context): Kodein.Module {
                 )
                 nm.notify(3, n)
             }
-            var w: IWhen? = null
+            var w1: IWhen? = null
+            var w2: IWhen? = null
             s.keepAlive.doWhenSet().then {
                 if (s.keepAlive()) {
-                    t.tunnelDropCount.cancel(w)
-                    w = t.tunnelDropCount.doOnUiWhenSet().then {
+                    t.tunnelDropCount.cancel(w1)
+                    w1 = t.tunnelDropCount.doOnUiWhenSet().then {
+                        keepAliveNotificationUpdater(t.tunnelDropCount())
+                    }
+                    t.enabled.cancel(w2)
+                    w2 = t.enabled.doOnUiWhenSet().then {
                         keepAliveNotificationUpdater(t.tunnelDropCount())
                     }
                     keepAliveAgent.bind(ctx)
                 } else {
-                    t.tunnelDropCount.cancel(w)
+                    t.tunnelDropCount.cancel(w1)
+                    t.enabled.cancel(w2)
                     keepAliveAgent.unbind(ctx)
                 }
             }
@@ -130,7 +136,7 @@ class KeepAliveService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         j.log("KeepAliveService: start command")
-        return Service.START_STICKY;
+        return Service.START_STICKY
     }
 
     private var binder: KeepAliveBinder? = null

--- a/app/src/legacy/kotlin/notification/ANotificationUtils.kt
+++ b/app/src/legacy/kotlin/notification/ANotificationUtils.kt
@@ -9,14 +9,19 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.support.v4.app.NotificationCompat
+import android.widget.Toast
 import com.github.salomonbrys.kodein.instance
-import core.Dns
-import core.MainActivity
-import core.Product
-import core.printServers
+import core.*
 import gs.environment.inject
 import gs.property.I18n
 import org.blokada.R
+import android.text.format.DateUtils
+import android.widget.RemoteViews
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+
+
+
 
 
 /**
@@ -78,10 +83,38 @@ fun createNotificationKeepAlive(ctx: Context, count: Int, last: String): Notific
         b.setContentTitle(provider)
         b.setContentText(ctx.getString(R.string.dns_keepalive_content, servers))
     } else {
-        b.setContentTitle(ctx.resources.getString(R.string.notification_keepalive_title, count))
-        b.setContentText(ctx.getString(R.string.notification_keepalive_content, last))
-    }
+        val expandedView = RemoteViews(ctx.packageName, R.layout.view_keepalive_expanded)
+        expandedView.setTextViewText(R.id.keep_alive_title, ctx.resources.getString(R.string.notification_keepalive_title, count))
+        expandedView.setTextViewText(R.id.keep_alive_text, ctx.getString(R.string.notification_keepalive_content, last))
+        expandedView.setTextViewText(R.id.keep_alive_timestamp, DateUtils.formatDateTime(ctx, System.currentTimeMillis(), DateUtils.FORMAT_SHOW_TIME))
 
+        val t: Tunnel = ctx.inject().instance()
+        var domainList = ""
+        val duplicates =ArrayList<String>(0)
+        t.tunnelRecentDropped().asReversed().forEach { s ->
+            if(!duplicates.contains(s)){
+                duplicates.add(s)
+                domainList += s + '\n'
+            }
+        }
+        expandedView.setTextViewText(R.id.keep_alive_message, domainList)
+
+        val intent = Intent(ctx, ANotificationsToggleService::class.java)
+        intent.putExtra("new_state",!t.enabled())
+        expandedView.setOnClickPendingIntent(R.id.keep_alive_button, PendingIntent.getService(ctx, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT))
+        if(t.enabled()) {
+            expandedView.setTextViewText(R.id.keep_alive_button, "Deactivate")
+        }else{
+            expandedView.setTextViewText(R.id.keep_alive_button, "Activate")
+        }
+
+        val collapsedView = RemoteViews(ctx.packageName, R.layout.view_keepalive_collapsed)
+        collapsedView.setTextViewText(R.id.keep_alive_title, ctx.resources.getString(R.string.notification_keepalive_title, count))
+        collapsedView.setTextViewText(R.id.keep_alive_text, ctx.getString(R.string.notification_keepalive_content, last))
+        collapsedView.setTextViewText(R.id.keep_alive_timestamp, DateUtils.formatDateTime(ctx, System.currentTimeMillis(), DateUtils.FORMAT_SHOW_TIME))
+        b.setCustomContentView(collapsedView)
+        b.setCustomBigContentView(expandedView)
+    }
     b.setSmallIcon(R.drawable.ic_stat_blokada)
     b.setPriority(NotificationCompat.PRIORITY_MIN)
     b.setOngoing(true)
@@ -135,3 +168,9 @@ fun displayNotificationForUpdate(ctx: Context, versionName: String) {
     notif.notify(2, b.build())
 }
 
+
+class DisplayToastRunnable(private val mContext: Context, private var mText: String) : Runnable {
+    override fun run() {
+        Toast.makeText(mContext, mText, Toast.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/legacy/kotlin/notification/ANotificationsToggleService.kt
+++ b/app/src/legacy/kotlin/notification/ANotificationsToggleService.kt
@@ -1,0 +1,25 @@
+package notification
+
+import android.app.IntentService
+import android.content.Intent
+import android.os.Handler
+import com.github.salomonbrys.kodein.instance
+import core.Tunnel
+import gs.environment.inject
+import org.blokada.R
+
+
+class ANotificationsToggleService : IntentService("notificationsToggle") {
+    private var mHandler: Handler = Handler()
+
+    override fun onHandleIntent(intent: Intent) {
+        val t: Tunnel = this.inject().instance()
+        t.enabled %= intent.getBooleanExtra("new_state", true)
+        if(intent.getBooleanExtra("new_state", true)){
+            mHandler.post(DisplayToastRunnable(this, this.resources.getString(R.string.notification_keepalive_activating)))
+        }else{
+            mHandler.post(DisplayToastRunnable(this, this.resources.getString(R.string.notification_keepalive_deactivating)))
+        }
+    }
+
+}

--- a/app/src/legacy/kotlin/notification/ANotificationsWhitelistService.kt
+++ b/app/src/legacy/kotlin/notification/ANotificationsWhitelistService.kt
@@ -2,6 +2,7 @@ package notification
 
 import android.app.IntentService
 import android.content.Intent
+import android.os.Handler
 import android.widget.Toast
 import com.github.salomonbrys.kodein.instance
 import core.ktx
@@ -14,6 +15,7 @@ import tunnel.FilterSourceDescriptor
 class ANotificationsWhitelistService : IntentService("notificationsWhitelist") {
 
     private val tunnel by lazy { inject().instance<tunnel.Main>() }
+    private var mHandler: Handler = Handler()
 
     override fun onHandleIntent(intent: Intent) {
         val host = intent.getStringExtra("host") ?: return
@@ -27,7 +29,7 @@ class ANotificationsWhitelistService : IntentService("notificationsWhitelist") {
 
         tunnel.putFilter(ktx("whitelistFromNotification"), f)
 
-        Toast.makeText(this, R.string.notification_blocked_whitelist_applied, Toast.LENGTH_SHORT).show()
+        mHandler.post(DisplayToastRunnable(this, getString(R.string.notification_blocked_whitelist_applied)))
         hideNotification(this)
     }
 

--- a/app/src/legacy/res/layout/view_keepalive_collapsed.xml
+++ b/app/src/legacy/res/layout/view_keepalive_collapsed.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@color/colorBackgroundTransWidget"
+    android:padding="8dp">
+
+    <RelativeLayout
+        android:id="@+id/icon_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/keep_alive_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:paddingLeft="4dp"
+            android:paddingRight="6dp"
+            android:paddingBottom="1dp"
+            android:src="@drawable/ic_stat_blokada" />
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="false"
+        android:layout_marginTop="3dp"
+        android:layout_toRightOf="@+id/icon_container"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingLeft="6dp">
+
+        <TextView
+            android:id="@+id/keep_alive_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/keep_alive_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/keep_alive_timestamp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentRight="true"
+        android:paddingTop="8dp"
+        android:paddingRight="3.5dp" />
+
+</RelativeLayout>

--- a/app/src/legacy/res/layout/view_keepalive_collapsed.xml
+++ b/app/src/legacy/res/layout/view_keepalive_collapsed.xml
@@ -2,7 +2,6 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="@color/colorBackgroundTransWidget"
     android:padding="8dp">
 
     <RelativeLayout
@@ -17,7 +16,7 @@
             android:paddingLeft="4dp"
             android:paddingRight="6dp"
             android:paddingBottom="1dp"
-            android:src="@drawable/ic_stat_blokada" />
+            android:src="@mipmap/ic_launcher" />
 
     </RelativeLayout>
 

--- a/app/src/legacy/res/layout/view_keepalive_expanded.xml
+++ b/app/src/legacy/res/layout/view_keepalive_expanded.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:alpha="10"
+    android:background="@color/colorBackgroundTransWidget"
+    android:padding="8dp">
+
+    <RelativeLayout
+        android:id="@+id/icon_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/keep_alive_icon"
+            android:layout_width="50dp"
+            android:layout_height="50dp"
+            android:paddingLeft="4dp"
+            android:paddingRight="6dp"
+            android:paddingBottom="1dp"
+            android:src="@drawable/ic_stat_blokada" />
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="false"
+        android:layout_marginTop="3dp"
+        android:layout_toRightOf="@+id/icon_container"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingLeft="6dp">
+
+        <TextView
+            android:id="@+id/keep_alive_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/keep_alive_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:id="@+id/keep_alive_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/icon_container"
+        android:layout_marginTop="8dp"
+        android:ellipsize="end"
+        android:maxLines="8" />
+
+    <TextView
+        android:id="@+id/keep_alive_timestamp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentRight="true"
+        android:paddingTop="8dp"
+        android:paddingRight="3.5dp" />
+
+    <Button
+        android:id="@+id/keep_alive_button"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@id/keep_alive_message" />
+
+</RelativeLayout>

--- a/app/src/legacy/res/layout/view_keepalive_expanded.xml
+++ b/app/src/legacy/res/layout/view_keepalive_expanded.xml
@@ -5,7 +5,6 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:alpha="10"
-    android:background="@color/colorBackgroundTransWidget"
     android:padding="8dp">
 
     <RelativeLayout
@@ -20,7 +19,7 @@
             android:paddingLeft="4dp"
             android:paddingRight="6dp"
             android:paddingBottom="1dp"
-            android:src="@drawable/ic_stat_blokada" />
+            android:src="@mipmap/ic_launcher" />
 
     </RelativeLayout>
 

--- a/app/src/legacy/res/layout/view_list_widget.xml
+++ b/app/src/legacy/res/layout/view_list_widget.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:alpha="10"
+    android:background="@drawable/bg_rounded"
+    android:padding="8dp">
+
+    <RelativeLayout
+        android:id="@+id/icon_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/widget_list_icon"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:paddingLeft="4dp"
+            android:paddingRight="4dp"
+            android:paddingBottom="2dp"
+            android:src="@drawable/ic_stat_blokada" />
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="false"
+        android:layout_marginTop="4dp"
+        android:layout_toRightOf="@+id/icon_container"
+        android:gravity="center_vertical"
+        android:orientation="vertical"
+        android:paddingLeft="6dp">
+
+        <TextView
+            android:id="@+id/widget_list_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/widget_list_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+    </LinearLayout>
+
+
+    <TextView
+        android:id="@+id/widget_list_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@+id/widget_list_button"
+        android:layout_below="@id/icon_container"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="0dp"
+        android:ellipsize="end"
+        android:maxLines="8" />
+
+    <TextView
+        android:id="@+id/widget_list_timestamp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:layout_alignParentRight="true"
+        android:paddingTop="8dp"
+        android:paddingRight="4dp" />
+
+    <Button
+        android:id="@+id/widget_list_button"
+        style="@style/Widget.AppCompat.Button.Borderless"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_marginBottom="16dp" />
+
+</RelativeLayout>

--- a/app/src/legacy/res/values/strings_notification.xml
+++ b/app/src/legacy/res/values/strings_notification.xml
@@ -31,4 +31,8 @@
     <string name="notification_keepalive_content">Last: %s</string>
     <!-- Content of the Keep Alive notification, if nothing was blocked yet, as in "Last: nothing yet". -->
     <string name="notification_keepalive_none">monitoring</string>
+    <string name="notification_keepalive_activate">Activate</string>
+    <string name="notification_keepalive_activating">Blokada is starting. This may take a moment.</string>
+    <string name="notification_keepalive_deactivate">Deactivate</string>
+    <string name="notification_keepalive_deactivating">Blokada got deactivated!</string>
 </resources>

--- a/app/src/legacy/res/xml/list_widget_info.xml
+++ b/app/src/legacy/res/xml/list_widget_info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="110dp"
+    android:minHeight="110dp"
+    android:minResizeWidth="110dp"
+    android:minResizeHeight="110dp"
+    android:maxHeight="330dp"
+    android:initialLayout="@layout/view_list_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen">
+</appwidget-provider>


### PR DESCRIPTION
I redesigned the permanent notification(keep alive) with the following changes:
 - There is now a button to (de-)activate Blokada
 - It's now extensible to display more information
 - It shows the unique domains in the 10 last blocked requests
 - Its design fits better to the overall look of Blokada.

Multiple users in the Telegram group wanted a widget with the same layout and informations, so I added this as well.
Fixes #97 