### PR TITLE
notification: Take at most 15 blocked history items

### DIFF
--- a/app/src/ui-blokada/kotlin/notification/ANotificationUtils.kt
+++ b/app/src/ui-blokada/kotlin/notification/ANotificationUtils.kt
@@ -175,13 +175,7 @@ class UsefulKeepAliveNotification(val count: Int, val last: String): BlokadaNoti
             } else {
                 val domainList = NotificationCompat.InboxStyle()
 
-                var logSublistEnd = RequestLog.getRecentHistory().size
-                if(logSublistEnd > 15) {
-                    logSublistEnd = 15
-                } else if (logSublistEnd > 0) {
-                    logSublistEnd--
-                }
-                RequestLog.getRecentHistory().filter { it.state == RequestState.BLOCKED_NORMAL }.subList(0,logSublistEnd).asReversed().distinct().forEach { request ->
+                RequestLog.getRecentHistory().filter { it.state == RequestState.BLOCKED_NORMAL }.take(15).asReversed().distinct().forEach { request ->
                     domainList.addLine(request.domain)
                 }
 


### PR DESCRIPTION
This fixes a nasty crash when toIndex in subList goes out of range:
(Cut down for brevity)
```
E AndroidRuntime: java.lang.RuntimeException: Unable to bind to service core.KeepAliveService@8ecb0ab with Intent { act=KeepAliveService cmp=org.blokada.origin.alarm/core.KeepAliveService }: java.lang.IndexOutOfBoundsException: toIndex = 15
[...]
E AndroidRuntime: 	at java.util.ArrayList.subListRangeCheck(ArrayList.java:1016)
E AndroidRuntime: 	at java.util.ArrayList.subList(ArrayList.java:1008)
E AndroidRuntime: 	at notification.UsefulKeepAliveNotification$1.invoke(ANotificationUtils.kt:184)
E AndroidRuntime: 	at notification.UsefulKeepAliveNotification$1.invoke(ANotificationUtils.kt:160)
E AndroidRuntime: 	at notification.BlokadaNotificationManager.getNotification(ANotificationUtils.kt:71)
```

4671acacb484a0151ec0046e3289763f6f8de7c2 applies a filter over history
which has a tendency to return fewer items than `logSublistEnd`, resulting
in the above bounds check failure. `.take` has no such limitations: it'll
give at most 15 of the desired items.

---
Note that I don't fully understand the:
```kt
} else if (logSublistEnd > 0) {
    logSublistEnd--
}
```
clause at the end. `toIndex` in `subList()` is exclusive according to [the docs](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-list/sub-list.html) meaning a list with one item results in `.subList(0, 0)` and hence no history elements as a result. Is this by accident or should this be replicated?
