### PR TITLE
Recommend Blokada 5 in the 4 metadata for F-Droid

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,5 +1,8 @@
 Block ads without killing the battery
 
+From now on, Blokada 5 is the recommended version for all new and existing users. 
+(https://f-droid.org/en/packages/org.blokada.fem.fdroid/)
+
 Try the new version of Blokada to experience even higher level of stability,
 speed and battery efficiency of one of the best ad blockers out there!
 


### PR DESCRIPTION
As 5 is the recommended version (https://community.blokada.org/t/blokada-5-for-android-is-now-stable/3692) this information should be displayed in version 4.x in F-Droid.

These changes the fastlane metadata it will only propagate to F-Droid after creating a new tag (which of course needs to be built at F-Droid).