### PR TITLE
implement local notification for user without log retention enabled

### DIFF
--- a/android/app/src/main/java/binding/CommonBinding.kt
+++ b/android/app/src/main/java/binding/CommonBinding.kt
@@ -81,6 +81,11 @@ object CommonBinding : CommonOps {
         callback(Result.success(Unit))
     }
 
+    override fun doCancel(notificationId: String, callback: (Result<Unit>) -> Unit) {
+        notification.cancel(notificationId)
+        callback(Result.success(Unit))
+    }
+
     // Rate
 
     var onShowRateDialog: () -> Unit = { }

--- a/android/app/src/main/java/binding/CommonBinding.kt
+++ b/android/app/src/main/java/binding/CommonBinding.kt
@@ -76,7 +76,7 @@ object CommonBinding : CommonOps {
         callback(Result.success(Unit))
     }
 
-    override fun doDismissAll(callback: (Result<Unit>) -> Unit) {
+    override fun doDismissDeliveredAll(callback: (Result<Unit>) -> Unit) {
         notification.dismissAll()
         callback(Result.success(Unit))
     }

--- a/android/app/src/main/java/service/NotificationService.kt
+++ b/android/app/src/main/java/service/NotificationService.kt
@@ -29,6 +29,7 @@ import utils.NotificationChannels
 import utils.NotificationPrototype
 import utils.OnboardingNotification
 import utils.QuickSettingsNotification
+import utils.ActivityLoggingReminderNotification
 import utils.WeeklyReportNotification
 import java.util.Calendar
 import java.util.Date
@@ -44,6 +45,7 @@ val NOTIF_ONBOARDING_FAMILY = "onboardingDnsAdviceFamily"
 val NOTIF_NEW_MESSAGE = "supportNewMessage"
 val NOTIF_QUICKSETTINGS = "quickSettings" // Shown while QS is changing app status
 val NOTIF_WEEKLY_REPORT = "weeklyReport"
+val NOTIF_ACTIVITY_LOGGING_REMINDER = "activityLoggingReminder"
 private const val WEEKLY_REPORT_BACKGROUND_LEAD_MS = 60 * 60 * 1000L
 private const val WEEKLY_REPORT_REFRESH_TITLE = "Weekly report updated"
 private const val WEEKLY_REPORT_REFRESH_BODY = "Your weekly report is updated."
@@ -101,6 +103,22 @@ private const val WEEKLY_REPORT_REFRESH_BODY = "Your weekly report is updated."
         notificationManager.cancelAll()
     }
 
+    fun cancel(notificationId: String) {
+        val ctx = context.requireAppContext()
+        val intent = Intent(ctx, NotificationAlarmReceiver::class.java)
+        intent.putExtra("id", notificationId)
+        val pendingIntent = PendingIntent.getBroadcast(
+            ctx,
+            notificationId.hashCode(),
+            intent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        alarmManager.cancel(pendingIntent)
+        pendingIntent.cancel()
+
+        notificationIntId(notificationId)?.let(notificationManager::cancel)
+    }
+
     fun show(notification: NotificationPrototype) {
         val builder = notification.create(context.requireContext())
         if (useChannels) builder.setChannelId(notification.channel.name)
@@ -156,10 +174,28 @@ class NotificationAlarmReceiver : BroadcastReceiver() {
                     WeeklyReportNotification(payload.title, payload.body)
                 }
             }
+            NOTIF_ACTIVITY_LOGGING_REMINDER ->
+                ActivityLoggingReminderNotification(intent.getStringExtra("body"))
             else -> null
         }
 
         if (n != null) notification.show(n)
+    }
+}
+
+private fun notificationIntId(notificationId: String): Int? {
+    return when (notificationId) {
+        NOTIF_ACC_EXP -> 4
+        NOTIF_ACC_EXP_FAM -> 5
+        NOTIF_LEASE_EXP -> 22
+        NOTIF_PAUSE -> 23
+        NOTIF_ONBOARDING -> 6
+        NOTIF_ONBOARDING_FAMILY -> 7
+        NOTIF_NEW_MESSAGE -> 8
+        NOTIF_QUICKSETTINGS -> 9
+        NOTIF_WEEKLY_REPORT -> 25
+        NOTIF_ACTIVITY_LOGGING_REMINDER -> 26
+        else -> null
     }
 }
 

--- a/android/app/src/main/java/utils/Notifications.kt
+++ b/android/app/src/main/java/utils/Notifications.kt
@@ -19,6 +19,7 @@ import model.BlokadaException
 import org.blokada.R
 import service.Localised
 import service.NOTIF_WEEKLY_REPORT
+import service.NOTIF_ACTIVITY_LOGGING_REMINDER
 import ui.MainActivity
 
 private const val IMPORTANCE_NONE = 0
