### PR TITLE
feat(payment): Android install-referrer → Adapty acquisition-source attribution

### DIFF
--- a/android/app/proguard-family.pro
+++ b/android/app/proguard-family.pro
@@ -7,3 +7,6 @@
 -keep class com.adapty.** { *; }
 -keep class com.adapty_flutter.** { *; }
 -keep class com.adapty.flutter.** { *; }
+
+# Google Play Install Referrer (used for Adapty acquisition-source attribution).
+-keep class com.android.installreferrer.** { *; }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -19,3 +19,6 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Google Play Install Referrer (used for Adapty acquisition-source attribution).
+-keep class com.android.installreferrer.** { *; }

--- a/android/app/src/six/kotlin/binding/PaymentBinding.kt
+++ b/android/app/src/six/kotlin/binding/PaymentBinding.kt
@@ -155,6 +155,27 @@ object PaymentBinding : PaymentOps, AdaptyUiEventListener {
         }
     }
 
+    override fun doUpdateAttribution(
+        attribution: Map<String, Any?>,
+        source: String,
+        callback: (Result<Unit>) -> Unit
+    ) {
+        try {
+            Adapty.updateAttribution(attribution, source) { error ->
+                if (error == null) {
+                    log("Sent install attribution to Adapty (native sdk)")
+                    callback(Result.success(Unit))
+                } else {
+                    logError("Failed updateAttribution", error)
+                    callback(Result.failure(error))
+                }
+            }
+        } catch (e: Throwable) {
+            logError("Failed updateAttribution (threw)", e)
+            callback(Result.failure(e))
+        }
+    }
+
     override fun doLogOnboardingStep(
         name: String,
         stepName: String,

--- a/common/lib/src/features/payment/domain/actor.dart
+++ b/common/lib/src/features/payment/domain/actor.dart
@@ -29,6 +29,7 @@ class PaymentActor with Actor, Logging, ValueEmitter<bool> {
   late final _stage = Core.get<StageStore>();
   late final _channel = Core.get<PaymentChannel>();
   late final _key = Core.get<AdaptyApiKey>();
+  late final _installReferrer = Core.get<InstallReferrerService>();
 
   bool _adaptyInitialized = false;
   Completer? _preloadCompleter = Completer();
@@ -77,6 +78,11 @@ class PaymentActor with Actor, Logging, ValueEmitter<bool> {
       await _syncCustomAttributes(m, account);
       await reportOnboarding(_pendingOnboard);
     }
+
+    // One-time Google Play install referrer -> Adapty attribution (Android
+    // only; the service self-gates on non-Android to protect iOS ASA). Runs
+    // after Adapty activate, non-blocking, idempotent via a persisted guard.
+    unawaited(_installReferrer.sendAttributionOnce(m));
 
     /// After init:
     /// - pass account id to Adapty if it changes, and has been active before

--- a/common/lib/src/features/payment/domain/adapty.dart
+++ b/common/lib/src/features/payment/domain/adapty.dart
@@ -235,4 +235,17 @@ class AdaptyPaymentChannel with Logging, PaymentChannel implements AdaptyUIPaywa
       }
     });
   }
+
+  @override
+  Future<void> updateAttribution(Marker m, Map<String, dynamic> attribution,
+      {String source = "custom"}) async {
+    return await log(m).trace("updateAttribution", (m) async {
+      try {
+        await _adapty.updateAttribution(attribution, source: source);
+        log(m).i("Sent install attribution to Adapty (flutter sdk)");
+      } on AdaptyError catch (adaptyError) {
+        throw Exception("Adapty error: ${adaptyError.message}");
+      }
+    });
+  }
 }

--- a/common/lib/src/features/payment/domain/channel.dart
+++ b/common/lib/src/features/payment/domain/channel.dart
@@ -8,6 +8,8 @@ mixin PaymentChannel {
   Future<void> showPaymentScreen(Marker m, Placement placement, {bool forceReload = false});
   Future<void> closePaymentScreen(bool isError);
   Future<void> setCustomAttributes(Marker m, Map<String, dynamic> attributes);
+  Future<void> updateAttribution(Marker m, Map<String, dynamic> attribution,
+      {String source = "custom"});
 }
 
 const cmdPaymentHandleSuccess = "paymentHandleSuccess";

