### PR TITLE
Fix broken link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ The trustworthy sources to download:
 - https://f-droid.org/
 - https://labs.xda-developers.com
 
-If you find a website that looks like ours, but the URL differs from that, please report it on [Google SafeBrowsing](https://safebrowsing.google.com/safebrowsing/report_badware).
+If you find a website that looks like ours, but the URL differs from that, please report it on [Google SafeBrowsing](https://safebrowsing.google.com/safebrowsing/report_phish).
 
 **Make the internet a better, safer place together.**


### PR DESCRIPTION
The link to report a phishing attempt is broken on the current `README`.

This updates the broken link with a working one.