@@ -239,6 +240,29 @@ class WeeklyReportNotification(
 
         val intentActivity = Intent(ctx, MainActivity::class.java)
         intentActivity.putExtra("notificationId", NOTIF_WEEKLY_REPORT)
+        val piActivity = ctx.getPendingIntentForActivity(intentActivity, 0)
+        b.setContentIntent(piActivity)
+    }
+)
+
+class ActivityLoggingReminderNotification(
+    private val bodyOverride: String?
+) : NotificationPrototype(
+    26, NotificationChannels.BLOCKA,
+    create = { ctx ->
+        val b = NotificationCompat.Builder(ctx)
+        val title = "Privacy Pulse"
+        val body = bodyOverride ?: "Enable activity logging to receive your weekly Privacy Pulse reports."
+
+        b.setContentTitle(title)
+        b.setContentText(body)
+        b.setStyle(NotificationCompat.BigTextStyle().bigText(body))
+        b.setSmallIcon(R.drawable.ic_stat_blokada)
+        b.setPriority(NotificationCompat.PRIORITY_MAX)
+        b.setVibrate(LongArray(0))
+
+        val intentActivity = Intent(ctx, MainActivity::class.java)
+        intentActivity.putExtra("notificationId", NOTIF_ACTIVITY_LOGGING_REMINDER)
         val piActivity = ctx.getPendingIntentForActivity(intentActivity, 0)
         b.setContentIntent(piActivity)
     }

--- a/common/lib/src/features/notification/domain/actor.dart
+++ b/common/lib/src/features/notification/domain/actor.dart
@@ -18,9 +18,9 @@ class NotificationActor with Logging, Actor {
   late final _device = Core.get<DeviceStore>();
   late final _payment = Core.get<PaymentActor>();
   late final _weeklyReport = Core.get<WeeklyReportActor>();
-  var _pendingPrivacyPulseNav = false;
-  Object? _pendingPrivacyPulseArgs;
-  var _privacyPulseNavInFlight = false;
+  Paths? _pendingNotificationPath;
+  Object? _pendingNotificationArgs;
+  var _notificationNavInFlight = false;
 
   late final _channel = Core.get<NotificationChannel>();
   late final _json = Core.get<NotificationApi>();
@@ -45,7 +45,7 @@ class NotificationActor with Logging, Actor {
       _account.addOn(accountIdChanged, syncNotificationConfigFromBackendAsync);
     }
     if (_stage.route.isForeground()) {
-      await _tryOpenPendingPrivacyPulse(m, trigger: "onStart");
+      await _tryOpenPendingNotification(m, trigger: "onStart");
     }
   }
 
@@ -87,7 +87,7 @@ class NotificationActor with Logging, Actor {
 
     return await log(m).trace("dismissNotifications", (m) async {
       await dismiss(m);
-      await _tryOpenPendingPrivacyPulse(m, trigger: "routeChanged");
+      await _tryOpenPendingNotification(m, trigger: "routeChanged");
     });
   }
 
@@ -213,57 +213,76 @@ class NotificationActor with Logging, Actor {
         // await sleepAsync(const Duration(seconds: 3));
         // await _stage.setRoute(Paths.support.path, m);
       } else if (id == NotificationId.activityLoggingReminder) {
-        await Navigation.open(Paths.settingsRetention);
+        await _queueNotificationNavigation(
+          m,
+          path: Paths.settingsRetention,
+          trigger: "notificationTapped",
+        );
       } else if (id == NotificationId.weeklyReport) {
         final args = {
           'toplistRange': ToplistRange.weekly,
         };
         if (!isOnPrivacyPulse) {
-          _pendingPrivacyPulseNav = true;
-          _pendingPrivacyPulseArgs = args;
-          if (_stage.route.isForeground()) {
-            await _tryOpenPendingPrivacyPulse(m, trigger: "notificationTapped");
-          }
+          await _queueNotificationNavigation(
+            m,
+            path: Paths.privacyPulse,
+            args: args,
+            trigger: "notificationTapped",
+          );
         }
       }
     });
   }
 