--- a/common/lib/src/features/payment/domain/install_referrer.dart
+++ b/common/lib/src/features/payment/domain/install_referrer.dart
@@ -1,0 +1,222 @@
+part of 'payment.dart';
+
+/// Parsed Google Play Install Referrer.
+///
+/// The referrer is a URL-encoded query fragment, e.g. for organic Play installs
+/// `utm_source=google-play&utm_medium=organic`, and for Google Ads
+/// `gclid=...&utm_source=google&utm_medium=cpc&utm_campaign=...`.
+class InstallReferrerData {
+  final String? utmSource;
+  final String? utmMedium;
+  final String? utmCampaign;
+  final String? utmContent;
+  final String? utmTerm;
+  final String? gclid;
+  final String? rawReferrer;
+  final bool isOrganic;
+
+  InstallReferrerData({
+    this.utmSource,
+    this.utmMedium,
+    this.utmCampaign,
+    this.utmContent,
+    this.utmTerm,
+    this.gclid,
+    this.rawReferrer,
+    required this.isOrganic,
+  });
+
+  factory InstallReferrerData.organic() =>
+      InstallReferrerData(isOrganic: true);
+
+  /// Never throws. A null/empty referrer (sideload, debug, non-Play) yields
+  /// an organic record. A malformed referrer keeps [rawReferrer] but parses
+  /// best-effort.
+  static InstallReferrerData parse(String? referrerUrl) {
+    if (referrerUrl == null || referrerUrl.trim().isEmpty) {
+      return InstallReferrerData.organic();
+    }
+
+    Map<String, String> q = {};
+    try {
+      q = Uri.splitQueryString(referrerUrl);
+    } catch (_) {
+      q = {};
+    }
+
+    String? g(String k) {
+      final v = q[k];
+      return (v == null || v.isEmpty) ? null : v;
+    }
+
+    final source = g('utm_source');
+    final medium = g('utm_medium');
+    final gclid = g('gclid');
+
+    // Google Ads installs carry a gclid (and usually utm_medium=cpc). Play
+    // organic installs report utm_source=google-play&utm_medium=organic.
+    final mediumLc = medium?.toLowerCase();
+    final isOrganic = gclid == null &&
+        (source == null || source == 'google-play' || source == '(not set)') &&
+        mediumLc != 'cpc' &&
+        mediumLc != 'paid';
+
+    return InstallReferrerData(
+      utmSource: source,
+      utmMedium: medium,
+      utmCampaign: g('utm_campaign'),
+      utmContent: g('utm_content'),
+      utmTerm: g('utm_term'),
+      gclid: gclid,
+      rawReferrer: referrerUrl,
+      isOrganic: isOrganic,
+    );
+  }
+
+  static String _truncate(String v, int max) =>
+      v.length > max ? v.substring(0, max) : v;
+
+  /// Adapty `updateAttribution` payload (recommended keys, each <=50 chars).
+  /// `status` is always present; other keys are omitted when empty.
+  Map<String, dynamic> toAttributionMap() {
+    final map = <String, dynamic>{};
+    map['status'] = isOrganic ? 'organic' : 'non_organic';
+
+    final channel = utmSource ?? (isOrganic ? 'google-play' : null);
+    if (channel != null && channel.isNotEmpty) {
+      map['channel'] = _truncate(channel, 50);
+    }
+    if (utmCampaign != null && utmCampaign!.isNotEmpty) {
+      map['campaign'] = _truncate(utmCampaign!, 50);
+    }
+    if (utmTerm != null && utmTerm!.isNotEmpty) {
+      map['ad_group'] = _truncate(utmTerm!, 50);
+    }
+    final adSet = utmMedium ?? (isOrganic ? 'organic' : null);
+    if (adSet != null && adSet.isNotEmpty) {
+      map['ad_set'] = _truncate(adSet, 50);
+    }
+    if (utmContent != null && utmContent!.isNotEmpty) {
+      map['creative'] = _truncate(utmContent!, 50);
+    }
+    return map;
+  }
+
+  static List<String> _chunk(String s, int size, int maxChunks) {
+    final out = <String>[];
+    for (var i = 0; i < s.length && out.length < maxChunks; i += size) {
+      out.add(s.substring(i, i + size > s.length ? s.length : i + size));
+    }
+    return out;
+  }
+
+  /// gclid stashed as Adapty custom attributes for downstream BI join.
+  /// Bypasses [AdaptyAttributeConverter] (its 30-char value cap would destroy
+  /// the gclid); chunked to Adapty's real ~50-char per-value limit. A gclid is
+  /// typically <100 chars, so at most 2 chunks; capped at 4 defensively.
+  List<Map<String, dynamic>> buildCustomAttributes() {
+    final attrs = <Map<String, dynamic>>[];
+    attrs.add({
+      'key': 'acq_status',
+      'value': isOrganic ? 'organic' : 'non_organic',
+    });
+
+    final gc = gclid;
+    if (gc != null && gc.isNotEmpty) {
+      final chunks = _chunk(gc, 50, 4);
+      for (var i = 0; i < chunks.length; i++) {
+        attrs.add({
+          'key': i == 0 ? 'acq_gclid' : 'acq_gclid_$i',
+          'value': chunks[i],
+        });
+      }
+    }
+    return attrs;
+  }
+}
+
+/// Test seam over the Play Install Referrer system API.
+mixin InstallReferrerChannel {
+  Future<String?> fetchReferrerUrl();
+}
+
+class PlatformInstallReferrerChannel with Logging, InstallReferrerChannel {
+  @override
+  Future<String?> fetchReferrerUrl() async {
+    // play_install_referrer throws on iOS / when Play Services are absent.
+    if (!Core.act.isAndroid) return null;
+    try {
+      final details = await PlayInstallReferrer.installReferrer;
+      return details.installReferrer;
+    } catch (e) {
+      // FEATURE_NOT_SUPPORTED / SERVICE_UNAVAILABLE / DEVELOPER_ERROR
+      // (sideload, debug, non-Play install) -> treat as organic/unknown.
+      log(Markers.root).i("Install referrer unavailable: $e");
+      return null;
+    }
+  }
+}
+
+/// Once-per-install idempotency guard. Stored in non-secure `local`
+/// SharedPreferences. Note: the app sets no allowBackup=false, so Android Auto
+/// Backup may restore this on reinstall (no re-send) — acceptable, since
+/// Adapty is one-source-per-profile and would reject a re-send anyway.
+class InstallReferrerSentValue extends BoolPersistedValue {
+  InstallReferrerSentValue() : super("payment:install_referrer_sent");
+}
+
+/// Captures the Google Play Install Referrer once and forwards it to Adapty
+/// as acquisition-source attribution + gclid custom attributes. Routed via the
+/// active [PaymentChannel] so v6 Android goes through the native Adapty SDK
+/// (Pigeon) and family through the Adapty Flutter SDK.
+class InstallReferrerService with Logging {
+  late final _channel = Core.get<InstallReferrerChannel>();
+  late final _payment = Core.get<PaymentChannel>();
+  late final _sentGuard = Core.get<InstallReferrerSentValue>();
+
+  Future<void> sendAttributionOnce(Marker m) async {
+    // CRITICAL: iOS keeps automatic Apple Search Ads attribution. The trigger
+    // in PaymentActor.onStart is cross-platform; on iOS PaymentChannel is the
+    // Adapty Flutter SDK, and updateAttribution(source:"custom") there would
+    // permanently clobber the ASA source (Adapty: one source per profile, no
+    // override). Gate FIRST, before the guard and before any Adapty call.
+    if (!Core.act.isAndroid) return;
+
+    return await log(m).trace("installReferrerAttribution", (m) async {
+      try {
+        // fetch() (not now()) so the guard is loaded from persistence — it
+        // must survive process restarts and is never resolved elsewhere.
+        if (await _sentGuard.fetch(m)) {
+          log(m).t("Install referrer attribution already sent, skip");
+          return;
+        }
+
+        final url = await _channel.fetchReferrerUrl();
+        final data = InstallReferrerData.parse(url);
+        log(m).i("Install referrer: organic=${data.isOrganic}, "
+            "hasGclid=${data.gclid != null}, available=${url != null}");
+
+        await _payment.updateAttribution(m, data.toAttributionMap());
+
+        final customAttrs = data.buildCustomAttributes();
+        if (customAttrs.isNotEmpty) {
+          await _payment
+              .setCustomAttributes(m, {'custom_attributes': customAttrs});
+        }
+
+        // Reached only on success (incl. organic when referrer unavailable —
+        // nothing better will ever arrive, so we never spin). On a transient
+        // Adapty error we fall to catch and leave the guard unset to retry on
+        // the next app start.
+        await _sentGuard.change(m, true);
+        log(m).i("Sent install referrer attribution to Adapty");
+      } catch (e, s) {
+        // Never rethrow: must not break the payment init/startup sequence.
+        log(m).e(
+            msg: "Failed sending install referrer attribution",
+            err: e,
+            stack: s);
+      }
+    });
+  }
+}

