### PR TITLE
fixed a bufferoverflow exception in Blokada Plus caused by cname blocking

### DIFF
--- a/app/src/full/kotlin/tunnel/BlockaTunnelFiltering.kt
+++ b/app/src/full/kotlin/tunnel/BlockaTunnelFiltering.kt
@@ -218,9 +218,9 @@ internal class BlockaTunnelFiltering(
                     .payloadBuilder(udpForward)
                     .build()
 
+            packet.limit(envelope.rawData.size)
             packet.put(envelope.rawData)
             packet.position(0)
-            packet.limit(envelope.rawData.size)
         }
     }
 


### PR DESCRIPTION
Don't know how this one slipped through my initial testing but sometimes when using cname blocking with Blokada Plus a BufferOverflowException would be thrown.
This was caused by the generated answer for the blocked cname sometimes being larger then the original answer and by that breaking the limit set on the buffer. This is fixed by setting the limit before copying the new content into the package buffer.