### PR TITLE
Bypass Threema HMS builds as well

### DIFF
--- a/android5/app/src/main/java/repository/AppRepository.kt
+++ b/android5/app/src/main/java/repository/AppRepository.kt
@@ -72,6 +72,8 @@ object AppRepository {
         "com.android.carrierconfig",
         "ch.threema.app",
         "ch.threema.app.work",
+        "ch.threema.app.hms",
+        "ch.threema.app.work.hms,
         "com.xiaomi.discover",
         "eu.siacs.conversations",
         "org.jitsi.meet",


### PR DESCRIPTION
Threema recently published their app in the Huawei AppGallery. Those
builds have a different package name compared to Google Play:

- ch.threema.app.hms
- ch.threema.app.work.hms

Bypass those as well.