### PR TITLE
implemented alternative DNS query answer as workaround for ColorOS

### DIFF
--- a/app/src/full/kotlin/core/bits/menu/advanced/MenuAdvanced.kt
+++ b/app/src/full/kotlin/core/bits/menu/advanced/MenuAdvanced.kt
@@ -21,7 +21,9 @@ fun createMenuAdvanced(ktx: AndroidKontext): NamedViewBinder {
                     KeepAliveVB(ktx, onTap = defaultOnTap),
                     WatchdogVB(ktx, onTap = defaultOnTap),
                     PowersaveVB(ktx, onTap = defaultOnTap),
-                    ReportVB(ktx, onTap = defaultOnTap)
+                    ReportVB(ktx, onTap = defaultOnTap),
+                    LabelVB(ktx, label = R.string.label_workarounds.res()),
+                    DnsAnswerTypeVB(ktx, onTap = defaultOnTap)
             ),
             name = R.string.panel_section_app_settings.res()
     )

--- a/app/src/full/kotlin/tunnel/BlockaTunnelFiltering.kt
+++ b/app/src/full/kotlin/tunnel/BlockaTunnelFiltering.kt
@@ -117,17 +117,7 @@ internal class BlockaTunnelFiltering(
         } else {
             dnsMessage.header.setFlag(Flags.QR.toInt())
             dnsMessage.header.rcode = Rcode.NOERROR
-            if(get(DnsAnswerState::class.java).hostNotFoundAnswer){
-                dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
-            }else{
-                dnsMessage.addRecord(
-                    ARecord(Name(dnsMessage.question.name.toString(false)),
-                    DClass.IN,
-                    60 * 3,
-                    InetAddress.getByAddress(byteArrayOf(127, 1, 1, 1))),
-                    Section.ANSWER
-                )
-            }
+            generateDnsAnswer(dnsMessage, denyResponse)
             toDeviceFakeDnsResponse(dnsMessage.toWire(), originEnvelope)
             emit(TunnelEvents.REQUEST, Request(host, blocked = true))
             true

--- a/app/src/full/kotlin/tunnel/BlockaTunnelFiltering.kt
+++ b/app/src/full/kotlin/tunnel/BlockaTunnelFiltering.kt
@@ -1,12 +1,14 @@
 package tunnel
 
 import core.emit
+import core.get
 import core.w
 import org.pcap4j.packet.*
 import org.xbill.DNS.*
 import java.io.IOException
 import java.net.Inet4Address
 import java.net.Inet6Address
+import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.util.*
@@ -115,7 +117,17 @@ internal class BlockaTunnelFiltering(
         } else {
             dnsMessage.header.setFlag(Flags.QR.toInt())
             dnsMessage.header.rcode = Rcode.NOERROR
-            dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
+            if(get(DnsAnswerState::class.java).hostNotFoundAnswer){
+                dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
+            }else{
+                dnsMessage.addRecord(
+                    ARecord(Name(dnsMessage.question.name.toString(false)),
+                    DClass.IN,
+                    60 * 3,
+                    InetAddress.getByAddress(byteArrayOf(127, 1, 1, 1))),
+                    Section.ANSWER
+                )
+            }
             toDeviceFakeDnsResponse(dnsMessage.toWire(), originEnvelope)
             emit(TunnelEvents.REQUEST, Request(host, blocked = true))
             true

--- a/app/src/full/kotlin/tunnel/DnsAnswer.kt
+++ b/app/src/full/kotlin/tunnel/DnsAnswer.kt
@@ -1,0 +1,28 @@
+package tunnel
+
+import core.get
+import org.xbill.DNS.*
+import java.net.InetAddress
+
+/*
+persistence for the setting, which determines which type of answer Blokada will give if a domain is blocked.
+If hostNotFoundAnswer is true it will send the "classic" deny response. If it's false Blokada will instead
+send a answer resolving the blocked domain to 127.1.1.1 .
+*/
+data class DnsAnswerState(
+        val hostNotFoundAnswer: Boolean
+)
+
+fun generateDnsAnswer(dnsMessage: Message, denyResponse: SOARecord){
+    if(get(DnsAnswerState::class.java).hostNotFoundAnswer){
+        dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
+    }else{
+        dnsMessage.addRecord(
+                ARecord(Name(dnsMessage.question.name.toString(false)),
+                        DClass.IN,
+                        5, //5 sec ttl
+                        InetAddress.getByAddress(byteArrayOf(127, 1, 1, 1))),
+                Section.ANSWER
+        )
+    }
+}

--- a/app/src/full/kotlin/tunnel/DnsAnswerState.kt
+++ b/app/src/full/kotlin/tunnel/DnsAnswerState.kt
@@ -1,0 +1,6 @@
+package tunnel
+
+
+data class DnsAnswerState(
+        val hostNotFoundAnswer: Boolean
+)

--- a/app/src/full/kotlin/tunnel/DnsAnswerState.kt
+++ b/app/src/full/kotlin/tunnel/DnsAnswerState.kt
@@ -1,6 +1,0 @@
-package tunnel
-
-
-data class DnsAnswerState(
-        val hostNotFoundAnswer: Boolean
-)

--- a/app/src/full/kotlin/tunnel/DnsProxy.kt
+++ b/app/src/full/kotlin/tunnel/DnsProxy.kt
@@ -70,17 +70,7 @@ internal class DnsProxy(
         } else {
             dnsMessage.header.setFlag(Flags.QR.toInt())
             dnsMessage.header.rcode = Rcode.NOERROR
-            if(get(DnsAnswerState::class.java).hostNotFoundAnswer){
-                dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
-                }else{
-                dnsMessage.addRecord(
-                    ARecord(Name(dnsMessage.question.name.toString(false)),
-                    DClass.IN,
-                    60 * 3,
-                    InetAddress.getByAddress(byteArrayOf(127, 1, 1, 1))),
-                    Section.ANSWER
-                )
-            }
+            generateDnsAnswer(dnsMessage, denyResponse)
             toDevice(dnsMessage.toWire(), -1, originEnvelope)
             emit(TunnelEvents.REQUEST, Request(host, blocked = true))
         }

--- a/app/src/full/kotlin/tunnel/DnsProxy.kt
+++ b/app/src/full/kotlin/tunnel/DnsProxy.kt
@@ -5,6 +5,7 @@ import android.system.OsConstants
 import com.github.michaelbull.result.mapError
 import core.Result
 import core.emit
+import core.get
 import core.w
 import org.pcap4j.packet.*
 import org.pcap4j.packet.namednumber.UdpPort
@@ -25,6 +26,7 @@ internal class DnsProxy(
         private val loopback: Queue<Triple<ByteArray, Int, Int>>,
         private val denyResponse: SOARecord = SOARecord(Name("org.blokada.invalid."), DClass.IN,
                 5L, Name("org.blokada.invalid."), Name("org.blokada.invalid."), 0, 0, 0, 0, 5),
+
         private val doCreateSocket: () -> DatagramSocket = { DatagramSocket() }
 ) : Proxy {
 
@@ -68,7 +70,17 @@ internal class DnsProxy(
         } else {
             dnsMessage.header.setFlag(Flags.QR.toInt())
             dnsMessage.header.rcode = Rcode.NOERROR
-            dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
+            if(get(DnsAnswerState::class.java).hostNotFoundAnswer){
+                dnsMessage.addRecord(denyResponse, Section.AUTHORITY)
+                }else{
+                dnsMessage.addRecord(
+                    ARecord(Name(dnsMessage.question.name.toString(false)),
+                    DClass.IN,
+                    60 * 3,
+                    InetAddress.getByAddress(byteArrayOf(127, 1, 1, 1))),
+                    Section.ANSWER
+                )
+            }
             toDevice(dnsMessage.toWire(), -1, originEnvelope)
             emit(TunnelEvents.REQUEST, Request(host, blocked = true))
         }

--- a/app/src/ui-blokada/kotlin/core/Tunnel.kt
+++ b/app/src/ui-blokada/kotlin/core/Tunnel.kt
@@ -317,6 +317,8 @@ fun newTunnelModule(ctx: Context): Module {
             setTunnelPersistenceSource()
             Register.sourceFor(BlockaVpnState::class.java, default = BlockaVpnState(false),
                     source = PaperSource("blockaVpnState"))
+            Register.sourceFor(DnsAnswerState::class.java, default = DnsAnswerState(true),
+                    source = PaperSource("DnsAnswerState"))
 
             entrypoint.onAppStarted()
         }

--- a/app/src/ui-blokada/kotlin/core/bits/Slots.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/Slots.kt
@@ -10,6 +10,7 @@ import android.widget.EditText
 import blocka.blokadaUserAgent
 import com.github.salomonbrys.kodein.instance
 import core.*
+import core.Register.set
 import core.Tunnel
 import core.bits.menu.MENU_CLICK_BY_NAME_SUBMENU
 import filter.hostnameRegex
@@ -998,6 +999,26 @@ class ResetCounterVB(private val ktx: AndroidKontext,
 
 }
 
+class DnsAnswerTypeVB(
+        private val ktx: AndroidKontext,
+        private val i18n: I18n = ktx.di().instance(),
+        onTap: (SlotView) -> Unit
+) : SlotVB(onTap) {
+
+    override fun attach(view: SlotView) {
+        view.enableAlternativeBackground()
+        view.type = Slot.Type.INFO
+        view.content = Slot.Content(
+                icon = ktx.ctx.getDrawable(R.drawable.ic_feedback),
+                label = i18n.getString(R.string.slot_dns_answer_label),
+                description = i18n.getString(R.string.slot_dns_answer_description),
+                switched = !get(DnsAnswerState::class.java).hostNotFoundAnswer
+        )
+        view.onSwitch = { set(DnsAnswerState::class.java, DnsAnswerState(!it)) }
+    }
+
+}
+
 class DnsListControlVB(
         private val ktx: AndroidKontext,
         private val ctx: Context = ktx.ctx,
@@ -1297,4 +1318,6 @@ class CleanupVB(
         }
     }
 }
+
+
 

--- a/app/src/ui-blokada/kotlin/core/bits/Slots.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/Slots.kt
@@ -1318,6 +1318,3 @@ class CleanupVB(
         }
     }
 }
