### PR TITLE
ios: add before_paywall essentials onboarding optional flow

### DIFF
--- a/common/lib/src/features/safari/domain/actor.dart
+++ b/common/lib/src/features/safari/domain/actor.dart
@@ -122,6 +122,7 @@ class SafariActor with Actor, Logging {
     return await log(m).trace("maybeShowMandatoryOnboard", (m) async {
       if (_app.status.isActive()) return;
       if (!_accountStore.isFreemium) return;
+      if (_mandatoryOnboardOrder() != EssentialsOnboardingOrder.afterPaywall) return;
 
       final ping = await _ping.fetch(m, force: true);
       final isActive = _isPingValidAndActive(m, ping);
@@ -201,5 +202,10 @@ class SafariActor with Actor, Logging {
     final isValid = _ping.isPingValidAndActive(ping);
     log(m).pair("ping timestamp valid", isValid);
     return isValid;
+  }
+
+  EssentialsOnboardingOrder _mandatoryOnboardOrder() {
+    final account = _accountStore.account?.jsonAccount;
+    return account?.getEssentialsOnboardingOrder() ?? EssentialsOnboardingOrder.afterPaywall;
   }
 }

--- a/common/lib/src/features/safari/domain/safari.dart
+++ b/common/lib/src/features/safari/domain/safari.dart
@@ -6,6 +6,7 @@ import 'package:common/src/features/safari/ui/safari_onboard_sheet.dart';
 import 'package:common/src/features/safari/ui/safari_onboard_yt_sheet.dart';
 import 'package:common/src/core/core.dart';
 import 'package:common/src/app_variants/family/module/device_v3/device.dart';
+import 'package:common/src/platform/account/api.dart';
 import 'package:common/src/platform/account/account.dart';
 import 'package:common/src/platform/app/app.dart';
 import 'package:common/src/platform/app/channel.pg.dart';

--- a/common/lib/src/platform/account/api.dart
+++ b/common/lib/src/platform/account/api.dart
@@ -62,7 +62,7 @@ class JsonAccount {
   EssentialsOnboardingOrder getEssentialsOnboardingOrder() {
     if (attributes == null) return EssentialsOnboardingOrder.afterPaywall;
     final value = attributes![_attrEssentialsOnboardingOrder];
-    return EssentialsOnboardingOrder.fromApiValue(value as String?);
+    return EssentialsOnboardingOrder.fromApiValue(value is String ? value : null);
   }
 
   DateTime getActiveUntil() {

--- a/common/lib/src/platform/account/api.dart
+++ b/common/lib/src/platform/account/api.dart
@@ -3,7 +3,27 @@ import 'dart:convert';
 import 'package:common/src/features/api/domain/api.dart';
 import 'package:common/src/core/core.dart';
 
+enum EssentialsOnboardingOrder {
+  afterPaywall("after_paywall"),
+  beforePaywall("before_paywall");
+
+  final String apiValue;
+
+  const EssentialsOnboardingOrder(this.apiValue);
+
+  static EssentialsOnboardingOrder fromApiValue(String? value) {
+    return EssentialsOnboardingOrder.values.firstWhere(
+      (order) => order.apiValue == value,
+      orElse: () => EssentialsOnboardingOrder.afterPaywall,
+    );
+  }
+}
+
 class JsonAccount {
+  static const String _attrFreemium = 'freemium';
+  static const String _attrFreemiumYoutubeUntil = 'freemium_youtube_until';
+  static const String _attrEssentialsOnboardingOrder = 'essentials_onboarding_order';
+
   late String id;
   String? activeUntil;
   bool? active;
@@ -25,16 +45,24 @@ class JsonAccount {
 
   isFreemium() {
     if (attributes == null) return false;
-    return attributes!['freemium'] == true;
+    return attributes![_attrFreemium] == true;
   }
 
   DateTime? getFreemiumYoutubeUntil() {
     if (attributes == null) return null;
-    final freemiumUntil = attributes!['freemium_youtube_until'];
+    final freemiumUntil = attributes![_attrFreemiumYoutubeUntil];
     if (freemiumUntil is String) {
       return DateTime.tryParse(freemiumUntil);
     }
     return null;
+  }
+
+  /// Defaults to the current post-paywall onboarding order when the API does
+  /// not provide a value so existing freemium behavior stays unchanged.
+  EssentialsOnboardingOrder getEssentialsOnboardingOrder() {
+    if (attributes == null) return EssentialsOnboardingOrder.afterPaywall;
+    final value = attributes![_attrEssentialsOnboardingOrder];
+    return EssentialsOnboardingOrder.fromApiValue(value as String?);
   }
 
   DateTime getActiveUntil() {

--- a/common/lib/src/platform/app/start/start.dart
+++ b/common/lib/src/platform/app/start/start.dart
@@ -10,6 +10,7 @@ import 'package:common/src/util/mobx.dart';
 import 'package:mobx/mobx.dart';
 
 import '../../account/account.dart';
+import '../../account/api.dart';
 import '../../device/device.dart';
 import '../../perm/perm.dart';
 import '../app.dart';
@@ -255,6 +256,10 @@ abstract class AppStartStoreBase with Store, Logging, Actor {
       if (_account.isFreemium) {
         final pingData = await _ping.fetch(m, force: true);
         if (!_ping.isPingValidAndActive(pingData)) {
+          if (_shouldShowEssentialsOnboardBeforePaywall()) {
+            await _modal.change(m, Modal.onboardSafari);
+            throw OnboardingException();
+          }
           throw AccountTypeException();
         }
         await _app.freemiumActivated(m, true);
@@ -268,5 +273,12 @@ abstract class AppStartStoreBase with Store, Logging, Actor {
       //   throw OnboardingException();
     }
     await _device.setCloudEnabled(m, true);
+  }
+
+  bool _shouldShowEssentialsOnboardBeforePaywall() {
+    if (!Core.act.isIos || !_account.isFreemium) return false;
+    final order = _account.account?.jsonAccount.getEssentialsOnboardingOrder() ??
+        EssentialsOnboardingOrder.afterPaywall;
+    return order == EssentialsOnboardingOrder.beforePaywall;
   }
 }

--- a/common/test/platform/account/json_test.dart
+++ b/common/test/platform/account/json_test.dart
@@ -72,6 +72,55 @@ void main() {
         expect(json["payment_source"], "internal");
       });
     });
+
+    test("defaultsEssentialsOnboardingOrderToAfterPaywall", () async {
+      await withTrace((m) async {
+        final subject = JsonAccount.fromJson(jsonDecode(fixtureJsonAccountLibre));
+
+        expect(
+          subject.getEssentialsOnboardingOrder(),
+          EssentialsOnboardingOrder.afterPaywall,
+        );
+      });
+    });
+
+    test("parsesExplicitEssentialsOnboardingOrder", () async {
+      await withTrace((m) async {
+        final subject = JsonAccount.fromJson({
+          "id": "mockedmocked",
+          "active": false,
+          "type": "libre",
+          "attributes": {
+            "freemium": true,
+            "essentials_onboarding_order": "before_paywall",
+          }
+        });
+
+        expect(
+          subject.getEssentialsOnboardingOrder(),
+          EssentialsOnboardingOrder.beforePaywall,
+        );
+      });
+    });
+
+    test("fallsBackToAfterPaywallForInvalidEssentialsOnboardingOrder", () async {
+      await withTrace((m) async {
+        final subject = JsonAccount.fromJson({
+          "id": "mockedmocked",
+          "active": false,
+          "type": "libre",
+          "attributes": {
+            "freemium": true,
+            "essentials_onboarding_order": "unexpected_value",
+          }
+        });
+
+        expect(
+          subject.getEssentialsOnboardingOrder(),
+          EssentialsOnboardingOrder.afterPaywall,
+        );
+      });
+    });
   });
 
   group("errors", () {

--- a/common/test/platform/account/json_test.dart
+++ b/common/test/platform/account/json_test.dart
@@ -121,6 +121,25 @@ void main() {
         );
       });
     });
