### PR TITLE
ios: revive mocked scheme for simulator-based ux iteration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,26 @@ make -C ios run-family [DEVICE_NAME="device name"] [CONFIG="Release|Debug"]
 make install-family-debug    # or make install-six-debug
 ```
 
+### Simulator Testing (iOS)
+
+```bash
+# iOS Mocked scheme on an auto-cloned per-worktree simulator (NetxServiceMock
+# substitutes the real NetworkExtension — no DNS/VPN entitlement needed).
+# Each worktree gets its own sim, so parallel checkouts don't contend.
+make -C ios run-six-mocked          # or run-family-mocked
+make -C ios appium-install-six-mocked  # install only, prints UDID for Appium
+
+# Pre-warm onboarding/login state once, reuse across clones:
+make -C ios run-six-mocked SIM_TEMPLATE="warm template"
+
+# Status / cleanup
+make -C ios sim-status sim-clean sim-gc
+```
+
+Use for UX/notifications/state work; use `run-six`/`run-family` on a real
+device when you need actual DNS/VPN behaviour. See `ios/SIMULATOR.md` for
+overrides, warm-template setup, and caveats.
+
 ## Testing & Linting
 
 ```bash

--- a/ios/BUILDING.md
+++ b/ios/BUILDING.md
@@ -5,3 +5,6 @@
 - check your account, signing certificates for the project
 - `make devsc`
 - tap the run button
+
+For simulator-based runs (Mocked scheme — no NetworkExtension entitlement
+needed) and parallel worktree workflows, see [SIMULATOR.md](SIMULATOR.md).

--- a/ios/IOS.xcodeproj/project.pbxproj
+++ b/ios/IOS.xcodeproj/project.pbxproj
@@ -3591,7 +3591,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MARKETING_VERSION = dev;
-				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG -D FAMILY";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG -D FAMILY -D MOCKED";
 				"OTHER_SWIFT_FLAGS[sdk=iphonesimulator*]" = "$(inherited) -D PREVIEW";
 				PRODUCT_BUNDLE_IDENTIFIER = net.blocka.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -4067,7 +4067,7 @@
 					"$(PROJECT_DIR)",
 				);
 				MARKETING_VERSION = dev;
-				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D DEBUG -D MOCKED";
 				"OTHER_SWIFT_FLAGS[sdk=iphonesimulator*]" = "$(inherited) -D PREVIEW";
 				PRODUCT_BUNDLE_IDENTIFIER = net.blocka.app;
 				PRODUCT_NAME = "Blokada $(TARGET_NAME)";

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -24,6 +24,7 @@ CHECK_CONFIG ?= Debug
 # the root directory instead.
 
 include make/run-helpers.mk
+include make/sim-helpers.mk
 
 
 # Build everything from scratch (release)

--- a/ios/NotFamily/PlusBinding.swift
+++ b/ios/NotFamily/PlusBinding.swift
@@ -185,12 +185,21 @@ class PlusBinding: PlusOps {
     }
 
     func doGenerateKeypair(completion: @escaping (Result<OpsKeypair, any Error>) -> Void) {
+        #if MOCKED
+        // Mocked scheme has no real VPN deps — return a base64-shaped placeholder
+        // so the Dart side gets a syntactically-valid keypair object.
+        let currentKeypair = OpsKeypair(
+            publicKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            privateKey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+        )
+        #else
         let privKey = PrivateKey()
         let pubKey = privKey.publicKey
         let currentKeypair = OpsKeypair(
             publicKey: pubKey.base64Key,
             privateKey: privKey.base64Key
         )
+        #endif
         completion(.success(currentKeypair))
     }
 

