### PR TITLE
pulse: show current hour counters

### DIFF
--- a/common/lib/platform/stats/stats.dart
+++ b/common/lib/platform/stats/stats.dart
@@ -803,7 +803,7 @@ PeriodCounters buildHourlyPeriodCountersFromRollingStats(
   final anchorSeconds = anchor.millisecondsSinceEpoch ~/ 1000;
 
   final hourUnit = Duration(hours: 1).inSeconds;
-  final currentEnd = anchorSeconds;
+  final currentEnd = anchorSeconds + hourUnit;
   final currentStart = currentEnd - hours * hourUnit;
   final previousEnd = currentStart;
   final previousStart = previousEnd - hours * hourUnit;

--- a/common/lib/v6/widget/home/stats/radial_chart.dart
+++ b/common/lib/v6/widget/home/stats/radial_chart.dart
@@ -63,12 +63,13 @@ class RadialChart extends StatelessWidget {
     final delta = counterDelta;
     final hasDelta = deltaReady && delta?.hasComparison == true;
     final statsUsable = statsReady && deltaReady;
+    final fallbackRatio = statsUsable ? gaugeFillFromDelta(0) : 0.0;
     final allowedRatio = hasDelta
         ? gaugeFillFromDelta(delta!.allowedPercent)
-        : (statsUsable ? stats.dayAllowedRatio : 0.0);
+        : fallbackRatio;
     final blockedRatio = hasDelta
         ? gaugeFillFromDelta(delta!.blockedPercent)
-        : (statsUsable ? stats.dayBlockedRatio : 0.0);
+        : fallbackRatio;
     final allowedVal = min(max(allowedRatio, 0.0), 100.0);
     final blockedVal = min(max(blockedRatio, 0.0), 100.0);
 

--- a/common/test/platform/stats/fixtures/stats_48h_new_user.json
+++ b/common/test/platform/stats/fixtures/stats_48h_new_user.json
@@ -1,0 +1,30 @@
+{
+  "total_allowed": "234",
+  "total_blocked": "28",
+  "stats": {
+    "metrics": [
+      {
+        "tags": {
+          "action": "blocked"
+        },
+        "dps": [
+          {
+            "timestamp": "1767607200",
+            "value": 10
+          }
+        ]
+      },
+      {
+        "tags": {
+          "action": "fallthrough"
+        },
+        "dps": [
+          {
+            "timestamp": "1767607200",
+            "value": 17
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- 50% fill if previous period is not available
- include current hour
- add "new user" test case