### PR TITLE
Add offline test target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,6 @@ already cached.
 
 `make test` runs the Flutter tests located in `common/`. These require the
 Flutter dependencies to be available locally.
+
+Use `make test-offline` to run the tests without contacting the network. This
+assumes all dependencies have already been fetched.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ADAPTY_VER := 3_4.0
 # Default target
 .DEFAULT_GOAL := build
 
-.PHONY: clean test build \
+.PHONY: clean test test-offline build \
         translate \
         build-android build-android-family build-android-six build-android-six-offline \
 	build-ios build-ios-family build-ios-six \
@@ -45,6 +45,10 @@ clean:
 
 test:
 	$(MAKE) -C common/ pub gen-android runner
+	$(MAKE) -C common/ test
+
+test-offline:
+	$(MAKE) -C common/ pub-offline gen-android runner
 	$(MAKE) -C common/ test
 
 # Build everything from scratch


### PR DESCRIPTION
## Summary
- add `test-offline` target to run Flutter tests without network
- document how to run tests offline in `AGENTS.md`

## Testing
- `make test-offline`

------
https://chatgpt.com/codex/tasks/task_b_683ecc652754832b819244525e65cfb2