### PR TITLE
Fixed SlotMutex "freezing" with all slots closed

### DIFF
--- a/app/src/ui-blokada/kotlin/core/bits/menu/adblocking/Sections.kt
+++ b/app/src/ui-blokada/kotlin/core/bits/menu/adblocking/Sections.kt
@@ -19,7 +19,7 @@ internal class SlotMutex {
     val openOneAtATime = { view: SlotView ->
         val opened = openedView
         when {
-            opened == null || !opened.isUnfolded() -> {
+            opened == null || !opened.isUnfolded() || !opened.isAttachedToWindow -> {
                 openedView = view
                 view.unfold()
             }


### PR DESCRIPTION
There is currently a problem, in the hostlog:
If you open a slot and scroll down the list is expanded and the last opened Slot-instance isn't attached anymore. This causes all slots to stay closed if you click them because the SlotMutex tries to close the detached Slot which isn't possible.