--- a/ios/SIMULATOR.md
+++ b/ios/SIMULATOR.md
@@ -1,0 +1,75 @@
+# Running on iOS Simulator
+
+Mocked-scheme Makefile targets build and launch the app on a per-checkout
+iOS Simulator via `NetxServiceMock` (a fake NetworkExtension). The fast
+path for UX, notifications, settings, account state — anything that
+doesn't need real DNS/VPN packets.
+
+## Quick start
+
+From `ios/`:
+
+```bash
+make pods                # once per checkout
+make run-six-mocked      # or run-family-mocked
+```
+
+First invocation auto-clones a sim named `iPhone 16 - <parent-dir>`.
+Worktrees each get their own, so two checkouts can run in parallel.
+
+Overrides: `SIM_BASE="iPhone 15"`, `NAME=custom`, `SIM_TEMPLATE="warm sim"`.
+
+## When to use what
+
+| Goal | Path |
+|---|---|
+| UX, notifications, account state, settings | `make run-*-mocked` (sim) |
+| Real DNS/VPN, NetworkExtension verification | `make run-six` (device) |
+| App Store binary | `make ipa-six` / `ipa-family` (unchanged) |
+
+## Appium targeting
+
+```bash
+SIM_UDID=$(make -C ios sim-status | sed -n 's/^SIM_UDID: *//p')
+appium --udid "$SIM_UDID" ...
+```
+
+Or `make appium-install-*-mocked` (installs without launching, prints UDID).
+The existing `make appium-test` is device-only today — sim-aware
+extension is a follow-up.
+
+## Warm-state template
+
+Default clones from a fresh `iPhone 16`, so first launch in each new
+checkout has to redo onboarding. To skip that, pre-warm one sim and
+point clones at it via `SIM_TEMPLATE`:
+
+```bash
+# one-time: create, boot, install, log in, then shut down
+RUNTIME=$(xcrun simctl list runtimes available | awk '/iOS/{r=$NF} END{print r}')
+xcrun simctl create "warm template" "iPhone 16" "$RUNTIME"
+
+# per checkout:
+make run-six-mocked SIM_TEMPLATE="warm template"
+```
+
+The clone inherits keychain, NSUserDefaults, App Group container, and
+installed apps from the template.
+
+## Helpers
+
+| Target | What |
+|---|---|
+| `make sim-status` | Show this checkout's sim name + UDID |
+| `make sim-clean` | Delete this checkout's sim |
+| `make sim-gc` | Delete orphaned sims (after Xcode runtime upgrades) |
+
+## Caveats
+
+- **Mocked is Debug-only.** Release builds of Mocked/FamilyMocked still hit the unguarded WireGuard path.
+- **Shared app group `group.net.blocka.app`.** All sim runs share one container; Mocked usually regenerates state per launch so this rarely bites.
+- **Device coexistence is not supported.** `make run-six` always installs `net.blocka.app` and overwrites prior installs.
+- **`common/` rebuilds per worktree.** Run `make -C ../common build-ios` once per worktree.
+- **Sims accumulate disk + clutter Xcode's device list.** `make sim-clean` per worktree, `make sim-gc` after Xcode upgrades.
+- **`simctl clone` can be flaky after Xcode runtime upgrades.** Try `make sim-gc` and re-run.
+- **Xcode SCM features (Blame, Log) don't work from a git worktree.** Use CLI git/jj, or open the main checkout for SCM.

