### PR TITLE
ci: static check for Adapty fallback paywalls format version

### DIFF
--- a/.github/workflows/check-adapty-fallback.yml
+++ b/.github/workflows/check-adapty-fallback.yml
@@ -1,0 +1,22 @@
+name: Check Adapty fallback version
+
+on:
+  pull_request:
+    paths:
+      - "common/assets/fallbacks/**"
+      - "android/app/src/main/assets/fallbacks/**"
+      - "common/pubspec.yaml"
+      - "common/pubspec.lock"
+      - "ios/Podfile.lock"
+      - "scripts/check-adapty-fallback-version.mjs"
+      - ".github/workflows/check-adapty-fallback.yml"
+  push:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+      - run: node scripts/check-adapty-fallback-version.mjs

--- a/scripts/check-adapty-fallback-version.mjs
+++ b/scripts/check-adapty-fallback-version.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+//
+// Verifies that the bundled Adapty fallback paywalls JSON files use a format
+// version recent enough for the shipped Adapty SDK. Older JSONs are rejected
+// by the SDK at cold start with error 2006 ("Decoding Fallback Paywalls
+// failed... The fallback paywalls version is not correct."), which silently
+// degrades to StageModal.paymentTempUnavailable because the Dart catch in
+// common/lib/src/features/payment/domain/adapty.dart swallows it.
+//
+// When Adapty bumps the fallback paywalls format alongside an SDK upgrade,
+// bump MIN_VERSION below in the same PR that refreshes the JSONs (and the
+// adapty_flutter dep in common/pubspec.yaml).
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import process from "node:process";
+
+const MIN_VERSION = 9;
+
+const FILES = [
+  "common/assets/fallbacks/ios.json",
+  "common/assets/fallbacks/android.json",
+  "android/app/src/main/assets/fallbacks/android.json",
+];
+
+let failed = false;
+for (const rel of FILES) {
+  const path = resolve(rel);
+  let json;
+  try {
+    json = JSON.parse(readFileSync(path, "utf8"));
+  } catch (e) {
+    console.error(`FAIL  ${rel}  could not parse: ${e.message}`);
+    failed = true;
+    continue;
+  }
+  const version = json?.meta?.version;
+  if (typeof version !== "number") {
+    console.error(`FAIL  ${rel}  meta.version is missing or not a number`);
+    failed = true;
+    continue;
+  }
+  if (version < MIN_VERSION) {
+    console.error(`FAIL  ${rel}  meta.version=${version}, expected >= ${MIN_VERSION}`);
+    failed = true;
+    continue;
+  }
+  console.log(`OK    ${rel}  meta.version=${version}`);
+}
+
+if (failed) {
+  console.error("");
+  console.error("Refresh fallback paywalls from the Adapty Dashboard and replace all three files.");
+  console.error("If the Adapty SDK was upgraded, also bump MIN_VERSION in this script to match the new format.");
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- Tiny Node script (`scripts/check-adapty-fallback-version.mjs`) that reads each of the three bundled Adapty fallback JSONs (`common/assets/fallbacks/{ios,android}.json` + `android/app/src/main/assets/fallbacks/android.json`) and asserts `meta.version >= MIN_VERSION` (currently `9`).
- GitHub Actions workflow (`.github/workflows/check-adapty-fallback.yml`) that runs the script on Ubuntu in ~5s on PRs that touch the fallback files, the Adapty deps, or the script itself.

## Why

Adapty SDK 3.15.7 was rejecting the bundled JSONs (`meta.version: 8`) at every cold start with error **2006** — _"Decoding Fallback Paywalls failed... The fallback paywalls version is not correct."_ The Dart catch at `common/lib/src/features/payment/domain/adapty.dart:39` swallows that error with a debug-level \"ignore\" log, so the bundled JSON went silently stale for months. When the live `getPaywall()` call also failed, the user ended up at `StageModal.paymentTempUnavailable`.

This catches it before merge with a deterministic signal — the format version is encoded in the file itself.

## Why this approach (and not the Appium smoke from #1056)

#1056 attempted runtime detection from the Appium smoke test. Three runtime approaches were tried; all of them hit blockers that needed either developer provisioning, runner-dependent device behavior, or a new entitlement we don't want. See the close comment on #1056 for the full trail.

The static check has one limitation worth flagging: it only catches *version-encoded* staleness. If Adapty ever changed the format without bumping `meta.version`, we'd miss it. In practice that field is literally the format version, so this is fine.

When Adapty's format bumps with a future SDK upgrade, the same PR that refreshes the JSONs bumps `MIN_VERSION` in the script.

## Verified locally

- Current `main` (`meta.version: 8`): script exits **1** with three clear FAIL lines pointing at the three JSONs.
- Cherry-picked the fixed JSONs from #1057 (`meta.version: 9`): script exits **0** with three OK lines.

## Test plan

- [ ] CI runs the workflow on this PR and turns **red** (because `main` still has v8 JSONs).
- [ ] After merging #1057 (the refresh), this check turns **green**.
- [ ] On a future SDK upgrade that bumps the format past 9, a PR that refreshes the JSONs and bumps `MIN_VERSION` together passes; one that only does one of those fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)