--- a/common/lib/src/features/payment/domain/install_referrer.dart
+++ b/common/lib/src/features/payment/domain/install_referrer.dart
@@ -135,24 +135,66 @@ class InstallReferrerData {
   }
 }
 
+enum InstallReferrerFetchStatus {
+  /// Referrer was read (the url may still be organic).
+  ok,
+
+  /// Referrer will never be available (non-Play / sideload / old Play Store).
+  /// Safe to record organic and latch the guard.
+  permanentlyUnavailable,
+
+  /// Transient Play hiccup (no connection / service busy). Must NOT be latched
+  /// as organic — retry on a later app start so a paid install isn't
+  /// permanently misattributed.
+  transientlyUnavailable,
+}
+
+class InstallReferrerFetchResult {
+  final InstallReferrerFetchStatus status;
+  final String? url; // present only when status == ok
+
+  const InstallReferrerFetchResult(this.status, [this.url]);
+}
+
 /// Test seam over the Play Install Referrer system API.
 mixin InstallReferrerChannel {
-  Future<String?> fetchReferrerUrl();
+  Future<InstallReferrerFetchResult> fetchReferrer();
 }
 
 class PlatformInstallReferrerChannel with Logging, InstallReferrerChannel {
+  // Connection-class errors: the referrer may be obtainable on a later launch.
+  static const _transientCodes = {
+    'SERVICE_UNAVAILABLE',
+    'SERVICE_DISCONNECTED',
+    'DEAD_OBJECT_EXCEPTION',
+    'BAD_STATE',
+  };
+
   @override
-  Future<String?> fetchReferrerUrl() async {
+  Future<InstallReferrerFetchResult> fetchReferrer() async {
     // play_install_referrer throws on iOS / when Play Services are absent.
-    if (!Core.act.isAndroid) return null;
+    if (!Core.act.isAndroid) {
+      return const InstallReferrerFetchResult(
+          InstallReferrerFetchStatus.permanentlyUnavailable);
+    }
     try {
       final details = await PlayInstallReferrer.installReferrer;
-      return details.installReferrer;
+      return InstallReferrerFetchResult(
+          InstallReferrerFetchStatus.ok, details.installReferrer);
+    } on PlatformException catch (e) {
+      // FEATURE_NOT_SUPPORTED / DEVELOPER_ERROR / PERMISSION_ERROR / unknown
+      // are permanent; only connection-class codes are retryable.
+      final transient = _transientCodes.contains(e.code);
+      log(Markers.root)
+          .i("Install referrer unavailable: ${e.code} (transient=$transient)");
+      return InstallReferrerFetchResult(transient
+          ? InstallReferrerFetchStatus.transientlyUnavailable
+          : InstallReferrerFetchStatus.permanentlyUnavailable);
     } catch (e) {
-      // FEATURE_NOT_SUPPORTED / SERVICE_UNAVAILABLE / DEVELOPER_ERROR
-      // (sideload, debug, non-Play install) -> treat as organic/unknown.
+      // Non-PlatformException (e.g. MissingPluginException) -> permanent.
       log(Markers.root).i("Install referrer unavailable: $e");
-      return null;
+      return const InstallReferrerFetchResult(
+          InstallReferrerFetchStatus.permanentlyUnavailable);
     }
   }
 }
@@ -191,25 +233,48 @@ class InstallReferrerService with Logging {
           return;
         }
 
-        final url = await _channel.fetchReferrerUrl();
+        final fetched = await _channel.fetchReferrer();
+        if (fetched.status ==
+            InstallReferrerFetchStatus.transientlyUnavailable) {
+          // A temporary Play hiccup must NOT latch a (possibly paid) install
+          // as organic. Send nothing, leave the guard unset, retry next start.
+          log(m).i("Install referrer temporarily unavailable, "
+              "will retry on next app start");
+          return;
+        }
+
+        // ok -> parse the (possibly organic) referrer; permanentlyUnavailable
+        // -> organic, since nothing better will ever arrive.
+        final url =
+            fetched.status == InstallReferrerFetchStatus.ok ? fetched.url : null;
         final data = InstallReferrerData.parse(url);
         log(m).i("Install referrer: organic=${data.isOrganic}, "
-            "hasGclid=${data.gclid != null}, available=${url != null}");
+            "hasGclid=${data.gclid != null}, status=${fetched.status.name}");
 
         await _payment.updateAttribution(m, data.toAttributionMap());
 