-
-
-

--- a/app/src/ui-blokada/res/values/strings_panel.xml
+++ b/app/src/ui-blokada/res/values/strings_panel.xml
@@ -263,4 +263,9 @@
     <string name="slot_reset_counter_label">Reset blocked host counter</string>
     <string name="slot_reset_counter_description">Sets the counter showing how many requests where blocked back to 0.</string>
     <string name="slot_reset_counter_action">Reset</string>
-</resources>
+
+
+    <string name="label_workarounds">device-specific workarounds</string>
+    <string name="slot_dns_answer_label"> alternative DNS answer</string>
+    <string name="slot_dns_answer_description">Changes the answer Blokada sends for blocked requests from "host not found" to an invalid ip. This can help on some ROMs which query other DNS servers if they get a "host not found" answer. please note that this might slow down some apps which try to connect to the invalid address.</string>
+    </resources>

--- a/app/src/ui-blokada/res/values/strings_panel.xml
+++ b/app/src/ui-blokada/res/values/strings_panel.xml
@@ -265,7 +265,7 @@
     <string name="slot_reset_counter_action">Reset</string>
 
 
-    <string name="label_workarounds">device-specific workarounds</string>
-    <string name="slot_dns_answer_label"> alternative DNS answer</string>
+    <string name="label_workarounds">Device-specific workarounds</string>
+    <string name="slot_dns_answer_label">Alternative DNS answer</string>
     <string name="slot_dns_answer_description">Changes the answer Blokada sends for blocked requests from "host not found" to an invalid ip. This can help on some ROMs which query other DNS servers if they get a "host not found" answer. please note that this might slow down some apps which try to connect to the invalid address.</string>
     </resources>


### PR DESCRIPTION
There were some users reporting that Blokada didn't block ads on ColorOS. Returning a invalid address instead of "host not found" seems to help.