### PR TITLE
Providing memory limitation per app

### DIFF
--- a/app/src/ui-blokada/kotlin/core/bits/Slots.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/Slots.kt
@@ -81,7 +81,7 @@ class FiltersStatusVB(
             content = Slot.Content(
                     label = i18n.getString(R.string.panel_ruleset_title, Format.counter(rules)),
                     header = i18n.getString(R.string.panel_ruleset),
-                    description = i18n.getString(R.string.panel_ruleset_built,
+                    description = i18n.getString(R.string.panel_ruleset_canfit,
                             Format.counter(rules), Format.counter(getMaxMemory()), Format.counter(memory, round = true))
             )
             date = refreshDate

--- a/app/src/ui-blokada/kotlin/core/bits/Slots.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/Slots.kt
@@ -38,6 +38,7 @@ class FiltersStatusVB(
 
     private var rules: Int = 0
     private var memory: Int = 0
+    private var maxMemory = getMaxMemory()
 
     private val updatingFilters = {
         view?.apply {
@@ -68,6 +69,13 @@ class FiltersStatusVB(
         Unit
     }
 
+    fun getMaxMemory(): Int {
+        val runtime = Runtime.getRuntime()
+        val totalmem = runtime.maxMemory()
+        val mb = totalmem.div(1048576)
+        return mb.toInt()
+    }
+
     private fun refresh() {
         view?.apply {
             type = Slot.Type.COUNTER
@@ -75,7 +83,7 @@ class FiltersStatusVB(
                     label = i18n.getString(R.string.panel_ruleset_title, Format.counter(rules)),
                     header = i18n.getString(R.string.panel_ruleset),
                     description = i18n.getString(R.string.panel_ruleset_built,
-                            Format.counter(rules), Format.counter(memory, round = true))
+                            Format.counter(rules), Format.counter(maxMemory), Format.counter(memory, round = true))
             )
             date = refreshDate
         }

--- a/app/src/ui-blokada/kotlin/core/bits/Slots.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/Slots.kt
@@ -38,7 +38,6 @@ class FiltersStatusVB(
 
     private var rules: Int = 0
     private var memory: Int = 0
-    private var maxMemory = getMaxMemory()
 
     private val updatingFilters = {
         view?.apply {
@@ -83,7 +82,7 @@ class FiltersStatusVB(
                     label = i18n.getString(R.string.panel_ruleset_title, Format.counter(rules)),
                     header = i18n.getString(R.string.panel_ruleset),
                     description = i18n.getString(R.string.panel_ruleset_built,
-                            Format.counter(rules), Format.counter(maxMemory), Format.counter(memory, round = true))
+                            Format.counter(rules), Format.counter(getMaxMemory()), Format.counter(memory, round = true))
             )
             date = refreshDate
         }

--- a/app/src/ui-blokada/res/values/strings_panel.xml
+++ b/app/src/ui-blokada/res/values/strings_panel.xml
@@ -37,7 +37,7 @@
     <!-- How many rules are configured. Parameters is number of rules. -->
     <string name="panel_ruleset_title">Filters now have %s rules.</string>
     <string name="panel_ruleset_updating">Updating filters...</string>
-    <string name="panel_ruleset_built">Filters are now configured with &lt;b&gt;%s&lt;/b&gt; rules. Up to &lt;b&gt;%s&lt;/b&gt; rules can fit into your device memory overall. Remember, this is just an estimate and subject to change depending on other apps on your device, so you should stay well below this limit to be safe.</string>
+    <string name="panel_ruleset_built">Filters are now configured with &lt;b&gt;%s&lt;/b&gt; rules. Your device allows max &lt;b&gt;%s&lt;/b&gt; MB of memory for every application, and up to &lt;b&gt;%s&lt;/b&gt; rules can fit into this allocated value.&lt;br&gt;Remember, this is just an estimate and Blokada utilises the most memory when it merges the lists.</string>
 
     <!-- Button to allow blocked domain -->
     <string name="slot_action_allow">Allow</string>

--- a/app/src/ui-blokada/res/values/strings_panel.xml
+++ b/app/src/ui-blokada/res/values/strings_panel.xml
@@ -37,7 +37,7 @@
     <!-- How many rules are configured. Parameters is number of rules. -->
     <string name="panel_ruleset_title">Filters now have %s rules.</string>
     <string name="panel_ruleset_updating">Updating filters...</string>
-    <string name="panel_ruleset_built">Filters are now configured with &lt;b&gt;%s&lt;/b&gt; rules. Your device allows max &lt;b&gt;%s&lt;/b&gt; MB of memory for every application, and up to &lt;b&gt;%s&lt;/b&gt; rules can fit into this allocated value.&lt;br&gt;Remember, this is just an estimate and Blokada utilises the most memory when it merges the lists.</string>
+    <string name="panel_ruleset_canfit">Filters are now configured with &lt;b&gt;%s&lt;/b&gt; rules. Your device allows max &lt;b&gt;%s&lt;/b&gt; MB of memory for every application, and up to &lt;b&gt;%s&lt;/b&gt; rules can fit into it.&lt;br&gt;Remember, this is just an estimate and Blokada utilises the most memory when it merges the lists.</string>
 
     <!-- Button to allow blocked domain -->
     <string name="slot_action_allow">Allow</string>


### PR DESCRIPTION
Applications can't utilise all the available RAM of the device, the Android system limits it. This value is the maxMemory. It is now showed on the UI to provide better explanation why users can't load all the lists.