### PR TITLE
Update logic to block request logging

### DIFF
--- a/app/src/tun-local/kotlin/tunnel/TunnelMain.kt
+++ b/app/src/tun-local/kotlin/tunnel/TunnelMain.kt
@@ -19,6 +19,7 @@ object TunnelEvents {
     val FILTERS_CHANGING = "FILTERS_CHANGING".newEvent()
     val FILTERS_CHANGED = "FILTERS_CHANGED".newEventOf<Collection<Filter>>()
     val REQUEST = "REQUEST".newEventOf<Request>()
+    val REQUEST_SAVED = "REQUEST_SAVED".newEventOf<Request>()
     val TUNNEL_POWER_SAVING = "TUNNEL_POWER_SAVING".newEvent()
     val MEMORY_CAPACITY = "MEMORY_CAPACITY".newEventOf<Int>()
     val TUNNEL_RESTART = "TUNNEL_RESTART".newEventOf<Int>()

--- a/app/src/ui-blokada/kotlin/core/Tunnel.kt
+++ b/app/src/ui-blokada/kotlin/core/Tunnel.kt
@@ -298,9 +298,14 @@ fun newTunnelModule(ctx: Context): Module {
                 }
             }
 
-            ktx.on(TunnelEvents.REQUEST_SAVED) { request ->
+            ktx.on(TunnelEvents.REQUEST) { request ->
                 if (request.blocked) {
                     s.tunnelDropCount %= s.tunnelDropCount() + 1
+                }
+            }
+
+            ktx.on(TunnelEvents.REQUEST_SAVED) { request ->
+                if (request.blocked) {
                     val dropped = s.tunnelRecentDropped() + request.domain
                     s.tunnelRecentDropped %= dropped.takeLast(10)
                 }

--- a/app/src/ui-blokada/kotlin/core/Tunnel.kt
+++ b/app/src/ui-blokada/kotlin/core/Tunnel.kt
@@ -298,7 +298,7 @@ fun newTunnelModule(ctx: Context): Module {
                 }
             }
 
-            ktx.on(TunnelEvents.REQUEST) { request ->
+            ktx.on(TunnelEvents.REQUEST_SAVED) { request ->
                 if (request.blocked) {
                     s.tunnelDropCount %= s.tunnelDropCount() + 1
                     val dropped = s.tunnelRecentDropped() + request.domain

--- a/app/src/ui-blokada/kotlin/core/bits/AdsDashboardSectionVB.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/AdsDashboardSectionVB.kt
@@ -68,12 +68,12 @@ class AdsDashboardSectionVB(
         tunnel.Persistence.request.load(0).onSuccess {
             it.forEach(request)
         }
-        ktx.on(TunnelEvents.REQUEST, request)
+        ktx.on(TunnelEvents.REQUEST_SAVED, request)
     }
 
     override fun detach(view: VBListView) {
         slotMutex.detach()
         displayingEntries.clear()
-        ktx.cancel(TunnelEvents.REQUEST, request)
+        ktx.cancel(TunnelEvents.REQUEST_SAVED, request)
     }
 }

--- a/app/src/ui-blokada/kotlin/core/bits/menu/adblocking/HostsLogVB.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/menu/adblocking/HostsLogVB.kt
@@ -76,7 +76,7 @@ class HostsLogVB(
             items.forEach { view.add(it) }
         }
 
-        ktx.on(TunnelEvents.REQUEST, request)
+        ktx.on(TunnelEvents.REQUEST_SAVED, request)
         view.onEndReached = loadMore
     }
 
@@ -85,7 +85,7 @@ class HostsLogVB(
         view.onEndReached = {}
         searchString = ""
         items.clear()
-        ktx.cancel(TunnelEvents.REQUEST, request)
+        ktx.cancel(TunnelEvents.REQUEST_SAVED, request)
     }
 
     private val loadMore = {

--- a/app/src/ui-blokada/res/values/strings_logger.xml
+++ b/app/src/ui-blokada/res/values/strings_logger.xml
@@ -4,6 +4,7 @@
     <string name="logger_slot_title">Request logger</string>
     <string name="logger_slot_desc">When enabled, Blokada will create a CSV file and log requests that have been allowed and / or blocked by the app. Look for "blokada" folder on your external storage.</string>
     <string name="logger_slot_mode_off">Disabled</string>
+    <string name="logger_slot_mode_internal">Log to internal storage only</string>
     <string name="logger_slot_mode_allowed">Log allowed requests</string>
     <string name="logger_slot_mode_denied">Log blocked requests</string>
     <string name="logger_slot_mode_all">Log all requests</string>

--- a/app/src/ui-blokada/res/values/strings_logger.xml
+++ b/app/src/ui-blokada/res/values/strings_logger.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="logger_permission">Please grant storage permission first.</string>
     <string name="logger_slot_title">Request logger</string>
-    <string name="logger_slot_desc">When enabled, Blokada will create a CSV file and log requests that have been allowed and / or blocked by the app. Look for "blokada" folder on your external storage.</string>
+    <string name="logger_slot_desc">By default, requests are only stored internally in Blokada. If this feature is enabled, Blokada will create a CSV file and log requests that have been allowed and / or blocked by the app. Look for "blokada" folder on your external storage. Alternatively, request logging can be disabled entirely, with just the number of blocked domains being stored.</string>
     <string name="logger_slot_mode_off">Disabled</string>
     <string name="logger_slot_mode_internal">Log to internal storage only</string>
     <string name="logger_slot_mode_allowed">Log allowed requests</string>


### PR DESCRIPTION
Update the "Disabled" request logging option to also block logging in memory / local storage. Added a new option, "Log to internal storage only", which is selected by default, and matches the current functionality.

Resolves issue #495 .