### PR TITLE
Bypass TomTom AmiGO by default

### DIFF
--- a/android5/app/src/main/java/repository/AppRepository.kt
+++ b/android5/app/src/main/java/repository/AppRepository.kt
@@ -75,6 +75,8 @@ object AppRepository {
         "com.xiaomi.discover",
         "eu.siacs.conversations",
         "org.jitsi.meet",
+        "com.tomtom.speedcams.android.map",
+        "com.tomtom.amigo.huawei",
         // RCS: https://github.com/blokadaorg/blokadaorg.github.io/pull/31
         "com.android.service.ims.RcsServiceApp",
         "com.google.android.carriersetup",


### PR DESCRIPTION
Based on issue [#847](https://github.com/blokadaorg/blokada/issues/847)