### PR TITLE
BUILD add and Bash edits

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,91 @@
+# Building Blokada
+
+#### This is a general set-up guide for people interested in contributing to Blokada development.
+
+**IMPORTANT NOTICE**: This guide intended for Linux users
+
+These instructions will give you some insights on how to
+
+* setup RUST for Android development
+* use NDK toolchains
+* generate signing key with `keytool` (JDK)
+* launch Blokada on an Android device
+
+## Prerequisites
+
+* Clone the project repository `git clone https://github.com/blokadaorg/blokada.git` in your desired location.
+
+* Make sure that you have [JDK](https://www.oracle.com/java/technologies/javase-downloads.html) installed on your machine
+
+* Make sure that you also have `android-tools` installed which can be found on most distributions.
+
+### The Android NDK toolchains
+
+[NDK DOWNLOAD](https://developer.android.com/ndk/downloads/)
+
+It's advised that the files from the downloaded NDK are stored in either `$HOME/.NDK` or in `$HOME/Android` which could be the same as `$ANDROID_HOME` if you have it set.
+
+## RUST and Boringtun preparations
+
+Rust is fairly easy to install with the tool **rustup**.rs. We need it to compile [Boringtun](https://github.com/blokadaorg/blokada/tree/master/boringtun).
+
+1. Simply copy and paste the following command in a terminal and follow the instructions: `curl https://sh.rustup.rs -sSf | sh` Depending on the shell you are using **rust** might **NOT** be in your $PATH. Run `rustc --version` to verify if this is the case.
+
+2. Next up we need to add the target Android architectures as they are not provided by default: `rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android`
+
+3. Now we need to tell RUST about the NDK toolchains. We'll make it a project-specific `cargo` configuration. In our case `blokada_root_dir/boringtun/.cargo/config`. This part could be problematic if we haven't set the proper paths to the toolchains. 
+Here is an example using `$HOME/Android/android-ndk-r21` as our path to the files we need:
+```
+[target.armv7-linux-androideabi]
+ar = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-ar"
+linker = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi21-clang"
+
+[target.aarch64-linux-android]
+ar = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar"
+linker = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang"
+
+[target.i686-linux-android]
+ar = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android-ar"
+linker = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android21-clang"
+
+[target.x86_64-linux-android]
+ar = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-ar"
+linker = "/home/user/Android/android-ndk-r21/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang"
+```
+
+4. We need to edit the helper script `build.sh` located in the `blokada/boringtun` directory. Add the following line **BEFORE** the line that starts with `export...`
+
+    `export NDK_STANDALONE=$HOME/Android/android-ndk-r21`
+        This will ensure that all the files from the toolchains we need are in the right place.
+
+5. Run the newly-edited `build.sh` script and wait to see if all the builds succeed.
+
+## Generating and using keys
+
+In order to succesfully build Blokada on our device we need to generate Android signing keys and then add them to `~/.gradle/gradle.properties`.
+
+If you haven't generated any keys before consider creating a directory for them `mkdir ~/keystores`
+
+1. Generate a key and a keystore like so `keytool -genkey -v -keystore ~/keystores/EXAMPLE.keystore -alias blokada -keypass PASSWORD`. Keep the alias as is and change **PASSWORD** and **EXAMPLE** to your liking. The generation tool will then prompt you for a password for your keystore (**REMEMBER IT**) which we will use in the next step.
+
+2. Now we need to edit the file `$HOME/.gradle/gradle.properties`. Let's assume that we use the **exact** command from the previous step. **IMPORTANT**: `BLOKADA_STORE_PASSWORD=` should be set to the **same password** as the one prompted by `keytool`!
+```
+BLOKADA_KEY_PASSWORD=PASSWORD
+BLOKADA_KEY_PATH=/home/user/EXAMPLE.keystore
+BLOKADA_STORE_PASSWORD=
+```
+
+3. To make sure everything is fine with the keys we can run `./gradlew signingReport` in the Blokada project root directory.
+
+## The device we will be testing on
+
+After making sure that the device has Developper Settings and USB Debugging enable, connect it to your laptop/desktop. Open a terminal once more and check if your device is connected properly with `adb devices` command.
+
+If your device is recognized navigate to the blokada project directory and run `./gradlew iFD`. The iFD stands for "installFullDebug". Hopefully everything will run smoothly and you will have your very own custom Beta Blokada build :).
+
+#### Helpful gradle commands:
+
+* check if signing is set properly `./gradlew signingReport`
+* see available tasks for the current project `./gradlew tasks`
+* gradle options `./gradlew --help`
+* uninstall a test build from the phone `./gradlew uFD` or `./gradlew uA` (uFD - uninstallFullDebug; uA - uninstallAll)

--- a/boringtun/build.sh
+++ b/boringtun/build.sh
@@ -1,7 +1,13 @@
 #!/bin/sh
 JNI_LIBS=../app/src/tun-blocka/jniLibs
 
-export PATH=$PATH:$NDK_STANDALONE/toolchains/llvm/prebuilt/linux-x86_64/bin
+# Change the next export as needed. It should point to your android ndk bundle
+export NDK=$HOME/Android/android-ndk-r21
+export PATH=$PATH:$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin
+
+# The next two sed commands change some paths...
+sed -i -e "s|/Users/kar/Library/Android/sdk/ndk-bundle|$NDK|" .cargo/config
+sed -i -e "s|darwin|linux|" .cargo/config
 
 rm -rf $JNI_LIBS
 mkdir $JNI_LIBS
@@ -28,6 +34,7 @@ export CXX=i686-linux-android21-clang++
 cargo build --lib --release --target i686-linux-android
 cp target/i686-linux-android/release/libboringtun.so $JNI_LIBS/x86/libboringtun.so
 
+# Comment this out to save some time
 echo "Building for v86_64..."
 export CC=x86_64-linux-android21-clang
 export CXX=x86_64-linux-android21-clang++

--- a/boringtun/src/ffi/benchmark.rs
+++ b/boringtun/src/ffi/benchmark.rs
@@ -49,7 +49,7 @@ fn format_float(number: f64) -> String {
     formatted
 }
 
-fn run_bench(test_func: &mut FnMut() -> usize) -> f64 {
+fn run_bench(test_func: &mut dyn FnMut() -> usize) -> f64 {
     let mut best_time = std::f64::MAX;
 
     // Take the best result out of ITRS runs

--- a/boringtun/src/noise/mod.rs
+++ b/boringtun/src/noise/mod.rs
@@ -64,7 +64,7 @@ impl FromStr for Verbosity {
     }
 }
 
-type LogFunction = Box<Fn(&str) + Send>;
+type LogFunction = Box< dyn Fn(&str) + Send>;
 
 /// Tunnel represents a point-to-point WireGuard connection
 pub struct Tunn {

--- a/install.sh
+++ b/install.sh
@@ -1,31 +1,3 @@
 #!/bin/sh
-JNI_LIBS=../app/src/tun-blocka/jniLibs
 
-export PATH=$PATH:$NDK_STANDALONE/arm64/bin
-
-cd boringtun
-
-rm -rf $JNI_LIBS
-mkdir $JNI_LIBS
-mkdir $JNI_LIBS/arm64-v8a
-mkdir $JNI_LIBS/armeabi-v7a
-mkdir $JNI_LIBS/x86
-
-echo "Building for armv7..."
-cargo build --lib --release --target armv7-linux-androideabi
-cp target/armv7-linux-androideabi/release/libboringtun.so $JNI_LIBS/armeabi-v7a/libboringtun.so
-
-echo "Building for aarch64..."
-export CC=aarch64-linux-android-gcc
-export CXX=aarch64-linux-android-g++
-cargo build --lib --release --target aarch64-linux-android
-cp target/aarch64-linux-android/release/libboringtun.so $JNI_LIBS/arm64-v8a/libboringtun.so
-
-echo "Building for i686..."
-export CC=i686-linux-android-gcc
-export CXX=i686-linux-android-g++
-cargo build --lib --release --target i686-linux-android
-cp target/i686-linux-android/release/libboringtun.so $JNI_LIBS/x86/libboringtun.so
-
-cd ../
-./gradlew iFD
+cd boringtun; . ./build.sh; cd ..; ./gradlew iFD


### PR DESCRIPTION
* BUILD.md still needs some work and possibly additional information

* The two `.rs` files changed are because of  `rustc` warning of deprecation.

* `install.sh` script made to directly call `boringtun/build.sh` to avoid errors regarding paths

* `build.sh` added an export to set the ndk bundle path to `~/Android/android-ndk-r21` (latest ndk as of yet)
* * also added sed commands to update the `boringtun/.cargo/config` to linux

I've run multiple test builds and managed to installFullDebug to my android device
Latest successful build with:
```
cargo 1.42.0 (86334295e 2020-01-31)
rustc 1.42.0 (b8cedc004 2020-03-09)
```