### PR TITLE
attempt offline android build

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Thu Oct 12 12:45:25 CEST 2023
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=file:/workspace/blokada/deps/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- point Android gradle wrapper at the bundled distribution so it doesn't fetch from the network

## Testing
- `make test` *(fails: Failed to update packages)*
- `timeout 120 make build-android-six-offline` *(fails: Plugin version not found offline)*