### PR TITLE
Fix missing signingConfig errors for cloners

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,16 +61,6 @@ android {
         abortOnError false
     }
 
-    signingConfigs {
-        // Set the BLOKADA_* constants in your ~/.gradle/gradle.properties to point to your keystore.
-        release {
-            keyAlias 'blokada'
-            keyPassword BLOKADA_KEY_PASSWORD
-            storeFile file(BLOKADA_KEY_PATH)
-            storePassword BLOKADA_STORE_PASSWORD
-        }
-    }
-
     buildTypes {
         debug {
             // By default it is a 'debuggable' build, signed with a debug key.
@@ -82,9 +72,28 @@ android {
              * inclusion standards, which means they cannot contain any non-free software or
              * tracking, hence we can provide only limited support for them.
              */
+
+            def f = rootProject.file('keystore.properties')
+            if (f.exists()) {
+                println "Release build will use Blokada keystore"
+                Properties props = new Properties()
+                InputStream inputStream = new FileInputStream(f)
+                props.load(inputStream)
+                inputStream.close()
+
+                signingConfigs {
+                    release {
+                        storeFile rootProject.file(props['BLOKADA_KEY_PATH'])
+                        storePassword props['BLOKADA_STORE_PASSWORD']
+                        keyAlias 'blokada'
+                        keyPassword props['BLOKADA_KEY_PASSWORD']
+                    }
+                }
+                signingConfig signingConfigs.release
+            }
+
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-            signingConfig signingConfigs.release
         }
 
         official {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
It's annoying to have to deal with every time the project is cloned. Hopefully it works right for you. If not, just mess around with it until it does (because I have no clue how yours is set up).

I put this together by merging usages of two of my favorite projects:
- https://github.com/Adamantcheese/Kuroba/blob/multi-feature/Kuroba/app/build.gradle#L170
- https://github.com/TwidereProject/Twidere-Android/blob/master/twidere/build.gradle#L72