-  Future<void> _tryOpenPendingPrivacyPulse(Marker m, {required String trigger}) async {
-    if (!_pendingPrivacyPulseNav) return;
-    if (_privacyPulseNavInFlight) return;
-
-    final isOnPrivacyPulse = Navigation.lastPath == Paths.privacyPulse;
-    if (isOnPrivacyPulse) {
-      _pendingPrivacyPulseNav = false;
-      _pendingPrivacyPulseArgs = null;
-      return;
-    }
-
-    _privacyPulseNavInFlight = true;
-    final args = _pendingPrivacyPulseArgs;
-    _pendingPrivacyPulseNav = false;
-    _pendingPrivacyPulseArgs = null;
-    try {
-      await _openPrivacyPulseWithRetry(m, args);
-    } finally {
-      _privacyPulseNavInFlight = false;
-      log(m).pair("privacyPulseNavTrigger", trigger);
+  Future<void> _queueNotificationNavigation(
+    Marker m, {
+    required Paths path,
+    Object? args,
+    required String trigger,
+  }) async {
+    _pendingNotificationPath = path;
+    _pendingNotificationArgs = args;
+    if (_stage.route.isForeground()) {
+      await _tryOpenPendingNotification(m, trigger: trigger);
     }
   }
 
-  Future<void> _openPrivacyPulseWithRetry(Marker m, Object? args) async {
+  Future<void> _tryOpenPendingNotification(Marker m, {required String trigger}) async {
+    final path = _pendingNotificationPath;
+    if (path == null) return;
+    if (_notificationNavInFlight) return;
+
+    if (Navigation.lastPath == path) {
+      _pendingNotificationPath = null;
+      _pendingNotificationArgs = null;
+      return;
+    }
+
+    _notificationNavInFlight = true;
+    final args = _pendingNotificationArgs;
+    _pendingNotificationPath = null;
+    _pendingNotificationArgs = null;
+    try {
+      await _openNotificationWithRetry(m, path, args);
+    } finally {
+      _notificationNavInFlight = false;
+      log(m).pair("notificationNavTrigger", trigger);
+      log(m).pair("notificationNavPath", path);
+    }
+  }
+
+  Future<void> _openNotificationWithRetry(Marker m, Paths path, Object? args) async {
     const attempts = 5;
     const delay = Duration(milliseconds: 250);
 
     for (var i = 0; i < attempts; i++) {
       try {
-        await Navigation.open(Paths.privacyPulse, arguments: args);
+        await Navigation.open(path, arguments: args);
         return;
       } catch (e, s) {
         final isLastAttempt = i == attempts - 1;
         if (isLastAttempt) {
-          log(m).e(msg: "Failed to open Privacy Pulse from notification tap", err: e, stack: s);
+          log(m).e(msg: "Failed to open notification destination", err: e, stack: s);
           return;
         }
         await sleepAsync(delay);

--- a/common/lib/src/features/notification/domain/actor.dart
+++ b/common/lib/src/features/notification/domain/actor.dart
@@ -7,11 +7,16 @@ part of 'notification.dart';
 /// we can do stuff in foreground (like refresh account).
 
 class NotificationActor with Logging, Actor {
+  static const _activityLoggingReminderDelay = Duration(minutes: 1);
+  static const _activityLoggingReminderBody =
+      "Enable activity logging to receive your weekly Privacy Pulse reports.";
+
   // TODO: fix those dependencies
   late final _stage = Core.get<StageStore>();
   late final _account = Core.get<AccountStore>();
   late final _accountRefresh = Core.get<AccountRefreshStore>();
   late final _device = Core.get<DeviceStore>();
+  late final _payment = Core.get<PaymentActor>();
   late final _weeklyReport = Core.get<WeeklyReportActor>();
   var _pendingPrivacyPulseNav = false;
   Object? _pendingPrivacyPulseArgs;
@@ -33,6 +38,8 @@ class NotificationActor with Logging, Actor {
     _stage.addOnValue(routeChanged, onRouteChanged);
     _account.addOn(accountChanged, sendFcmTokenAsync);
     _device.addOn(deviceChanged, sendFcmTokenAsync);
+    _device.addOn(deviceChanged, _onDeviceChanged);
+    _payment.addOnValue(paymentSuccessful, _onPaymentSuccessful);
     if (!Core.act.isFamily) {
       _account.addOn(accountChanged, syncNotificationConfigFromBackendAsync);
       _account.addOn(accountIdChanged, syncNotificationConfigFromBackendAsync);
@@ -65,8 +72,12 @@ class NotificationActor with Logging, Actor {
 
   // Only dismisses all notifications for now
   dismiss(Marker m, {NotificationId id = NotificationId.all}) async {
-    return await log(m).trace("dismissAll", (m) async {
-      _addCapped(NotificationEvent.dismissed());
+    return await log(m).trace("dismiss", (m) async {
+      if (id == NotificationId.all) {
+        _addCapped(NotificationEvent.dismissed());
+      } else {
+        _addCapped(NotificationEvent.dismissed(id: id));
+      }
       await _updateChannel();
     });
   }
@@ -201,6 +212,8 @@ class NotificationActor with Logging, Actor {
         // await _stage.setRoute(Paths.settings.path, m);
         // await sleepAsync(const Duration(seconds: 3));
         // await _stage.setRoute(Paths.support.path, m);
+      } else if (id == NotificationId.activityLoggingReminder) {
+        await Navigation.open(Paths.settingsRetention);
       } else if (id == NotificationId.weeklyReport) {
         final args = {
           'toplistRange': ToplistRange.weekly,
@@ -318,6 +331,30 @@ class NotificationActor with Logging, Actor {
     return resolveNotificationScheduleHint(scheduleHint, DateTime.now());
   }
 
+  Future<void> _onPaymentSuccessful(bool restore, Marker m) async {
+    if (restore || Core.act.isFamily) return;
+
+    await log(m).trace("activityLoggingReminder:onPaymentSuccessful", (m) async {
+      await _device.fetch(m, force: true);
+      if (_device.retention?.isEnabled() ?? false) {
+        await dismiss(m, id: NotificationId.activityLoggingReminder);
+        return;
+      }
+
+      await showWithBody(
+        NotificationId.activityLoggingReminder,
+        m,
+        _activityLoggingReminderBody,
+        when: DateTime.now().add(_activityLoggingReminderDelay),
+      );
+    });
+  }
+
+  Future<void> _onDeviceChanged(Marker m) async {
+    if (!(_device.retention?.isEnabled() ?? false)) return;
+    await dismiss(m, id: NotificationId.activityLoggingReminder);
+  }
+
   _addCapped(NotificationEvent event) {
     final notifications = _notifications.now.toList();
     notifications.add(event);
@@ -332,7 +369,11 @@ class NotificationActor with Logging, Actor {
     if (event.type == NotificationEventType.show) {
       await _channel.doShow(event.id.name, event.when!.toUtc().toIso8601String(), event.body);
     } else if (event.type == NotificationEventType.dismiss) {
-      await _channel.doDismissAll();
+      if (event.id == NotificationId.all) {
+        await _channel.doDismissAll();
+      } else {
+        await _channel.doCancel(event.id.name);
+      }
     }
   }
 }

--- a/common/lib/src/features/notification/domain/actor.dart
+++ b/common/lib/src/features/notification/domain/actor.dart
@@ -370,7 +370,7 @@ class NotificationActor with Logging, Actor {
       await _channel.doShow(event.id.name, event.when!.toUtc().toIso8601String(), event.body);
     } else if (event.type == NotificationEventType.dismiss) {
       if (event.id == NotificationId.all) {
-        await _channel.doDismissAll();
+        await _channel.doDismissDeliveredAll();
       } else {
         await _channel.doCancel(event.id.name);
       }

--- a/common/lib/src/features/notification/domain/model.dart
+++ b/common/lib/src/features/notification/domain/model.dart
@@ -8,9 +8,8 @@ class NotificationEvent {
 
   NotificationEvent.shown(this.id, this.when, {this.body}) : type = NotificationEventType.show;
 
-  NotificationEvent.dismissed()
-      : id = NotificationId.all,
-        type = NotificationEventType.dismiss,
+  NotificationEvent.dismissed({this.id = NotificationId.all})
+      : type = NotificationEventType.dismiss,
         when = null,
         body = null;
 }
@@ -22,6 +21,7 @@ enum NotificationId {
   supportNewMessage,
   weeklyReport,
   weeklyRefresh,
+  activityLoggingReminder,
 }
 
 enum NotificationEventType {

--- a/common/lib/src/features/notification/domain/notification.dart
+++ b/common/lib/src/features/notification/domain/notification.dart
@@ -31,7 +31,7 @@ part 'weekly_report.dart';
 @PlatformProvided()
 mixin NotificationChannel {
   Future<void> doShow(String notificationId, String atWhen, String? body);
-  Future<void> doDismissAll();
+  Future<void> doDismissDeliveredAll();
   Future<void> doCancel(String notificationId);
 }
 

--- a/common/lib/src/features/notification/domain/notification.dart
+++ b/common/lib/src/features/notification/domain/notification.dart
@@ -5,6 +5,7 @@ import 'dart:ui' as ui;
 
 import 'package:collection/collection.dart';
 import 'package:common/src/features/api/domain/api.dart';
+import 'package:common/src/features/payment/domain/payment.dart';
 import 'package:common/src/shared/navigation.dart';
 import 'package:common/src/shared/i18n/locales.dart';
 import 'package:common/src/core/core.dart';
@@ -31,6 +32,7 @@ part 'weekly_report.dart';
 mixin NotificationChannel {
   Future<void> doShow(String notificationId, String atWhen, String? body);
   Future<void> doDismissAll();
+  Future<void> doCancel(String notificationId);
 }
 
 class NotificationsValue extends Value<List<NotificationEvent>> {

--- a/common/lib/src/platform/common/channel.dart
+++ b/common/lib/src/platform/common/channel.dart
@@ -1,12 +1,7 @@
 part of 'common.dart';
 
 abstract class CommonChannel
-    with
-        RateChannel,
-        EnvChannel,
-        LinkChannel,
-        HttpChannel,
-        NotificationChannel, ConfigChannel {}
+    with RateChannel, EnvChannel, LinkChannel, HttpChannel, NotificationChannel, ConfigChannel {}
 
 class PlatformCommonChannel extends CommonChannel {
   late final _ops = CommonOps();
@@ -37,11 +32,8 @@ class PlatformCommonChannel extends CommonChannel {
   // LinkChannel
 
   @override
-  Future<void> doLinksChanged(Map<LinkId, String> links) async =>
-      await _ops.doLinksChanged(
-        links.entries
-            .map((e) => OpsLink(id: e.key.name, url: e.value))
-            .toList(),
+  Future<void> doLinksChanged(Map<LinkId, String> links) async => await _ops.doLinksChanged(
+        links.entries.map((e) => OpsLink(id: e.key.name, url: e.value)).toList(),
       );
 
   // HttpChannel
@@ -62,6 +54,9 @@ class PlatformCommonChannel extends CommonChannel {
 
   @override
   Future<void> doDismissAll() => _ops.doDismissAll();
+
+  @override
+  Future<void> doCancel(String notificationId) => _ops.doCancel(notificationId);
 
   @override
   Future<void> doShow(String notificationId, String atWhen, String? body) =>
@@ -103,8 +98,7 @@ class NoOpCommonChannel extends CommonChannel {
   // HttpChannel
 
   @override
-  Future<String> doGet(String url) =>
-      throw Exception("Mock http not implemented");
+  Future<String> doGet(String url) => throw Exception("Mock http not implemented");
 
   @override
   Future<String> doRequest(String url, String? payload, String type) =>
@@ -121,8 +115,10 @@ class NoOpCommonChannel extends CommonChannel {
   Future<void> doDismissAll() => Future.value();
 
   @override
-  Future<void> doShow(String notificationId, String atWhen, String? body) =>
-      Future.value();
+  Future<void> doCancel(String notificationId) => Future.value();
+
+  @override
+  Future<void> doShow(String notificationId, String atWhen, String? body) => Future.value();
 
   @override
   Future<void> doConfigChanged(bool skipBypassList) => Future.value();

--- a/common/lib/src/platform/common/channel.dart
+++ b/common/lib/src/platform/common/channel.dart
@@ -53,7 +53,7 @@ class PlatformCommonChannel extends CommonChannel {
   // NotificationChannel
 
   @override
-  Future<void> doDismissAll() => _ops.doDismissAll();
+  Future<void> doDismissDeliveredAll() => _ops.doDismissDeliveredAll();
 
   @override
   Future<void> doCancel(String notificationId) => _ops.doCancel(notificationId);
@@ -112,7 +112,7 @@ class NoOpCommonChannel extends CommonChannel {
   // NotificationChannel
 
   @override
-  Future<void> doDismissAll() => Future.value();
+  Future<void> doDismissDeliveredAll() => Future.value();
 
   @override
   Future<void> doCancel(String notificationId) => Future.value();

--- a/common/libgen/Common.dart
+++ b/common/libgen/Common.dart
@@ -30,7 +30,7 @@ abstract class CommonOps {
   void doShow(String notificationId, String atWhen, String? body);
 
   @async
-  void doDismissAll();
+  void doDismissDeliveredAll();
 
   @async
   void doCancel(String notificationId);

--- a/common/libgen/Common.dart
+++ b/common/libgen/Common.dart
@@ -32,6 +32,9 @@ abstract class CommonOps {
   @async
   void doDismissAll();
 
+  @async
+  void doCancel(String notificationId);
+
   // -- Config
   @async
   void doConfigChanged(bool skipBypassList);

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -94,7 +94,6 @@ flutter:
     - assets/translations/ui/
     - assets/translations/packs/
     - assets/translations/packtags/
-    - assets/videos/
     - assets/fallbacks/
 
   # An image asset can refer to one or more resolution-specific "variants", see

--- a/common/test/platform/notification/notification_test.dart
+++ b/common/test/platform/notification/notification_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:common/src/features/notification/domain/notification.dart';
+import 'package:common/src/features/payment/domain/payment.dart';
 import 'package:common/src/core/core.dart';
 import 'package:common/src/platform/account/account.dart';
 import 'package:common/src/platform/account/refresh/refresh.dart';
@@ -35,6 +36,7 @@ void main() {
       await withTrace((m) async {
         Core.register<AccountStore>(MockAccountStore());
         Core.register<StageStore>(MockStageStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
 
         Core.register(NotificationsValue());
 
@@ -55,6 +57,7 @@ void main() {
       await withTrace((m) async {
         Core.register<AccountStore>(MockAccountStore());
         Core.register<StageStore>(MockStageStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register(NotificationsValue());
         Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
 
@@ -85,6 +88,7 @@ void main() {
       await withTrace((m) async {
         Core.register<AccountStore>(MockAccountStore());
         Core.register<StageStore>(MockStageStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register(NotificationsValue());
         Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
 
@@ -114,6 +118,7 @@ void main() {
       await withTrace((m) async {
         Core.register<AccountStore>(MockAccountStore());
         Core.register<StageStore>(MockStageStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register(NotificationsValue());
         final accountRefresh = _FakeAccountRefreshStore();
         Core.register<AccountRefreshStore>(accountRefresh);
@@ -143,6 +148,7 @@ void main() {
         when(stage.route).thenReturn(StageRouteState.init());
         Core.register<StageStore>(stage);
         Core.register<AccountStore>(MockAccountStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register<DeviceStore>(_MockDeviceStore());
         Core.register(NotificationsValue());
         Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
@@ -166,6 +172,7 @@ void main() {
         when(stage.route).thenReturn(StageRouteState.init());
         Core.register<StageStore>(stage);
         Core.register<AccountStore>(MockAccountStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register(NotificationsValue());
         Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
 
@@ -183,13 +190,15 @@ void main() {
       });
     });
 
-    test("notification tap opens privacy pulse on actor start if app is already foreground", () async {
+    test("notification tap opens privacy pulse on actor start if app is already foreground",
+        () async {
       await withTrace((m) async {
         final stage = MockStageStore();
         var route = StageRouteState.init();
         when(stage.route).thenAnswer((_) => route);
         Core.register<StageStore>(stage);
         Core.register<AccountStore>(MockAccountStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register<DeviceStore>(_MockDeviceStore());
         Core.register(NotificationsValue());
         Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
@@ -224,6 +233,7 @@ void main() {
         when(stage.route).thenReturn(StageRouteState.init());
         Core.register<StageStore>(stage);
         Core.register<AccountStore>(MockAccountStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
         Core.register(NotificationsValue());
         Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
 
@@ -245,6 +255,159 @@ void main() {
         expect(opened, 0);
         expect(Navigation.lastPath, isNull);
         Navigation.onNavigated = (_) {};
+      });
+    });
+
+    test("non-restore payment schedules activity logging reminder when retention is disabled",
+        () async {
+      await withTrace((m) async {
+        Navigation.isTabletMode = false;
+        final stage = MockStageStore();
+        when(stage.route).thenReturn(StageRouteState.init());
+        final payment = _FakePaymentActor();
+        final device = _FakeDeviceStore()..retentionValue = "";
+
+        Core.register<StageStore>(stage);
+        Core.register<AccountStore>(MockAccountStore());
+        Core.register<DeviceStore>(device);
+        Core.register<PaymentActor>(payment);
+        Core.register(NotificationsValue());
+        Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
+
+        final ops = MockNotificationChannel();
+        Core.register<NotificationChannel>(ops);
+
+        final store = NotificationActor();
+        Core.register<NotificationActor>(store);
+
+        await store.onStart(m);
+        await payment.emitValue(paymentSuccessful, false, m);
+
+        final captured = verify(ops.doShow(
+          NotificationId.activityLoggingReminder.name,
+          captureAny,
+          "Enable activity logging to receive your weekly Privacy Pulse reports.",
+        )).captured;
+        final scheduledAt = DateTime.parse(captured.single as String).toLocal();
+        expect(
+          scheduledAt.difference(DateTime.now()).inDays,
+          inInclusiveRange(6, 7),
+        );
+      });
+    });
+
+    test("restore payment does not schedule activity logging reminder", () async {
+      await withTrace((m) async {
+        Navigation.isTabletMode = false;
+        final stage = MockStageStore();
+        when(stage.route).thenReturn(StageRouteState.init());
+        final payment = _FakePaymentActor();
+        final device = _FakeDeviceStore()..retentionValue = "";
+
+        Core.register<StageStore>(stage);
+        Core.register<AccountStore>(MockAccountStore());
+        Core.register<DeviceStore>(device);
+        Core.register<PaymentActor>(payment);
+        Core.register(NotificationsValue());
+        Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
+
+        final ops = MockNotificationChannel();
+        Core.register<NotificationChannel>(ops);
+
+        final store = NotificationActor();
+        Core.register<NotificationActor>(store);
+
+        await store.onStart(m);
+        await payment.emitValue(paymentSuccessful, true, m);
+
+        verifyNever(ops.doShow(NotificationId.activityLoggingReminder.name, any, any));
+      });
+    });
+
+    test("enabled retention does not schedule activity logging reminder", () async {
+      await withTrace((m) async {
+        Navigation.isTabletMode = false;
+        final stage = MockStageStore();
+        when(stage.route).thenReturn(StageRouteState.init());
+        final payment = _FakePaymentActor();
+        final device = _FakeDeviceStore()..retentionValue = "24h";
+
+        Core.register<StageStore>(stage);
+        Core.register<AccountStore>(MockAccountStore());
+        Core.register<DeviceStore>(device);
+        Core.register<PaymentActor>(payment);
+        Core.register(NotificationsValue());
+        Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
+
+        final ops = MockNotificationChannel();
+        Core.register<NotificationChannel>(ops);
+
+        final store = NotificationActor();
+        Core.register<NotificationActor>(store);
+
+        await store.onStart(m);
+        await payment.emitValue(paymentSuccessful, false, m);
+
+        verifyNever(ops.doShow(NotificationId.activityLoggingReminder.name, any, any));
+        verify(ops.doCancel(NotificationId.activityLoggingReminder.name)).called(1);
+      });
+    });
+
+    test("enabling retention cancels pending activity logging reminder", () async {
+      await withTrace((m) async {
+        Navigation.isTabletMode = false;
+        final stage = MockStageStore();
+        when(stage.route).thenReturn(StageRouteState.init());
+        final payment = _FakePaymentActor();
+        final device = _FakeDeviceStore()..retentionValue = "";
+
+        Core.register<StageStore>(stage);
+        Core.register<AccountStore>(MockAccountStore());
+        Core.register<DeviceStore>(device);
+        Core.register<PaymentActor>(payment);
+        Core.register(NotificationsValue());
+        Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
+
+        final ops = MockNotificationChannel();
+        Core.register<NotificationChannel>(ops);
+
+        final store = NotificationActor();
+        Core.register<NotificationActor>(store);
+
+        await store.onStart(m);
+        await payment.emitValue(paymentSuccessful, false, m);
+        device.retentionValue = "24h";
+        await device.emit(deviceChanged, "device-tag", m);
+
+        verify(ops.doCancel(NotificationId.activityLoggingReminder.name)).called(1);
+      });
+    });
+
+    test("activity logging reminder tap opens retention settings", () async {
+      await withTrace((m) async {
+        final stage = MockStageStore();
+        when(stage.route).thenReturn(StageRouteState.init().newFg());
+        Core.register<StageStore>(stage);
+        Core.register<AccountStore>(MockAccountStore());
+        Core.register<DeviceStore>(_MockDeviceStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
+        Core.register(NotificationsValue());
+        Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
+
+        final ops = MockNotificationChannel();
+        Core.register<NotificationChannel>(ops);
+
+        final store = NotificationActor();
+        Core.register<NotificationActor>(store);
+        Navigation.lastPath = null;
+        Navigation.isTabletMode = true;
+        Navigation.openInTablet = (path, arguments) {
+          Navigation.lastPath = path;
+        };
+
+        await store.notificationTapped(m, NotificationId.activityLoggingReminder.name);
+
+        expect(Navigation.lastPath, Paths.settingsRetention);
       });
     });
   });
@@ -304,3 +467,23 @@ class _FakeAccountRefreshStore extends Mock implements AccountRefreshStore {
 }
 
 class _MockDeviceStore extends Mock implements DeviceStore {}
+
+class _FakePaymentActor extends PaymentActor {
+  _FakePaymentActor() {
+    willAcceptOnValue(paymentSuccessful, [paymentClosed]);
+  }
+}
+
+class _FakeDeviceStore extends Mock with Logging, Emitter implements DeviceStore {
+  String? retentionValue;
+
+  _FakeDeviceStore() {
+    willAcceptOn([deviceChanged]);
+  }
+
+  @override
+  String? get retention => retentionValue;
+
+  @override
+  Future<void> fetch(Marker m, {bool force = false}) async {}
+}

--- a/common/test/platform/notification/notification_test.dart
+++ b/common/test/platform/notification/notification_test.dart
@@ -408,6 +408,38 @@ void main() {
         expect(Navigation.lastPath, Paths.settingsRetention);
       });
     });
+
+    test("activity logging reminder tap defers navigation until app is foreground", () async {
+      await withTrace((m) async {
+        final stage = MockStageStore();
+        when(stage.route).thenReturn(StageRouteState.init());
+        Core.register<StageStore>(stage);
+        Core.register<AccountStore>(MockAccountStore());
+        Core.register<DeviceStore>(_MockDeviceStore());
+        Core.register<PaymentActor>(_FakePaymentActor());
+        Core.register(NotificationsValue());
+        Core.register<WeeklyReportActor>(_FakeWeeklyReportActor(_weeklyEvent()));
+
+        final ops = MockNotificationChannel();
+        Core.register<NotificationChannel>(ops);
+
+        final store = NotificationActor();
+        Core.register<NotificationActor>(store);
+        Navigation.lastPath = null;
+        Navigation.isTabletMode = true;
+        Navigation.openInTablet = (path, arguments) {
+          Navigation.lastPath = path;
+        };
+
+        await store.notificationTapped(m, NotificationId.activityLoggingReminder.name);
+        expect(Navigation.lastPath, isNull);
+
+        when(stage.route).thenReturn(StageRouteState.init().newFg());
+        await store.onRouteChanged(StageRouteState.init().newFg(), m);
+
+        expect(Navigation.lastPath, Paths.settingsRetention);
+      });
+    });
   });
 
   group("resolveNotificationScheduleHint", () {

--- a/common/test/platform/notification/notification_test.dart
+++ b/common/test/platform/notification/notification_test.dart
@@ -289,10 +289,8 @@ void main() {
           "Enable activity logging to receive your weekly Privacy Pulse reports.",
         )).captured;
         final scheduledAt = DateTime.parse(captured.single as String).toLocal();
-        expect(
-          scheduledAt.difference(DateTime.now()).inDays,
-          inInclusiveRange(6, 7),
-        );
+        final delay = scheduledAt.difference(DateTime.now());
+        expect(delay.inSeconds, inInclusiveRange(30, 120));
       });
     });
 

--- a/ios/App/Binding/CommonBinding.swift
+++ b/ios/App/Binding/CommonBinding.swift
@@ -359,6 +359,12 @@ class CommonBinding: CommonOps {
         completion(.success(()))
     }
 
+    func doCancel(notificationId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        center.removePendingNotificationRequests(withIdentifiers: [notificationId])
+        center.removeDeliveredNotifications(withIdentifiers: [notificationId])
+        completion(.success(()))
+    }
+
     func getPermissions() -> AnyPublisher<Granted, Error> {
         return Future<Granted, Error> { promise in
             self.center.getNotificationSettings { settings in

--- a/ios/App/Binding/CommonBinding.swift
+++ b/ios/App/Binding/CommonBinding.swift
@@ -354,8 +354,8 @@ class CommonBinding: CommonOps {
         .store(in: &cancellables)
     }
     
-    func doDismissAll(completion: @escaping (Result<Void, Error>) -> Void) {
-        clearAllNotifications()
+    func doDismissDeliveredAll(completion: @escaping (Result<Void, Error>) -> Void) {
+        clearDeliveredNotifications()
         completion(.success(()))
     }
 
@@ -450,9 +450,8 @@ class CommonBinding: CommonOps {
         .eraseToAnyPublisher()
     }
 
-    func clearAllNotifications() {
+    func clearDeliveredNotifications() {
         center.removeAllDeliveredNotifications()
-        center.removeAllPendingNotificationRequests()
         UIApplication.shared.applicationIconBadgeNumber = 0
     }
 

--- a/ios/App/Binding/Notification.swift
+++ b/ios/App/Binding/Notification.swift
@@ -25,6 +25,7 @@ let NOTIF_ACC_EXP_FAMILY = "accountExpiredFamily"
 let NOTIF_SUPPORT_NEWMSG = "supportNewMessage"
 let NOTIF_WEEKLY_REFRESH = "weeklyRefresh"
 let NOTIF_WEEKLY_REPORT = "weeklyReport"
+let NOTIF_ACTIVITY_LOGGING_REMINDER = "activityLoggingReminder"
 let WEEKLY_REPORT_BACKGROUND_LEAD_MS = 60 * 60 * 1000
 
 struct WeeklyReportPayload: Codable {
@@ -114,6 +115,9 @@ func mapNotificationToUser(_ id: String, _ body: String?) -> UNMutableNotificati
     } else if id == NOTIF_WEEKLY_REFRESH {
         content.title = "Update your filters"
         content.body = "Tap to update your ad-block filters and stay safe from websites and apps that are most likely to cause you harm."
+    } else if id == NOTIF_ACTIVITY_LOGGING_REMINDER {
+        content.title = "Privacy Pulse"
+        content.body = body ?? "Enable activity logging to receive your weekly Privacy Pulse reports."
     } else {
         content.title = L10n.notificationGenericHeader
         content.subtitle = L10n.notificationGenericSubtitle

--- a/ios/App/Common.swift
+++ b/ios/App/Common.swift
@@ -160,7 +160,7 @@ protocol CommonOps {
   func doShowRateDialog(completion: @escaping (Result<Void, Error>) -> Void)
   func doLinksChanged(links: [OpsLink], completion: @escaping (Result<Void, Error>) -> Void)
   func doShow(notificationId: String, atWhen: String, body: String?, completion: @escaping (Result<Void, Error>) -> Void)
-  func doDismissAll(completion: @escaping (Result<Void, Error>) -> Void)
+  func doDismissDeliveredAll(completion: @escaping (Result<Void, Error>) -> Void)
   func doConfigChanged(skipBypassList: Bool, completion: @escaping (Result<Void, Error>) -> Void)
   func doShareText(text: String, completion: @escaping (Result<Void, Error>) -> Void)
 }
@@ -293,10 +293,10 @@ class CommonOpsSetup {
     } else {
       doShowChannel.setMessageHandler(nil)
     }
-    let doDismissAllChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.common.CommonOps.doDismissAll", binaryMessenger: binaryMessenger, codec: codec)
+    let doDismissDeliveredAllChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.common.CommonOps.doDismissDeliveredAll", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {
-      doDismissAllChannel.setMessageHandler { _, reply in
-        api.doDismissAll() { result in
+      doDismissDeliveredAllChannel.setMessageHandler { _, reply in
+        api.doDismissDeliveredAll() { result in
           switch result {
             case .success:
               reply(wrapResult(nil))
@@ -306,7 +306,7 @@ class CommonOpsSetup {
         }
       }
     } else {
-      doDismissAllChannel.setMessageHandler(nil)
+      doDismissDeliveredAllChannel.setMessageHandler(nil)
     }
     let doConfigChangedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.common.CommonOps.doConfigChanged", binaryMessenger: binaryMessenger, codec: codec)
     if let api = api {


### PR DESCRIPTION
notification delay is set for 1min for testing (should be 7 days)
texts are hardcoded, production copy to be defined

- when user completes purchase, schedule this notification
- cancel once logretention is enabled
- added plumbing to support notification cancelling
- will not trigger notification on account restore, only or purchase
- android/ios implementation
- tests
- tested manually on android the happy path