-        final customAttrs = data.buildCustomAttributes();
-        if (customAttrs.isNotEmpty) {
-          await _payment
-              .setCustomAttributes(m, {'custom_attributes': customAttrs});
-        }
-
-        // Reached only on success (incl. organic when referrer unavailable —
-        // nothing better will ever arrive, so we never spin). On a transient
-        // Adapty error we fall to catch and leave the guard unset to retry on
-        // the next app start.
+        // Checkpoint immediately: the #71-critical acquisition-source signal is
+        // delivered. Adapty is one-source-per-profile, so updateAttribution
+        // must never be re-attempted — do not couple it to the best-effort
+        // custom-attribute write below. On an updateAttribution failure we fall
+        // to catch with the guard unset and retry on the next app start.
         await _sentGuard.change(m, true);
         log(m).i("Sent install referrer attribution to Adapty");
+
+        // Best-effort BI extras (gclid / acq_status). Independently swallowed:
+        // a failure here must not unset the guard nor re-trigger attribution.
+        final customAttrs = data.buildCustomAttributes();
+        if (customAttrs.isNotEmpty) {
+          try {
+            await _payment
+                .setCustomAttributes(m, {'custom_attributes': customAttrs});
+          } catch (e, s) {
+            log(m).e(
+                msg: "Failed syncing acq_* custom attributes (best-effort)",
+                err: e,
+                stack: s);
+          }
+        }
       } catch (e, s) {
         // Never rethrow: must not break the payment init/startup sequence.
         log(m).e(

--- a/common/lib/src/features/payment/domain/payment.dart
+++ b/common/lib/src/features/payment/domain/payment.dart
@@ -12,6 +12,7 @@ import 'package:common/src/platform/stage/stage.dart';
 import 'package:common/src/shared/ui/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:i18n_extension/i18n_extension.dart';
+import 'package:play_install_referrer/play_install_referrer.dart';
 
 part 'actor.dart';
 part 'adapty.dart';
@@ -19,6 +20,7 @@ part 'adapty_key.dart';
 part 'attribute_converter.dart';
 part 'api.dart';
 part 'channel.dart';
+part 'install_referrer.dart';
 part 'paywall_sheet.dart';
 
 enum OnboardingStep {
@@ -59,6 +61,9 @@ class PaymentModule with Module {
   @override
   onCreateModule() async {
     await register(CurrentOnboardingStepValue());
+    await register(InstallReferrerSentValue());
+    await register<InstallReferrerChannel>(PlatformInstallReferrerChannel());
+    await register(InstallReferrerService());
     await register(PaymentActor());
     await register(PaymentApi());
     await register(PaymentCommand());

--- a/common/lib/src/features/payment/domain/payment.dart
+++ b/common/lib/src/features/payment/domain/payment.dart
@@ -11,6 +11,7 @@ import 'package:common/src/platform/stage/channel.pg.dart';
 import 'package:common/src/platform/stage/stage.dart';
 import 'package:common/src/shared/ui/theme.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
 import 'package:i18n_extension/i18n_extension.dart';
 import 'package:play_install_referrer/play_install_referrer.dart';
 

--- a/common/lib/src/platform/payment/channel.dart
+++ b/common/lib/src/platform/payment/channel.dart
@@ -27,4 +27,9 @@ class PlatformPaymentChannel with PaymentChannel {
   @override
   Future<void> setCustomAttributes(Marker m, Map<String, dynamic> attributes) =>
       _ops.doSetCustomAttributes(attributes);
+
+  @override
+  Future<void> updateAttribution(Marker m, Map<String, dynamic> attribution,
+          {String source = "custom"}) =>
+      _ops.doUpdateAttribution(attribution, source);
 }

--- a/common/libgen/Payment.dart
+++ b/common/libgen/Payment.dart
@@ -22,4 +22,7 @@ abstract class PaymentOps {
 
   @async
   void doSetCustomAttributes(Map<String, Object?> attributes);
+
+  @async
+  void doUpdateAttribution(Map<String, Object?> attribution, String source);
 }

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -824,6 +824,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.6"
+  play_install_referrer:
+    dependency: "direct main"
+    description:
+      name: play_install_referrer
+      sha256: "7dd808236d35d15199d5e7a5b55488e4343c1b67c4694902d6b95196b22b19cd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   flyer_chat_text_message: ^2.0.0
   logger: ^2.4.0
   adapty_flutter: 3.15.5
+  play_install_referrer: ^0.5.0
   input_code_field: ^2.0.2
   flutter_linkify: ^6.0.0
   cached_network_image: ^3.3.1

--- a/common/test/features/payment/domain/install_referrer_actor_test.dart
+++ b/common/test/features/payment/domain/install_referrer_actor_test.dart
@@ -5,14 +5,14 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../../tools.dart';
 
 class _FakeReferrerChannel implements InstallReferrerChannel {
-  String? url;
-  bool throwOnFetch = false;
+  InstallReferrerFetchResult result = const InstallReferrerFetchResult(
+      InstallReferrerFetchStatus.permanentlyUnavailable);
+
+  void ok(String? url) =>
+      result = InstallReferrerFetchResult(InstallReferrerFetchStatus.ok, url);
 
   @override
-  Future<String?> fetchReferrerUrl() async {
-    if (throwOnFetch) throw Exception('referrer boom');
-    return url;
-  }
+  Future<InstallReferrerFetchResult> fetchReferrer() async => result;
 }
 
 class _FakePaymentChannel implements PaymentChannel {
@@ -20,6 +20,7 @@ class _FakePaymentChannel implements PaymentChannel {
   final attributionSources = <String>[];
   final customAttrCalls = <Map<String, dynamic>>[];
   bool throwOnUpdateAttribution = false;
+  bool throwOnSetCustomAttributes = false;
 
   @override
   Future<void> updateAttribution(Marker m, Map<String, dynamic> attribution,
@@ -32,7 +33,8 @@ class _FakePaymentChannel implements PaymentChannel {
   @override
   Future<void> setCustomAttributes(
       Marker m, Map<String, dynamic> attributes) async {
-    customAttrCalls.add(attributes);
+    customAttrCalls.add(attributes); // record the attempt, then maybe fail
+    if (throwOnSetCustomAttributes) throw Exception('custom attrs failed');
   }
 
   @override
@@ -80,8 +82,8 @@ void main() {
     test('sends Google Ads attribution + gclid once, then guards', () async {
       await withTrace((m) async {
         final c = await _setup(android: true);
-        c.ref.url = 'gclid=G1&utm_source=google&utm_medium=cpc'
-            '&utm_campaign=summer';
+        c.ref.ok('gclid=G1&utm_source=google&utm_medium=cpc'
+            '&utm_campaign=summer');
 
         await c.svc.sendAttributionOnce(m);
 
@@ -107,7 +109,7 @@ void main() {
       await withTrace((m) async {
         final c = await _setup(android: true);
         await c.guard.change(m, true);
-        c.ref.url = 'gclid=G&utm_medium=cpc';
+        c.ref.ok('gclid=G&utm_medium=cpc');
 
         await c.svc.sendAttributionOnce(m);
 
@@ -116,10 +118,12 @@ void main() {
       });
     });
 
-    test('referrer unavailable -> organic sent, guard set, no spin', () async {
+    test('permanently unavailable -> organic sent, guard set, no spin',
+        () async {
       await withTrace((m) async {
         final c = await _setup(android: true);
-        c.ref.url = null;
+        c.ref.result = const InstallReferrerFetchResult(
+            InstallReferrerFetchStatus.permanentlyUnavailable);
 
         await c.svc.sendAttributionOnce(m);
 
@@ -129,11 +133,35 @@ void main() {
       });
     });
 
+    test(
+        'transiently unavailable -> nothing sent, guard unset, retries next '
+        'start (no permanent organic misattribution)', () async {
+      await withTrace((m) async {
+        final c = await _setup(android: true);
+        c.ref.result = const InstallReferrerFetchResult(
+            InstallReferrerFetchStatus.transientlyUnavailable);
+
+        await c.svc.sendAttributionOnce(m);
+
+        expect(c.pay.attributionMaps, isEmpty);
+        expect(c.pay.customAttrCalls, isEmpty);
+        expect(await c.guard.now(), isFalse);
+
+        // Next app start: Play is reachable, the real campaign is captured.
+        c.ref.ok('gclid=G9&utm_source=google&utm_medium=cpc');
+        await c.svc.sendAttributionOnce(m);
+
+        expect(c.pay.attributionMaps, hasLength(1));
+        expect(c.pay.attributionMaps.single['status'], 'non_organic');
+        expect(await c.guard.now(), isTrue);
+      });
+    });
+
     test('transient updateAttribution error: no rethrow, guard unset, retries',
         () async {
       await withTrace((m) async {
         final c = await _setup(android: true);
-        c.ref.url = 'gclid=G&utm_medium=cpc';
+        c.ref.ok('gclid=G&utm_medium=cpc');
         c.pay.throwOnUpdateAttribution = true;
 
         // Must not throw into the startup sequence.
@@ -148,11 +176,35 @@ void main() {
       });
     });
 
+    test(
+        'setCustomAttributes failure after updateAttribution succeeds: guard '
+        'still set, no rethrow, not re-attempted', () async {
+      await withTrace((m) async {
+        final c = await _setup(android: true);
+        c.ref.ok('gclid=G&utm_source=google&utm_medium=cpc');
+        c.pay.throwOnSetCustomAttributes = true;
+
+        await c.svc.sendAttributionOnce(m);
+
+        // Attribution delivered + checkpointed despite the best-effort
+        // custom-attribute write failing (decoupled).
+        expect(c.pay.attributionMaps, hasLength(1));
+        expect(c.pay.customAttrCalls, hasLength(1)); // attempted
+        expect(await c.guard.now(), isTrue);
+
+        // Next start does NOT re-attempt updateAttribution (Adapty is
+        // one-source-per-profile) nor wedge.
+        c.pay.throwOnSetCustomAttributes = false;
+        await c.svc.sendAttributionOnce(m);
+        expect(c.pay.attributionMaps, hasLength(1));
+      });
+    });
+
     test('iOS is gated: never calls Adapty (protects Apple Search Ads)',
         () async {
       await withTrace((m) async {
         final c = await _setup(android: false);
-        c.ref.url = 'gclid=G&utm_source=google&utm_medium=cpc';
+        c.ref.ok('gclid=G&utm_source=google&utm_medium=cpc');
 
         await c.svc.sendAttributionOnce(m);
 

--- a/common/test/features/payment/domain/install_referrer_actor_test.dart
+++ b/common/test/features/payment/domain/install_referrer_actor_test.dart
@@ -1,0 +1,165 @@
+import 'package:common/src/core/core.dart';
+import 'package:common/src/features/payment/domain/payment.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../tools.dart';
+
+class _FakeReferrerChannel implements InstallReferrerChannel {
+  String? url;
+  bool throwOnFetch = false;
+
+  @override
+  Future<String?> fetchReferrerUrl() async {
+    if (throwOnFetch) throw Exception('referrer boom');
+    return url;
+  }
+}
+
+class _FakePaymentChannel implements PaymentChannel {
+  final attributionMaps = <Map<String, dynamic>>[];
+  final attributionSources = <String>[];
+  final customAttrCalls = <Map<String, dynamic>>[];
+  bool throwOnUpdateAttribution = false;
+
+  @override
+  Future<void> updateAttribution(Marker m, Map<String, dynamic> attribution,
+      {String source = "custom"}) async {
+    if (throwOnUpdateAttribution) throw Exception('adapty unavailable');
+    attributionMaps.add(attribution);
+    attributionSources.add(source);
+  }
+
+  @override
+  Future<void> setCustomAttributes(
+      Marker m, Map<String, dynamic> attributes) async {
+    customAttrCalls.add(attributes);
+  }
+
+  @override
+  Future<void> init(
+      Marker m, String apiKey, String? accountId, bool verboseLogs) async {}
+  @override
+  Future<void> identify(String accountId) async {}
+  @override
+  Future<void> logOnboardingStep(String name, OnboardingStep step) async {}
+  @override
+  Future<void> preload(Marker m, Placement placement) async {}
+  @override
+  Future<void> showPaymentScreen(Marker m, Placement placement,
+      {bool forceReload = false}) async {}
+  @override
+  Future<void> closePaymentScreen(bool isError) async {}
+}
+
+typedef _Ctx = ({
+  _FakeReferrerChannel ref,
+  _FakePaymentChannel pay,
+  InstallReferrerSentValue guard,
+  InstallReferrerService svc,
+});
+
+Future<_Ctx> _setup({required bool android}) async {
+  Core.act = ActScreenplay(ActScenario.test, Flavor.v6,
+      android ? PlatformType.android : PlatformType.iOS);
+  Core.register<Persistence>(Persistence(isSecure: false));
+  Core.register<Persistence>(Persistence(isSecure: true),
+      tag: Persistence.secure);
+
+  final ref = _FakeReferrerChannel();
+  final pay = _FakePaymentChannel();
+  final guard = InstallReferrerSentValue();
+  Core.register<InstallReferrerChannel>(ref);
+  Core.register<PaymentChannel>(pay);
+  Core.register(guard);
+
+  return (ref: ref, pay: pay, guard: guard, svc: InstallReferrerService());
+}
+
+void main() {
+  group('InstallReferrerService', () {
+    test('sends Google Ads attribution + gclid once, then guards', () async {
+      await withTrace((m) async {
+        final c = await _setup(android: true);
+        c.ref.url = 'gclid=G1&utm_source=google&utm_medium=cpc'
+            '&utm_campaign=summer';
+
+        await c.svc.sendAttributionOnce(m);
+
+        expect(c.pay.attributionMaps, hasLength(1));
+        expect(c.pay.attributionSources.single, 'custom');
+        expect(c.pay.attributionMaps.single['status'], 'non_organic');
+        expect(c.pay.attributionMaps.single['channel'], 'google');
+        expect(c.pay.attributionMaps.single['campaign'], 'summer');
+        expect(c.pay.customAttrCalls, hasLength(1));
+        final attrs = c.pay.customAttrCalls.single['custom_attributes']
+            as List<Map<String, dynamic>>;
+        expect(attrs.any((a) => a['key'] == 'acq_gclid' && a['value'] == 'G1'),
+            isTrue);
+        expect(await c.guard.now(), isTrue);
+
+        // Second call is a no-op (idempotent).
+        await c.svc.sendAttributionOnce(m);
+        expect(c.pay.attributionMaps, hasLength(1));
+      });
+    });
+
+    test('does nothing when the guard is already set', () async {
+      await withTrace((m) async {
+        final c = await _setup(android: true);
+        await c.guard.change(m, true);
+        c.ref.url = 'gclid=G&utm_medium=cpc';
+
+        await c.svc.sendAttributionOnce(m);
+
+        expect(c.pay.attributionMaps, isEmpty);
+        expect(c.pay.customAttrCalls, isEmpty);
+      });
+    });
+
+    test('referrer unavailable -> organic sent, guard set, no spin', () async {
+      await withTrace((m) async {
+        final c = await _setup(android: true);
+        c.ref.url = null;
+
+        await c.svc.sendAttributionOnce(m);
+
+        expect(c.pay.attributionMaps, hasLength(1));
+        expect(c.pay.attributionMaps.single['status'], 'organic');
+        expect(await c.guard.now(), isTrue);
+      });
+    });
+
+    test('transient updateAttribution error: no rethrow, guard unset, retries',
+        () async {
+      await withTrace((m) async {
+        final c = await _setup(android: true);
+        c.ref.url = 'gclid=G&utm_medium=cpc';
+        c.pay.throwOnUpdateAttribution = true;
+
+        // Must not throw into the startup sequence.
+        await c.svc.sendAttributionOnce(m);
+        expect(await c.guard.now(), isFalse);
+
+        // Next app start retries successfully.
+        c.pay.throwOnUpdateAttribution = false;
+        await c.svc.sendAttributionOnce(m);
+        expect(c.pay.attributionMaps, hasLength(1));
+        expect(await c.guard.now(), isTrue);
+      });
+    });
+
+    test('iOS is gated: never calls Adapty (protects Apple Search Ads)',
+        () async {
+      await withTrace((m) async {
+        final c = await _setup(android: false);
+        c.ref.url = 'gclid=G&utm_source=google&utm_medium=cpc';
+
+        await c.svc.sendAttributionOnce(m);
+
+        expect(c.pay.attributionMaps, isEmpty);
+        expect(c.pay.customAttrCalls, isEmpty);
+        expect(await c.guard.now(), isFalse);
+      });
+    });
+  });
+}

--- a/common/test/features/payment/domain/install_referrer_test.dart
+++ b/common/test/features/payment/domain/install_referrer_test.dart
@@ -1,0 +1,137 @@
+import 'package:common/src/features/payment/domain/payment.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('InstallReferrerData.parse', () {
+    test('parses a Google Ads referrer as non-organic', () {
+      final d = InstallReferrerData.parse(
+          'gclid=ABC123&utm_source=google&utm_medium=cpc'
+          '&utm_campaign=summer&utm_content=banner&utm_term=vpn');
+
+      expect(d.gclid, 'ABC123');
+      expect(d.utmSource, 'google');
+      expect(d.utmMedium, 'cpc');
+      expect(d.utmCampaign, 'summer');
+      expect(d.utmContent, 'banner');
+      expect(d.utmTerm, 'vpn');
+      expect(d.isOrganic, isFalse);
+      expect(d.rawReferrer, contains('gclid=ABC123'));
+    });
+
+    test('parses a Play organic referrer as organic', () {
+      final d = InstallReferrerData.parse(
+          'utm_source=google-play&utm_medium=organic');
+
+      expect(d.isOrganic, isTrue);
+      expect(d.gclid, isNull);
+      expect(d.utmSource, 'google-play');
+    });
+
+    test('url-decodes values', () {
+      final d = InstallReferrerData.parse(
+          'utm_campaign=hello%20world&gclid=a%2Bb');
+
+      expect(d.utmCampaign, 'hello world');
+      expect(d.gclid, 'a+b');
+      expect(d.isOrganic, isFalse);
+    });
+
+    test('null/empty referrer is organic with all fields null', () {
+      for (final v in [null, '', '   ']) {
+        final d = InstallReferrerData.parse(v);
+        expect(d.isOrganic, isTrue);
+        expect(d.gclid, isNull);
+        expect(d.utmSource, isNull);
+        expect(d.rawReferrer, isNull);
+      }
+    });
+
+    test('malformed referrer does not throw and keeps rawReferrer', () {
+      final d = InstallReferrerData.parse('&&=foo&utm_source');
+      expect(d.rawReferrer, '&&=foo&utm_source');
+      expect(d.isOrganic, isTrue); // no gclid, no usable source
+    });
+
+    test('any gclid forces non-organic even with google-play source', () {
+      final d = InstallReferrerData.parse(
+          'utm_source=google-play&gclid=xyz');
+      expect(d.isOrganic, isFalse);
+    });
+
+    test('utm_medium=paid is treated as non-organic', () {
+      final d = InstallReferrerData.parse(
+          'utm_source=partner&utm_medium=paid');
+      expect(d.isOrganic, isFalse);
+    });
+  });
+
+  group('InstallReferrerData.toAttributionMap', () {
+    test('maps Google Ads fields and omits empty keys', () {
+      final map = InstallReferrerData.parse(
+              'gclid=g&utm_source=google&utm_medium=cpc'
+              '&utm_campaign=summer&utm_content=banner&utm_term=vpn')
+          .toAttributionMap();
+
+      expect(map['status'], 'non_organic');
+      expect(map['channel'], 'google');
+      expect(map['campaign'], 'summer');
+      expect(map['ad_set'], 'cpc');
+      expect(map['creative'], 'banner');
+      expect(map['ad_group'], 'vpn');
+    });
+
+    test('organic produces status organic with sane defaults', () {
+      final map = InstallReferrerData.parse(null).toAttributionMap();
+      expect(map['status'], 'organic');
+      expect(map['channel'], 'google-play');
+      expect(map['ad_set'], 'organic');
+      expect(map.containsKey('campaign'), isFalse);
+      expect(map.containsKey('creative'), isFalse);
+    });
+
+    test('truncates values to 50 chars', () {
+      final long = 'c' * 80;
+      final map =
+          InstallReferrerData.parse('utm_source=google&utm_campaign=$long')
+              .toAttributionMap();
+      expect((map['campaign'] as String).length, 50);
+    });
+  });
+
+  group('InstallReferrerData.buildCustomAttributes', () {
+    test('always includes acq_status', () {
+      final attrs = InstallReferrerData.parse(null).buildCustomAttributes();
+      final status = attrs.firstWhere((a) => a['key'] == 'acq_status');
+      expect(status['value'], 'organic');
+    });
+
+    test('chunks a long gclid into <=50-char acq_gclid keys', () {
+      final gclid = 'x' * 120;
+      final attrs =
+          InstallReferrerData.parse('gclid=$gclid&utm_medium=cpc')
+              .buildCustomAttributes();
+
+      final gclidAttrs =
+          attrs.where((a) => (a['key'] as String).startsWith('acq_gclid'));
+      expect(gclidAttrs, isNotEmpty);
+      for (final a in gclidAttrs) {
+        expect((a['key'] as String), matches(r'^[a-zA-Z0-9\-._]+$'));
+        expect((a['key'] as String).length, lessThanOrEqualTo(30));
+        expect((a['value'] as String).length, lessThanOrEqualTo(50));
+      }
+      expect(gclidAttrs.any((a) => a['key'] == 'acq_gclid'), isTrue);
+      // reconstructed value matches original (capped at 4 chunks => 200 chars,
+      // here 120 chars fits fully)
+      final joined = gclidAttrs.map((a) => a['value'] as String).join();
+      expect(joined, gclid);
+    });
+
+    test('no gclid key when gclid absent', () {
+      final attrs =
+          InstallReferrerData.parse('utm_source=google-play')
+              .buildCustomAttributes();
+      expect(attrs.any((a) => (a['key'] as String).startsWith('acq_gclid')),
+          isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Context / Why

The Google Ads campaign (issue #71, `blokadaorg/issue-tracker`) ran with **no app-side attribution on Android**, so install→paid events couldn't be tied to the campaign and CPA_paid was unknown. iOS already has this automatically via Adapty's Apple Search Ads integration; **Android had no equivalent for either flavor** (no `updateAttribution`, no Install Referrer; Adapty has no first-class Google Ads integration). This adds the privacy-safe Android counterpart so #71 can resume against a reliable install→paid-by-campaign read.

## SDK-migration decision (the other half of #71)

Evaluated replacing the native Android Adapty SDK with the Flutter SDK: **rejected.** `six` keeps the native SDK solely for in-paywall subscription **proration** (`onAwaitingPurchaseParams`), and the Adapty Flutter Paywall Builder still has no pre-purchase hook (Adapty SDK-Flutter #160 open). Migrating would regress v6. Native SDK + Pigeon bridge kept untouched.

## What changed

- **`play_install_referrer` 0.5.0** (maintained; AGP-8 namespace verified) — captures the Google Play Install Referrer.
- **`install_referrer.dart`** — shared Dart: parse UTM + `gclid`, map to Adapty's `status/channel/campaign/ad_group/ad_set/creative`, stash `gclid` as `acq_*` custom attributes (bypasses the 30-char converter via the existing pre-built-list path). **iOS-gated** so Apple Search Ads is never clobbered (Adapty = one source per profile). Persisted once-per-install idempotency guard.
- **`updateAttribution`** added to the `PaymentChannel` mixin + both impls: Adapty Flutter SDK (`adapty.dart`) for family/iOS; new **Pigeon `doUpdateAttribution`** → native `Adapty.updateAttribution` in `PaymentBinding.kt` for v6 Android (the Flutter SDK is not activated on v6 Android).
- Trigger wired into `PaymentActor.onStart` (post-init, `unawaited`, idempotent). ProGuard keeps for both flavors.

Privacy-safe: no GAID/IDFA/IP (Adapty's collection-disabled flags untouched).

## Testing

- 24 new unit tests (parse / attribution-map / gclid-chunk / idempotency / iOS-gate / transient-error retry); **full suite 228/228 green** incl. untouched `attribute_converter` regression.
- `six` + `family` debug builds **SUCCESSFUL** (Pigeon regen + native Kotlin + plugin compile under AGP 8.13).
- **On-device (OnePlus 7T, Android 12), both flavors:** app starts, attribution path runs and is **accepted by the Adapty backend** (`{"attribution_json":"{...status:organic,channel:google-play...}","source":"custom"}` + `acq_status` custom attr — verified at the HTTP-request level on the native path), idempotency guard sets, **paywalls present** (native `AdaptyPaywallView` for six, `AdaptyUIPaywallPlatformView` for family), no crash. No purchase attempted (not yet testable).
- A multi-agent diff review caught and fixed one blocker (persisted-guard read must use `fetch()` not `now()`), since confirmed on hardware.

## Out-of-band acceptance (not blocking this PR)

Confirm in the Adapty dashboard that a `"custom"` attribution source filters install→paid the same way the integrated Apple Search Ads source does. Real campaign attribution requires a Play internal-testing install (sideloaded builds report organic, as seen on-device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)