### PR TITLE
fixed smartlist not working if settings location is internal storage

### DIFF
--- a/app/src/core/kotlin/core/Persistence.kt
+++ b/app/src/core/kotlin/core/Persistence.kt
@@ -8,7 +8,12 @@ import io.paperdb.Paper
 
 class Persistence {
     companion object {
-        const val DEFAULT_PATH = ""
+        val DEFAULT_PATH = if ((getActiveContext()?.filesDir != null)) {
+            getActiveContext()?.filesDir?.absolutePath + "/"
+        }else{
+            e("could not get filesDir!")
+            ""
+        }
         val global = GlobalPersistence()
         val slots = SlotStatusPersistence()
         val pause = TunnelPausePersistence()

--- a/app/src/core/kotlin/core/Persistence.kt
+++ b/app/src/core/kotlin/core/Persistence.kt
@@ -8,19 +8,14 @@ import io.paperdb.Paper
 
 class Persistence {
     companion object {
-        val DEFAULT_PATH = if ((getActiveContext()?.filesDir != null)) {
-            getActiveContext()?.filesDir?.absolutePath + "/"
-        }else{
-            e("could not get filesDir!")
-            ""
-        }
+        const val DEFAULT_PATH = ""
         val global = GlobalPersistence()
         val slots = SlotStatusPersistence()
         val pause = TunnelPausePersistence()
 
         fun paper() = {
             with(Persistence.global.loadPath()) {
-                if (this != DEFAULT_PATH) Paper.bookOn(this)
+                if (!Persistence.global.usesDefaultPath()) Paper.bookOn(this)
                 else Paper.book()
             }
         }()
@@ -29,9 +24,22 @@ class Persistence {
 
 class GlobalPersistence {
     val loadPath = {
-        Result.of { Paper.book().read<String>("persistencePath", Persistence.DEFAULT_PATH) }
+        val path = Result.of { Paper.book().read<String>("persistencePath", Persistence.DEFAULT_PATH) }
                 .or { Ok(Persistence.DEFAULT_PATH) }.get()
+        if (path.isNullOrBlank()) {
+            if ((getActiveContext()?.filesDir != null)) {
+                getActiveContext()?.filesDir?.absolutePath + "/"
+            }else{
+                e("could not get filesDir!")
+                ""
+            }
+        }else{
+            path
+        }
     }
+
+    val usesDefaultPath = {Result.of { Paper.book().read<String>("persistencePath", Persistence.DEFAULT_PATH) }
+                .or { Ok(Persistence.DEFAULT_PATH) }.get() == Persistence.DEFAULT_PATH }
 
     val savePath = { path: String ->
         Result.of { Paper.book().write("persistencePath", path) }

--- a/app/src/tun-local/kotlin/tunnel/Persistence.kt
+++ b/app/src/tun-local/kotlin/tunnel/Persistence.kt
@@ -38,7 +38,7 @@ class FiltersPersistence {
                     ktx.v("loading from the persistence", core.Persistence.paper().path)
                     Result.of { core.Persistence.paper().read("filters2", FilterStore()) }
                             .orElse { ex ->
-                                if (core.Persistence.global.loadPath() != core.Persistence.DEFAULT_PATH) {
+                                if (!core.Persistence.global.usesDefaultPath()) {
                                     ktx.w("failed loading from a custom path, resetting")
                                     core.Persistence.global.savePath(core.Persistence.DEFAULT_PATH)
                                     Result.of { core.Persistence.paper().read("filters2", FilterStore()) }
@@ -52,7 +52,7 @@ class FiltersPersistence {
     }
 
     private fun loadLegacy34(ktx: AndroidKontext) = {
-        if (core.Persistence.global.loadPath() != core.Persistence.DEFAULT_PATH)
+        if (!core.Persistence.global.usesDefaultPath())
             Err(Exception("custom persistence path detected, skipping legacy import"))
         else {
             val prefs = ktx.ctx.getSharedPreferences("filters", Context.MODE_PRIVATE)

--- a/app/src/ui-blokada/kotlin/core/bits/Slots.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/Slots.kt
@@ -1094,7 +1094,7 @@ class StorageLocationVB(
         //tunnelMain.reloadConfig(ktx, device.onWifi())
     })
 
-    private fun isExternal() = core.Persistence.global.loadPath() != core.Persistence.DEFAULT_PATH
+    private fun isExternal() = !core.Persistence.global.usesDefaultPath()
 
     override fun attach(view: SlotView) {
         view.enableAlternativeBackground()


### PR DESCRIPTION
There was a bug that lead to smart list throwing a exception on internal storage because it tried to safe the files in the root directory. This fixes it and makes the path for persistence etc. less prone to error.