+
+    test("fallsBackToAfterPaywallForNonStringEssentialsOnboardingOrder", () async {
+      await withTrace((m) async {
+        final subject = JsonAccount.fromJson({
+          "id": "mockedmocked",
+          "active": false,
+          "type": "libre",
+          "attributes": {
+            "freemium": true,
+            "essentials_onboarding_order": 1,
+          }
+        });
+
+        expect(
+          subject.getEssentialsOnboardingOrder(),
+          EssentialsOnboardingOrder.afterPaywall,
+        );
+      });
+    });
   });
 
   group("errors", () {

--- a/common/test/platform/app/start/start_test.dart
+++ b/common/test/platform/app/start/start_test.dart
@@ -3,6 +3,7 @@ import 'package:common/src/features/payment/domain/payment.dart';
 import 'package:common/src/features/safari/domain/safari.dart';
 import 'package:common/src/core/core.dart';
 import 'package:common/src/platform/account/account.dart';
+import 'package:common/src/platform/account/api.dart';
 import 'package:common/src/platform/account/refresh/refresh.dart';
 import 'package:common/src/platform/app/app.dart';
 import 'package:common/src/platform/app/channel.pg.dart';
@@ -447,6 +448,8 @@ void main() {
       "onUnpauseAppFreemiumWithInactiveSafariExtensionShouldShowPaywall",
       () async {
         await withTrace((m) async {
+          final modal = CurrentModalValue();
+          Core.register(modal);
           Core.register<Scheduler>(MockScheduler());
 
           final stage = MockStageStore();
@@ -488,6 +491,7 @@ void main() {
 
           // Should show paywall
           verify(payment.openPaymentScreen(any)).called(1);
+          expect(modal.present, null);
         });
       },
     );
@@ -530,6 +534,65 @@ void main() {
 
           // Should show paywall
           verify(payment.openPaymentScreen(any)).called(1);
+        });
+      },
+    );
+
+    test(
+      "onUnpauseAppFreemiumWithBeforePaywallOrderShowsEssentialsOnboardingFirst",
+      () async {
+        await withTrace((m) async {
+          final modal = CurrentModalValue();
+          Core.register(modal);
+          Core.register<Scheduler>(MockScheduler());
+
+          final stage = MockStageStore();
+          Core.register<StageStore>(stage);
+
+          final account = MockAccountStore();
+          when(account.type).thenAnswer((_) => AccountType.libre);
+          when(account.isFreemium).thenAnswer((_) => true);
+          when(account.account).thenReturn(
+            AccountState(
+              "mockedmocked",
+              JsonAccount(
+                id: "mockedmocked",
+                activeUntil: null,
+                active: false,
+                type: AccountType.libre.name,
+                attributes: {
+                  "freemium": true,
+                  "essentials_onboarding_order": "before_paywall",
+                },
+              ),
+            ),
+          );
+          Core.register<AccountStore>(account);
+
+          final app = MockAppStore();
+          final conditions = AppStatusStrategy(accountIsFreemium: true);
+          when(app.conditions).thenReturn(conditions);
+          Core.register<AppStore>(app);
+
+          Core.register<PlusActor>(MockPlusActor());
+
+          final perm = MockPlatformPermActor();
+          Core.register<PlatformPermActor>(perm);
+
+          final payment = MockPaymentActor();
+          Core.register<PaymentActor>(payment);
+
+          final ping = MockBlockawebPingValue();
+          when(ping.fetch(any, force: true)).thenAnswer((_) async => null);
+          when(ping.isPingValidAndActive(null)).thenReturn(false);
+          Core.register<BlockawebPingValue>(ping);
+
+          final subject = AppStartStore();
+
+          await expectLater(subject.unpauseApp(m), throwsException);
+
+          expect(modal.present, Modal.onboardSafari);
+          verifyNever(payment.openPaymentScreen(any));
         });
       },
     );


### PR DESCRIPTION
  Introduce essentials_onboarding_order account attribute support for iOS freemium
  onboarding and keep the current post-paywall flow as the default. The app now
  parses a typed onboarding-order value from account attributes, routes flagged
  users to the Safari Essentials onboarding before the paywall, and suppresses the
  existing post-paywall onboarding for that override so the flow stays exclusive.

  Also add focused tests covering attribute parsing, default fallback behavior, and
  the guardrail that Essentials is not shown before the paywall unless the API
  explicitly enables it.