### PR TITLE
allow MainActivity to be shown in landscape mode

### DIFF
--- a/android5/app/src/main/AndroidManifest.xml
+++ b/android5/app/src/main/AndroidManifest.xml
@@ -49,7 +49,7 @@
             android:name="ui.MainActivity"
             android:label="@string/app_name"
             android:launchMode="singleTask"
-            android:screenOrientation="portrait">
+            android:screenOrientation="sensor">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
This change allows users to use Blokada in landscape mode (see #833).

Tested on a 10" tablet.