### PR TITLE
Fix typo

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -9,7 +9,7 @@ Work in progress
 - install rustup
 - make sure you use stable toolchain `rustup default stable`
 - cargo install cargo-make
-- cargo install cdbindgen
+- cargo install cbindgen
 - rustup target add aarch64-apple-ios
 
 ## build for ios


### PR DESCRIPTION
In the command `cargo install cdbindgen` there is a typo, the correct name of the package is `cbindgen`.