### PR TITLE
pulse: dont format percent multipliers display in counters

### DIFF
--- a/common/lib/src/platform/stats/weekly_comparison.dart
+++ b/common/lib/src/platform/stats/weekly_comparison.dart
@@ -27,9 +27,6 @@ class WeeklyComparison {
   }
 
   String formatForCounterLabel() {
-    if (increased && multiplierLabel != null) {
-      return multiplierLabel!;
-    }
     final rounded = roundedPercent;
     if (rounded == 0) return '';
     final sign = rounded > 0 ? '+' : '';

--- a/common/test/platform/stats/counter_delta_test.dart
+++ b/common/test/platform/stats/counter_delta_test.dart
@@ -124,14 +124,14 @@ void main() {
       expect(delta.hasComparison, isFalse);
     });
 
-    test('uses multiplier-style labels for large weekly increases', () {
+    test('uses percentage labels for counter deltas even on large weekly increases', () {
       final delta = computeCounterDelta(
         previous: const StatsCounters(allowed: 10, blocked: 20, total: 30),
         current: const StatsCounters(allowed: 21, blocked: 30, total: 51),
         hasComparison: true,
       );
 
-      expect(delta.allowedLabel, equals('3x'));
+      expect(delta.allowedLabel, equals('+110%'));
       expect(delta.blockedLabel, equals('+50%'));
     });
   });
@@ -146,6 +146,12 @@ void main() {
       expect(decreased.formatForNotification(), equals('-50'));
       expect(slightDecrease.formatForNotification(), equals('-10'));
       expect(slightDecrease.formatForCounterLabel(), equals('-10%'));
+    });
+
+    test('formats counter labels as percentages for large increases', () {
+      final increased = compareWeeklyTotals(10, 25);
+
+      expect(increased.formatForCounterLabel(), equals('+150%'));
     });
   });
 


### PR DESCRIPTION
Fixes mistaken label processing for pulse screen counters, where it shows 6x instead of +600%