### PR TITLE
Replacing 'Private DNS' with 'Custom DNS'

### DIFF
--- a/app/src/ui-blokada/res/values/strings_panel.xml
+++ b/app/src/ui-blokada/res/values/strings_panel.xml
@@ -109,7 +109,7 @@
     <string name="slot_allapp_whitelist">Bypass</string>
 
     <string name="slot_dns_name">DNS is active</string>
-    <string name="slot_dns_name_private">Private DNS is active</string>
+    <string name="slot_dns_name_private">Custom DNS is active</string>
     <string name="slot_dns_name_disabled">DNS is deactivated</string>
     <string name="slot_action_none">This action is not available yet.</string>
     <string name="slot_action_unwhitelist">Cancel</string>


### PR DESCRIPTION
Google calls DoH and DoT as 'Private DNS' in system's Settings - 'Network & Internet', using the same term for 3rd party DNS servers may confuse the users