### PR TITLE
Remove non-JSON DoH resolver until RFC 8484 is supported

### DIFF
--- a/android5/app/src/main/java/repository/DnsDataSource.kt
+++ b/android5/app/src/main/java/repository/DnsDataSource.kt
@@ -103,16 +103,17 @@ object DnsDataSource {
             ips = listOf("80.67.169.12", "80.67.169.40"),
             label = "French Data Network"
         ),
-        Dns(
-            id = "digitalegesellschaft",
-            ips = listOf("185.95.218.42", "185.95.218.43", "2a05:fc84::42", "2a05:fc84::43"),
-            port = 443,
-            name = "dns.digitale-gesellschaft.ch",
-            path = "dns-query",
-            label = "Digitale Gesellschaft (Switzerland)",
-            canUseInCleartext = false,
-            region = "europe"
-        ),
+        // TODO #927: require DoH according to RFC 8484 support
+        //Dns(
+        //    id = "digitalegesellschaft",
+        //    ips = listOf("185.95.218.42", "185.95.218.43", "2a05:fc84::42", "2a05:fc84::43"),
+        //    port = 443,
+        //    name = "dns.digitale-gesellschaft.ch",
+        //    path = "dns-query",
+        //    label = "Digitale Gesellschaft (Switzerland)",
+        //    canUseInCleartext = false,
+        //    region = "europe"
+        //),
         Dns(
             id = "google",
             ips = listOf("8.8.8.8", "8.8.4.4", "2001:4860:4860::8888", "2001:4860:4860::8844"),

--- a/blocka_engine/blocka_dns/src/runtime.rs
+++ b/blocka_engine/blocka_dns/src/runtime.rs
@@ -425,7 +425,9 @@ mod test {
         "dns-query".into(),
         vec![
           "185.95.218.42".parse().unwrap(),
-          "2a05:fc84::4".parse().unwrap(),
+          "2a05:fc84::42".parse().unwrap(),
+          "185.95.218.43".parse().unwrap(),
+          "2a05:fc84::43".parse().unwrap(),
         ],
         Duration::from_secs(1),
       )),
@@ -477,7 +479,8 @@ mod test {
       cloudflare,
       cloudflare_malware,
       cloudflare_adult,
-      gesellschaft,
+      // TODO #927: require DoH according to RFC 8484 support
+      // gesellschaft,
       // opendns,
       // opendns_family,
       opennic_eu,

--- a/ios/App/Model/DnsModel.swift
+++ b/ios/App/Model/DnsModel.swift
@@ -75,7 +75,8 @@ extension Dns {
         // Turns out those two are not DoH
         //Dns(ips: ["1.1.1.2", "1.0.0.2", "2606:4700:4700::1112", "2606:4700:4700::1002"], port: 443, name: "cloudflare-dns.com", path: "dns-query", label: "Cloudflare: malware blocking"),
         //Dns(ips: ["1.1.1.3", "1.0.0.3", "2606:4700:4700::1113", "2606:4700:4700::1003"], port: 443, name: "cloudflare-dns.com", path: "dns-query", label: "Cloudflare: malware & adult blocking"),
-        Dns(ips: ["185.95.218.42", "185.95.218.43", "2a05:fc84::42", "2a05:fc84::43"], port: 443, name: "dns.digitale-gesellschaft.ch", path: "dns-query", label: "Digitale Gesellschaft (Switzerland)", plusIps: nil),
+        // TODO #927: require DoH according to RFC 8484 support
+        // Dns(ips: ["185.95.218.42", "185.95.218.43", "2a05:fc84::42", "2a05:fc84::43"], port: 443, name: "dns.digitale-gesellschaft.ch", path: "dns-query", label: "Digitale Gesellschaft (Switzerland)", plusIps: nil),
         Dns(ips: ["8.8.8.8", "8.8.4.4", "2001:4860:4860::8888", "2001:4860:4860::8844"], port: 443, name: "dns.google", path: "resolve", label: "Google", plusIps: nil),
     ]
 


### PR DESCRIPTION
DoH resolver of [Digital Society Switzerland](https://www.digitale-gesellschaft.ch/) don't support DoH based on JSON. Although it was never officially supported, it had worked. Users of Blokada who select these name resolvers are facing name resolution issues.

As soon as #927 is implemented these DoH resolvers can be enabled again.