### PR TITLE
Changing memory related values

### DIFF
--- a/app/src/tun-local/kotlin/tunnel/Model.kt
+++ b/app/src/tun-local/kotlin/tunnel/Model.kt
@@ -53,7 +53,7 @@ class Memory {
         val linesAvailable = {
             val r = Runtime.getRuntime()
             val free = r.maxMemory() - (r.totalMemory() - r.freeMemory())
-            (free / (18 * 2 * 6)).toInt() // (avg chars per host name) * (char size) * (correction)
+            (free / (21 * 2 * 3)).toInt() // (avg chars per host name) * (unicode char size) * (correction)
         }
     }
 }

--- a/app/src/ui-blokada/res/values/strings_bits.xml
+++ b/app/src/ui-blokada/res/values/strings_bits.xml
@@ -49,7 +49,7 @@
     <string name="home_account_error">Could not verify account. Are you online?</string>
     <string name="home_permission_error">Please grant VPN permissions.</string>
     <string name="home_zero_filters_error">You have no filters configured. Check your adblocking and wifi settings.</string>
-    <string name="home_filters_memory_error">Could not load all filters to memory. Check your adblocking settings.</string>
+    <string name="home_filters_memory_error">Some lists could not be loaded; select fewer lists in Ad blocking settings.</string>
 
     <string name="tasker_switch_label">Tap on one of the options to configure to turn it on (or off) for your trigger.</string>
 

--- a/app/src/ui-blokada/res/values/strings_panel.xml
+++ b/app/src/ui-blokada/res/values/strings_panel.xml
@@ -37,7 +37,7 @@
     <!-- How many rules are configured. Parameters is number of rules. -->
     <string name="panel_ruleset_title">Filters now have %s rules.</string>
     <string name="panel_ruleset_updating">Updating filters...</string>
-    <string name="panel_ruleset_canfit">Filters are now configured with &lt;b&gt;%s&lt;/b&gt; rules. Your device allows max &lt;b&gt;%s&lt;/b&gt; MB of memory for every application, and up to &lt;b&gt;%s&lt;/b&gt; rules can fit into it.&lt;br&gt;Remember, this is just an estimate and Blokada utilises the most memory when it merges the lists.</string>
+    <string name="panel_ruleset_canfit">Filters are now configured with &lt;b&gt;%s&lt;/b&gt; rules. Your device allows max &lt;b&gt;%s&lt;/b&gt; MB of memory for every application, and up to &lt;b&gt;%s&lt;/b&gt; rules can fit into it.&lt;br&gt;Remember, this is just an estimate and Blokada utilises the most memory when it merges the lists. If you enabled a few of them recently, wait a few minutes for the system to free up memory.</string>
 
     <!-- Button to allow blocked domain -->
     <string name="slot_action_allow">Allow</string>


### PR DESCRIPTION
Based on a list with 1.327.728 unique hostnames, the average hostname lenght is 20,41 char long. As fractions aren't supported, it's better to round up to 21.
Unicode characters use 2 bytes.
I ran a test for a few days to see how much RAM one hostname consumes in average, it is around 130 bytes