--- a/ios/make/sim-helpers.mk
+++ b/ios/make/sim-helpers.mk
@@ -1,0 +1,115 @@
+# Mocked-scheme simulator runner (worktree-aware).
+#
+# Runs the app on an iOS Simulator using the Mocked / FamilyMocked schemes
+# (NetxServiceMock substitutes the real NetworkExtension). Works from any
+# checkout with no setup. The simulator name is derived from the parent
+# directory of `ios/`, so each parallel worktree automatically gets its
+# own simulator and multiple worktrees can run in parallel without
+# contention. See ios/SIMULATOR.md for usage.
+#
+# Variables (override on the make command line):
+#   NAME         per-checkout label; defaults to basename of CURDIR/..
+#   SIM_BASE     iPhone model used in the sim name (default: iPhone 16)
+#   SIM_TEMPLATE source sim to clone from (default: $(SIM_BASE) — fresh)
+#                Set to a pre-warmed sim name to seed each new clone
+#                with that sim's state (onboarding, logged in, etc.).
+
+NAME         ?= $(notdir $(abspath $(CURDIR)/..))
+SIM_BASE     ?= iPhone 16
+SIM_TEMPLATE ?= $(SIM_BASE)
+SIM_NAME     := $(SIM_BASE) - $(NAME)
+
+# Literal `(` for use in shell strings — keeps Make's $(...) parser happy.
+LPAREN := (
+
+sim-udid = $(shell xcrun simctl list devices 2>/dev/null | awk -v needle="    $(SIM_NAME) $(LPAREN)" 'index($$0, needle) == 1 {print; exit}' | sed -E 's/.*\(([-0-9A-Fa-f]+)\).*/\1/')
+
+.PHONY: sim-status sim-clean sim-gc \
+	run-six-mocked run-family-mocked \
+	appium-install-six-mocked appium-install-family-mocked \
+	print-build-dir-scheme print-product-name-scheme \
+	_ensure-sim _build-mocked
+
+# Internal: echo this checkout's sim UDID; clone the sim if missing.
+_ensure-sim:
+	@UDID="$(sim-udid)"; \
+	if [ -z "$$UDID" ]; then \
+		SRC_UDID=$$(xcrun simctl list devices available | awk -v needle="    $(SIM_TEMPLATE) $(LPAREN)" 'index($$0, needle) == 1 {print; exit}' | sed -E 's/.*\(([-0-9A-Fa-f]+)\).*/\1/'); \
+		if [ -z "$$SRC_UDID" ]; then \
+			echo "Error: no available sim named '$(SIM_TEMPLATE)' to clone from. Try SIM_BASE=\"iPhone 15\" or SIM_TEMPLATE=<existing-sim>. Available:" >&2; \
+			xcrun simctl list devices available | grep -E '^\s+iPhone' | head >&2; \
+			exit 1; \
+		fi; \
+		CLONE_ERR=$$(mktemp); \
+		UDID=$$(xcrun simctl clone "$$SRC_UDID" "$(SIM_NAME)" 2>"$$CLONE_ERR") || { \
+			echo "Error: simctl clone failed (known to be flaky after Xcode upgrades — try \`make sim-gc\` and retry). Detail: $$(cat "$$CLONE_ERR")" >&2; \
+			rm -f "$$CLONE_ERR"; \
+			exit 1; \
+		}; \
+		rm -f "$$CLONE_ERR"; \
+		echo "cloned '$(SIM_TEMPLATE)' -> '$(SIM_NAME)' ($$UDID)" >&2; \
+	fi; \
+	echo "$$UDID"
+
+sim-status:
+	@UDID="$(sim-udid)"; \
+	echo "SIM_NAME: $(SIM_NAME)"; \
+	if [ -n "$$UDID" ]; then echo "SIM_UDID: $$UDID"; else echo "SIM_UDID: (not cloned — will auto-clone on first run-*-mocked)"; fi
+
+sim-clean:
+	@UDID="$(sim-udid)"; \
+	if [ -n "$$UDID" ]; then \
+		echo "deleting '$(SIM_NAME)' ($$UDID)"; \
+		xcrun simctl delete "$$UDID"; \
+	else \
+		echo "no simulator named '$(SIM_NAME)' to clean"; \
+	fi
+
+sim-gc:
+	@echo "removing unavailable simulators (orphaned by Xcode runtime upgrades)..."
+	xcrun simctl delete unavailable
+	@echo "current iPhone/iPad sim count: $$(xcrun simctl list devices available 2>/dev/null | grep -cE '^\s+(iPhone|iPad)')"
+
+# Internal: build-dir for any scheme, used by run-mocked-app macro.
+print-build-dir-scheme:
+	@$(call xcode-build-dir,$(SCHEME),Debug,$(DESTINATION))
+
+# Internal: resolves the produced .app filename (FULL_PRODUCT_NAME) for any
+# scheme. Needed because PRODUCT_NAME varies — Mocked builds as "Blokada
+# Mocked.app", FamilyMocked as "FamilyMocked.app", etc.
+print-product-name-scheme:
+	@$(XCODEBUILD) -workspace $(XCODE_WORKSPACE) -scheme $(SCHEME) -configuration Debug $(if $(strip $(DESTINATION)),-destination '$(strip $(DESTINATION))') -showBuildSettings 2>/dev/null | awk -F'= ' '/FULL_PRODUCT_NAME/{print $$2; exit}'
+
+# Internal: build any scheme via run-helpers' xcode-build macro. Lives on its
+# own recipe line so the leading `@` in xcode-build is parsed as Make's silent
+# prefix; inlining it inside a shell pipeline would leak the literal `@` and
+# break bash.
+_build-mocked:
+	$(call xcode-build,build,$(SCHEME),Debug,$(DESTINATION),)
+
+# $(call run-mocked-app,scheme,mode)
+#   scheme: Mocked or FamilyMocked (.app filename matches scheme name)
+#   mode:   "launch" to foreground after install, "install" to just install
+# Both Mocked and FamilyMocked use bundle ID net.blocka.app per existing
+# project convention (see pbxproj entries for FamilyMocked).
+define run-mocked-app
+	@set -e; \
+	UDID=$$($(MAKE) --no-print-directory _ensure-sim); \
+	DEST="platform=iOS Simulator,id=$$UDID"; \
+	$(MAKE) --no-print-directory _build-mocked SCHEME=$(1) DESTINATION="$$DEST"; \
+	xcrun simctl boot "$$UDID" 2>/dev/null || true; \
+	APP_DIR=$$($(MAKE) --no-print-directory print-build-dir-scheme SCHEME=$(1) DESTINATION="$$DEST"); \
+	APP_NAME=$$($(MAKE) --no-print-directory print-product-name-scheme SCHEME=$(1) DESTINATION="$$DEST"); \
+	xcrun simctl install "$$UDID" "$$APP_DIR/$$APP_NAME"; \
+	if [ "$(2)" = "launch" ]; then \
+		open -a Simulator --args -CurrentDeviceUDID "$$UDID"; \
+		xcrun simctl launch "$$UDID" net.blocka.app; \
+	else \
+		echo "installed $$APP_NAME on '$(SIM_NAME)' ($$UDID) — Appium target UDID: $$UDID"; \
+	fi
+endef
+
+run-six-mocked:               ; @$(call run-mocked-app,Mocked,launch)
+run-family-mocked:            ; @$(call run-mocked-app,FamilyMocked,launch)
+appium-install-six-mocked:    ; @$(call run-mocked-app,Mocked,install)
+appium-install-family-mocked: ; @$(call run-mocked-app,FamilyMocked,install)


### PR DESCRIPTION
## Summary

Revives the iOS `Mocked` / `FamilyMocked` Xcode schemes as the fast path for UX, notifications, and state-flow iteration that doesn't need real VPN/DNS, and wires them up to be CLI-invokable on a per-worktree iOS Simulator.

- new `ios/make/sim-helpers.mk` (included from `ios/Makefile`) exposing `run-six-mocked`, `run-family-mocked`, `appium-install-*-mocked`, plus `sim-status`/`sim-clean`/`sim-gc` helpers. Auto-clones an "iPhone 16 - <worktree-name>" simulator on first use; multiple parallel jj worktrees each get their own foregrounded sim.
- unbreaks the `Mocked` / `FamilyMocked` schemes (broken since a 2025-01 sixcommon refactor introduced an unguarded `PrivateKey()` call in `PlusBinding.swift`): adds `-D MOCKED` to the Mocked / FamilyMocked Debug `OTHER_SWIFT_FLAGS`, guards the keypair-generation call with `#if MOCKED` and returns a base64-shaped placeholder so Dart still gets a usable keypair object.
- new `ios/SIMULATOR.md` documenting the workflow + caveats (shared app group, disk usage, `sim-gc`, Xcode SCM behaviour in worktrees, the warm-template `SIM_TEMPLATE` pattern); one-line cross-link added to `ios/BUILDING.md`.

Closes part of #303. Follow-up bullets in #303: add Mocked/FamilyMocked to the CI compile gate so this class of regression can't go latent again, and extend the Appium harness to optionally target a simulator (today it filters simulators out at `automation/shared/lib/devices.mjs`).

## Test plan

- [x] `make -C ios check CHECK_SCHEME=Mocked` — green (was red before this PR)
- [x] `make -C ios check CHECK_SCHEME=Dev` — verified unaffected via diff inspection (pbxproj edit only touches Mocked + FamilyMocked Debug configs; the daily-driver schemes are byte-identical to before)
- [x] `make -C ios run-six-mocked` end-to-end: auto-clones the sim, builds, installs, launches; `Blokada Mocked` reaches the home screen, `xcrun simctl listapps` confirms `net.blocka.app` installed, `launchctl list` shows `UIKitApplication:net.blocka.app[...]` running
- [x] Appium-against-sim manually verified: XCUITest session opens against the cloned sim's UDID, `mobile: queryAppState` returns `4` (foregrounded), `getPageSource()` returns the live `XCUIElementTypeApplication` hierarchy
- [ ] First-time fresh checkout: `cd ios && make pods && make run-six-mocked` works from a clean clone without manual setup
- [ ] Parallel worktrees: `make run-six-mocked` in two worktrees simultaneously produces two independent sim windows
- [ ] `make ipa-six` and `make ipa-family` still produce identical signed `.ipa`s via `fastlane match` (sanity check that the pbxproj edit didn't disturb Release/AppStore configs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)