### PR TITLE
ios: synchronize HTTP timeouts across all network components

### DIFF
--- a/ios/App/Assets/Constants.swift
+++ b/ios/App/Assets/Constants.swift
@@ -14,3 +14,6 @@ import Foundation
 
 // Many events initiated from UI are debounced to avoid general abuse (in seconds)
 let DEFAULT_USER_INTERACTION_DEBOUNCE = 0.3
+
+// HTTP timeout configuration - used by main app, network extension, and WgService (in seconds)
+let HTTP_TIMEOUT_INTERVAL: TimeInterval = 15.0

--- a/ios/App/Binding/CommonBinding.swift
+++ b/ios/App/Binding/CommonBinding.swift
@@ -33,8 +33,8 @@ class CommonBinding: CommonOps {
 
     init() {
         let configuration = URLSessionConfiguration.default
-        configuration.timeoutIntervalForRequest = TimeInterval(15)
-        configuration.timeoutIntervalForResource = TimeInterval(15)
+        configuration.timeoutIntervalForRequest = HTTP_TIMEOUT_INTERVAL
+        configuration.timeoutIntervalForResource = HTTP_TIMEOUT_INTERVAL
         session = URLSession(configuration: configuration)
 
         CommonOpsSetup.setUp(binaryMessenger: flutter.getMessenger(), api: self)

--- a/ios/IOS.xcodeproj/project.pbxproj
+++ b/ios/IOS.xcodeproj/project.pbxproj
@@ -662,6 +662,8 @@
 		4EF8ED822B87AA3B00E6E607 /* ScanQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF8ED7D2B87AA3B00E6E607 /* ScanQrCodeView.swift */; };
 		4EF8ED832B87AA3B00E6E607 /* ScanQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF8ED7D2B87AA3B00E6E607 /* ScanQrCodeView.swift */; };
 		81A14548F0971940140E60F7 /* Pods_FamilyProd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 172E613B3E5E2ECA63DB72B5 /* Pods_FamilyProd.framework */; };
+		B2382A312E61E14300ED7415 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2A172760E400005A59F5 /* Constants.swift */; };
+		B2382A322E61E14300ED7415 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2A172760E400005A59F5 /* Constants.swift */; };
 		D457AF88E4351BB1D413F70B /* Pods_FamilyMocked.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39323AFF3B4C4CB93EF7EEB4 /* Pods_FamilyMocked.framework */; };
 /* End PBXBuildFile section */
 
@@ -2755,6 +2757,7 @@
 				4E23CFE6293DFAB300613D0A /* PacketTunnelProvider.swift in Sources */,
 				4E23CFF0293DFEE200613D0A /* x25519.c in Sources */,
 				4E23D02C293E20BC00613D0A /* PrivateKey.swift in Sources */,
+				B2382A312E61E14300ED7415 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3172,6 +3175,7 @@
 				4ED751722D635F2F00CEE82E /* PacketTunnelProvider.swift in Sources */,
 				4ED751732D635F2F00CEE82E /* x25519.c in Sources */,
 				4ED751742D635F2F00CEE82E /* PrivateKey.swift in Sources */,
+				B2382A322E61E14300ED7415 /* Constants.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/NotFamily/WgService.swift
+++ b/ios/NotFamily/WgService.swift
@@ -52,7 +52,7 @@ class WgService: NetxServiceIn {
         // First state will be soon rewritten by actual state unless something is wrong
         //self.writeWgState.send(VpnStatus.inProgress())
     }
-    
+
     private func initTunnelsManager() {
         TunnelsManager.create { [weak self] result in
             guard let self = self else { return }
@@ -264,7 +264,7 @@ class WgService: NetxServiceIn {
                         guard error == nil else {
                             return promise(.failure("stopVpn: could not disable on-demand".cause(error)))
                         }
-                        
+
                         return promise(.success(manager))
                     }
                 }
@@ -284,7 +284,7 @@ class WgService: NetxServiceIn {
 
                     // Also make a timeout
                     Just(true)
-                    .delay(for: 15.0, scheduler: self.bgQueue)
+                    .delay(for: .seconds(HTTP_TIMEOUT_INTERVAL), scheduler: self.bgQueue)
                     .flatMap { _ in self.wgStateHot.first() }
                     .tryMap { state -> Ignored in
                         if state == .activated {
@@ -319,7 +319,7 @@ class WgService: NetxServiceIn {
                         if let error = error {
                             return promise(.failure("createVpnProfile: could not remove".cause(error)))
                         }
-                        
+
                         return promise(.success(manager))
                     }
                 }
@@ -366,7 +366,7 @@ class WgService: NetxServiceIn {
     func getStatePublisher() -> AnyPublisher<VpnStatus, Never> {
         return wgStateHot
     }
-    
+
     func getPermsPublisher() -> AnyPublisher<Granted, Never> {
         return permsHot
     }
@@ -450,11 +450,11 @@ class WgService: NetxServiceIn {
                 BlockaLogger.v("WgService", "No perms, emitting disconnected")
                 self.writeWgState.send(.deactivated)
             }
-            
+
         })
         .store(in: &cancellables)
     }
-    
+
     func makeProtectedRequest(url: String, method: String, body: String) -> AnyPublisher<String, Error> {
         let request = [
             NetworkCommand.request.rawValue, url, method, ":body:", body
@@ -504,9 +504,9 @@ class WgService: NetxServiceIn {
                 }
                 .eraseToAnyPublisher(),
 
-                // Also make a timeout
+                // Also make a timeout, same as http client timeout
                 Just(true)
-                .delay(for: 5.0, scheduler: self.bgQueue)
+                .delay(for: .seconds(HTTP_TIMEOUT_INTERVAL), scheduler: self.bgQueue)
                 .tryMap { state -> String in
                     throw "WG message timeout"
                 }

--- a/ios/WireguardCopiedFilesExtension/BlockaPacketTunnelProvider.swift
+++ b/ios/WireguardCopiedFilesExtension/BlockaPacketTunnelProvider.swift
@@ -9,6 +9,7 @@ import Factory
 // This is our override of wg-ios that adds the ability to perform protected HTTP requests.
 class BlockaPacketTunnelProvider: PacketTunnelProvider {
     private var env = Env()
+    
 
     private func performProtectedHttpRequest(url: String, method: String, body: String, completionHandler: @escaping ((Error?, String?) -> Void)) {
         
@@ -17,6 +18,7 @@ class BlockaPacketTunnelProvider: PacketTunnelProvider {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue(env.getUserAgent(), forHTTPHeaderField: "User-Agent")
+        request.timeoutInterval = HTTP_TIMEOUT_INTERVAL
 
         if !body.isEmpty {
             request.httpBody = data


### PR DESCRIPTION
- Add HTTP_TIMEOUT_INTERVAL constant (15.0s) in Constants.swift
- Update CommonBinding.swift to use shared timeout constant  
- Fix WgService.swift timeout delays to use HTTP_TIMEOUT_INTERVAL
- Set request timeout in BlockaPacketTunnelProvider.swift
- Add Constants.swift to WireGuard extension targets in project.pbxproj
