### PR TITLE
ios: add development build and run targets with device management

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "BASH_DEFAULT_TIMEOUT_MS": "900000"
+  },
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew:*)",
+      "Bash(dart run:*)",
+      "Bash(fastlane match:*)",
+      "Bash(flutter analyze:*)",
+      "Bash(flutter build:*)",
+      "Bash(flutter packages pub run build_runner:*)",
+      "Bash(flutter test:*)",
+      "Bash(fvm dart run build_runner build:*)",
+      "Bash(fvm flutter:*)",
+      "Bash(fvm list:*)",
+      "Bash(fvm use:*)",
+      "Bash(make build:*)",
+      "Bash(make clean:*)",
+      "Bash(make gen)",
+      "Bash(make install:*)",
+      "Bash(make regen:*)",
+      "Bash(make test:*)",
+      "Bash(make uninstall)",
+      "Bash(pod install:*)",
+      "Bash(pod update:*)",
+      "Bash(make -C ios run:*)",
+      "Bash(xcrun devicectl list:*)",
+      "Bash(xcodebuild:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ blokada-appstore.json
 *.keystore
 
 *.local.json
+!.claude/
+!.claude/settings.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,54 +40,66 @@ Before building, ensure dependencies are initialized:
 git submodule update --init --recursive
 ```
 
+### Development Workflow
+
+**Iterative development process:**
+1. **Make code changes**
+2. **Regenerate interfaces** (if modified `libgen/*.dart`): `make regen-ios` (iOS only) or `make regen` (all platforms)  
+3. **Check linting**: `fvm flutter analyze` - fix syntax/style issues immediately
+4. **Ensure tests pass**: `make test` - iterate steps 1-4 until **ALL** tests pass
+5. **Test on device**: Manual verification on physical device
+
+### Device Testing (Step 5 of Workflow)
+
+```bash
+# iOS: Build, install and run with console output
+make -C ios run-six      # or make -C ios run-family
+make -C ios run-six DEVICE_NAME="Your Device"  # specify device
+
+# Android: Install debug builds
+make install-family-debug    # or make install-six-debug
+```
+
 ### Building
 
-#### Android Debug APKs
+#### Debug Builds (for development)
 ```bash
-# Build Family app (debug)
+# Android
 make build-android-family-debug
-
-# Build Blokada 6 app (debug)
 make build-android-six-debug
-
-# Quick rebuild (if common lib unchanged)
-make build-android-family-debug-quick
+make build-android-family-debug-quick  # if common lib unchanged
 make build-android-six-debug-quick
+
+# iOS  
+make build-ios-six-debug
+# Note: make -C ios run automatically builds, installs, and runs
 ```
 
-#### Android Release AABs
+#### Release Builds (for deployment)
 ```bash
-# Build all Android apps
+# Android
 make build-android
-
-# Build specific app
 make build-android-family
 make build-android-six
-```
 
-#### iOS
-```bash
-# Build all iOS apps
+# iOS
 make build-ios
-
-# Build specific app
 make build-ios-family
 make build-ios-six
 ```
 
-### Testing
+### Testing & Linting (Steps 3-4 of Workflow)
+
 ```bash
 # Run all tests
 make test
 
-# Run Flutter tests directly
-cd common && flutter test
-```
+# Check linting
+fvm flutter analyze
 
-### Linting
-```bash
-# Run Flutter analyzer
-cd common && flutter analyze
+# Direct Flutter commands (if needed)
+cd common && fvm flutter test
+cd common && fvm flutter analyze
 ```
 
 ### Code Generation
@@ -117,6 +129,18 @@ make install-six-debug    # debug
 
 # Uninstall all
 make uninstall
+```
+
+### Device Testing & Debugging
+```bash
+# iOS: Build, install and run with console output (BLOCKING - use background task)
+make -C ios run-six [DEVICE_NAME="device name"] [CONFIG="Release|Debug"]
+make -C ios run-family [DEVICE_NAME="device name"] [CONFIG="Release|Debug"]
+# Default: CONFIG=Release (required for iOS 14+ to launch without Xcode/Flutter tooling)
+# These commands are blocking and provide console output - run as background task when needed
+
+# Android: Install and run debug builds
+make install-family-debug    # or make install-six-debug
 ```
 
 ### Version Management
@@ -149,6 +173,7 @@ The `common/` directory is a Flutter module that gets embedded into native apps:
 - Schemes: `FamilyProd`, `FamilyDev`, `Prod`, `Dev`, `Mocked`
 - Fastlane for automation and deployment
 - CocoaPods for dependency management
+- **iOS 14+ Flutter Debug Limitation**: Flutter debug mode apps cannot launch directly on device without Xcode/Flutter tooling connection. The `make -C ios run` target defaults to Release mode to bypass this restriction.
 
 ## Important Considerations
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ADAPTY_VER := 3_8.0
 .PHONY: clean test build \
 	translate \
 	build-android build-android-family build-android-six \
-	build-ios build-ios-family build-ios-six \
+	build-ios build-ios-family build-ios-six build-ios-six-debug \
 	version version-clean \
 	publish-android gplay-key-unpack gplay-key-clean \
 	publish-ios appstore-key-unpack appstore-key-clean fastlane-match \
@@ -82,6 +82,11 @@ build-ios-family:
 build-ios-six:
 	$(MAKE) -C common/ build-ios
 	$(MAKE) -C ios/ build-six
+
+# Build ios six .ipa from scratch (debug)
+build-ios-six-debug:
+	$(MAKE) -C common/ build-ios
+	$(MAKE) -C ios/ build-six-debug
 
 
 # Set version in proper files for all apps (use NAME and CODE params, or env vars)

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -1,10 +1,13 @@
 # Define common variables
 FASTLANE := fastlane
 
+# Make shell exit on any command failure
+.SHELLFLAGS := -ec
+
 # Default target
 .DEFAULT_GOAL := build
 
-.PHONY: build build-family build-six ipa-family ipa-six pods
+.PHONY: build build-family build-six build-six-debug build-family-debug ipa-family ipa-six pods run-six run-family
 
 # Note: for all targets in this Makefile, the common lib has to be
 # ready beforehand. This is handled when running make targets from
@@ -42,7 +45,54 @@ ipa-six:
 	$(MAKE) -C BlockaWebExtension gen-rules
 	$(FASTLANE) build_ios_six
 
+# Build .ipa of six - configurable configuration (defaults to Debug, overridden by CONFIG parameter)
+build-six-debug:
+	$(MAKE) -C BlockaWebExtension gen-rules
+	xcodebuild -workspace IOS.xcworkspace -scheme Dev -configuration $(or $(CONFIG),Debug) build
+
+# Build .ipa of family - configurable configuration (defaults to Debug, overridden by CONFIG parameter)
+build-family-debug:
+	$(MAKE) -C BlockaWebExtension gen-rules
+	xcodebuild -workspace IOS.xcworkspace -scheme FamilyDev -configuration $(or $(CONFIG),Debug) build
+
 # Regenerate Podfile.lock
 pods:
 	rm -rf Podfile.lock
 	pod install --repo-update
+
+# Build, install and run six flavor on connected device with console output
+# Usage: make run-six [DEVICE_NAME="device name"] [CONFIG="Release|Debug"]
+# Default: CONFIG=Release (required for iOS 14+ to launch without Xcode/Flutter tooling connection)
+run-six: CONFIG?=Release
+run-six: build-six-debug
+	$(call install-and-launch,Dev,Dev.app,net.blocka.app)
+
+# Build, install and run family flavor on connected device with console output
+# Usage: make run-family [DEVICE_NAME="device name"] [CONFIG="Release|Debug"]
+# Default: CONFIG=Release (required for iOS 14+ to launch without Xcode/Flutter tooling connection)
+run-family: CONFIG?=Release
+run-family: build-family-debug
+	$(call install-and-launch,FamilyDev,FamilyDev.app,net.blocka.app.family)
+
+# Shared function to discover device and install/launch app
+# Usage: $(call install-and-launch,SCHEME,APP_NAME,BUNDLE_ID)
+define install-and-launch
+	@DEVICES_JSON=$$(xcrun devicectl -q list devices --json-output /dev/stdout 2>&1 | sed '/ERROR:/,$$d'); \
+	if [ -n "$(DEVICE_NAME)" ]; then \
+		DEVICE_UDID=$$(echo "$$DEVICES_JSON" | jq -r ".result.devices[] | select(.deviceProperties.name == \"$(DEVICE_NAME)\" and .hardwareProperties.platform == \"iOS\" and .connectionProperties.pairingState == \"paired\") | .hardwareProperties.udid" | head -n 1 2>/dev/null); \
+		DEVICE_NAME_FOUND="$(DEVICE_NAME)"; \
+	else \
+		DEVICE_UDID=$$(echo "$$DEVICES_JSON" | jq -r '.result.devices[] | select(.hardwareProperties.deviceType == "iPhone" and .connectionProperties.pairingState == "paired") | .hardwareProperties.udid' | head -n 1 2>/dev/null); \
+		DEVICE_NAME_FOUND=$$(echo "$$DEVICES_JSON" | jq -r ".result.devices[] | select(.hardwareProperties.udid == \"$$DEVICE_UDID\") | .deviceProperties.name" 2>/dev/null); \
+	fi; \
+	if [ -z "$$DEVICE_UDID" ]; then \
+		echo "Error: No device found. Available devices:"; \
+		echo "$$DEVICES_JSON" | jq -r '.result.devices[] | select(.hardwareProperties.platform == "iOS" and .connectionProperties.pairingState == "paired") | "  \(.deviceProperties.name) (\(.hardwareProperties.deviceType))"' 2>/dev/null || echo "  (none found)"; \
+		exit 1; \
+	fi; \
+	echo "📱 Found device: $$DEVICE_NAME_FOUND"; \
+	APP_DIR=$$(xcodebuild -workspace IOS.xcworkspace -scheme $(1) -configuration $(CONFIG) -showBuildSettings | awk -F'= ' '/CONFIGURATION_BUILD_DIR/{print $$2; exit}'); \
+	echo "📦 Installing and launching..."; \
+	xcrun devicectl device install app --device $$DEVICE_UDID "$$APP_DIR/$(2)" && \
+	xcrun devicectl device process launch --device $$DEVICE_UDID --terminate-existing --console $(3)
+endef


### PR DESCRIPTION
- Add `run-six` and `run-family` targets that builds, installs, and launches on connected iPhone with console output.
- Document recommended development workflow for Claude
- Add .claude/settings.json with bash permissions for common development commands

Makefile target will run with release profile to work around the issue where flutter immediately exits unless dev tools are available.