### PR TITLE
fastlane: decouple listing-text metadata from binary releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ ADAPTY_VER := 3_8.0
 	build-android build-android-family build-android-six \
 	build-ios build-ios-family build-ios-six build-ios-six-debug \
 	version version-clean \
-	publish-android gplay-key-unpack gplay-key-clean \
-	publish-ios appstore-key-unpack appstore-key-clean fastlane-match \
+	publish-android upload-android-metadata gplay-key-unpack gplay-key-clean \
+	publish-ios upload-ios-metadata appstore-key-unpack appstore-key-clean fastlane-match \
 	build-android-family-debug build-android-six-debug \
 	build-android-family-quick build-android-six-quick \
 	build-android-family-debug-quick build-android-six-debug-quick \
@@ -156,7 +156,10 @@ version-clean:
 	git restore $(IOS_PROJECT_FILE)
 
 
-# Publish android app to Google Play internal channel (use FLAVOR param)
+# Publish android app to Google Play internal channel (use FLAVOR param).
+# Listing TEXT (title, short/long description) is decoupled and skipped here;
+# screenshots, images, and changelogs still ship with the binary as before.
+# To push listing text changes, use `make upload-android-metadata FLAVOR=...`.
 publish-android:
 	$(MAKE) gplay-key-unpack
 	@AAB=$(if $(filter family,$(FLAVOR)),familyRelease/app-family-release.aab,sixRelease/app-six-release.aab); \
@@ -165,7 +168,29 @@ publish-android:
 	--package_name "$$PKG" \
 	--json_key blokada-gplay.json \
 	--metadata_path metadata/android-$(FLAVOR) \
+	--skip_upload_metadata \
 	--track internal
+	$(MAKE) gplay-key-clean
+
+# Upload android listing metadata (no binary). Use FLAVOR param.
+# Uploads listing text, images, and screenshots from metadata/android-FLAVOR.
+# Skips APK/AAB and changelogs — changelogs are version-bound and require a
+# version code that a metadata-only run doesn't have; they ship via the
+# binary lane instead.
+# TRACK defaults to production because Play Console listing text is global
+# across tracks (the parameter is kept so callers can override if needed).
+upload-android-metadata:
+	$(MAKE) gplay-key-unpack
+	@PKG=$(if $(filter family,$(FLAVOR)),org.blokada.family,org.blokada.sex); \
+	TRACK=$(or $(TRACK),production); \
+	$(FASTLANE) supply \
+	--package_name "$$PKG" \
+	--json_key blokada-gplay.json \
+	--metadata_path metadata/android-$(FLAVOR) \
+	--skip_upload_apk \
+	--skip_upload_aab \
+	--skip_upload_changelogs \
+	--track $$TRACK
 	$(MAKE) gplay-key-clean
 
 # Unpack Google Play api key for publishing (use env var)
@@ -180,10 +205,21 @@ gplay-key-unpack:
 gplay-key-clean:
 	rm -rf blokada-gplay.json
 
-# Publish ios app to AppStore TestFlight (use FLAVOR param)
+# Publish ios app to AppStore TestFlight (use FLAVOR param).
+# Listing metadata is decoupled: this target uploads the IPA only. To push
+# metadata changes, use `make upload-ios-metadata FLAVOR=...`.
 publish-ios:
 	$(MAKE) appstore-key-unpack
 	@LANE=$(if $(filter family,$(FLAVOR)),publish_ios_family,publish_ios_six); \
+	cd ios/ && $(FASTLANE) $$LANE
+	$(MAKE) appstore-key-clean
+
+# Upload ios listing metadata only (no binary). Use FLAVOR param.
+# The lane opens fastlane's HTML preview before uploading — abort there if the
+# diff looks wrong.
+upload-ios-metadata:
+	$(MAKE) appstore-key-unpack
+	@LANE=$(if $(filter family,$(FLAVOR)),upload_ios_family_metadata,upload_ios_six_metadata); \
 	cd ios/ && $(FASTLANE) $$LANE
 	$(MAKE) appstore-key-clean
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -43,6 +43,7 @@ platform :ios do
       app_identifier: "net.blocka.app",
       metadata_path: "../metadata/ios-six/",
       api_key_path: "./blokada-appstore.json",
+      skip_metadata: true, # metadata ships via upload_ios_six_metadata, not with the binary
       skip_screenshots: true,
       skip_app_version_update: false,
       force: true, # skips verification of HTML preview file
@@ -56,10 +57,40 @@ platform :ios do
       app_identifier: "net.blocka.app.family",
       metadata_path: "../metadata/ios-family/",
       api_key_path: "./blokada-appstore.json",
+      skip_metadata: true, # metadata ships via upload_ios_family_metadata, not with the binary
       skip_screenshots: true,
       skip_app_version_update: false,
       force: true, # skips verification of HTML preview file
       run_precheck_before_submit: false # not supported through ASC API yet
+   )
+  end
+
+  # Metadata-only upload (no binary). Deliberately omits `force: true` so the
+  # HTML preview fires and the operator confirms the diff before any write.
+  # NOTE: do not invoke these lanes from headless CI — fastlane will block
+  # forever waiting for stdin confirmation on the HTML preview. Manual,
+  # interactive use only.
+  lane :upload_ios_six_metadata do
+   deliver(
+      app_identifier: "net.blocka.app",
+      metadata_path: "../metadata/ios-six/",
+      api_key_path: "./blokada-appstore.json",
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      use_live_version: true, # edit the live App Store listing, not an in-flight Prepare-for-Submission version
+      run_precheck_before_submit: false
+   )
+  end
+
+  lane :upload_ios_family_metadata do
+   deliver(
+      app_identifier: "net.blocka.app.family",
+      metadata_path: "../metadata/ios-family/",
+      api_key_path: "./blokada-appstore.json",
+      skip_binary_upload: true,
+      skip_screenshots: true,
+      use_live_version: true, # edit the live App Store listing, not an in-flight Prepare-for-Submission version
+      run_precheck_before_submit: false
    )
   end
 end


### PR DESCRIPTION
## Summary

Stops listing text (title, short/long description) from auto-shipping on every binary release. Adds explicit metadata-only upload lanes for App Store and Play Store so we can land copy changes without immediately shipping them, and promote A/B winners with one command.

- `publish_ios_six` / `publish_ios_family`: add `skip_metadata: true`. Other behavior unchanged (`force: true` preserved for CI).
- `publish-android`: add `--skip_upload_metadata`. Screenshots, images, and changelogs continue to ship with the binary as before.
- New: `upload_ios_six_metadata`, `upload_ios_family_metadata` (Fastfile) — omit `force: true` so fastlane's HTML preview gates the upload. Interactive only — do not run headless.
- New: `make upload-android-metadata FLAVOR=...` and `make upload-ios-metadata FLAVOR=...`
- `upload-android-metadata` uploads listing text + images + screenshots; skips APK/AAB and changelogs (version-bound, would fail without a version_code). `TRACK` defaults to `production` since listing text is global across tracks.

Related: blokadaorg/issue-tracker#284

## Test plan

- [ ] Static review: diffs match the intended scope (only `skip_metadata: true` added to existing iOS lanes; only `--skip_upload_metadata` added to publish-android).
- [ ] `bundle exec fastlane lanes` in `ios/` lists `upload_ios_six_metadata` and `upload_ios_family_metadata`.
- [ ] `make -n upload-android-metadata FLAVOR=six` resolves to a `supply` call with `--skip_upload_apk --skip_upload_aab --skip_upload_changelogs --track production`.
- [ ] `make -n upload-android-metadata FLAVOR=family TRACK=internal` overrides TRACK correctly.
- [ ] First real use: rehearse against a sentinel scratch metadata directory before promoting real copy.
- [ ] Next binary release after merge does not push listing text to either store.

## Out of scope / follow-ups

- GHA workflows for the new metadata lanes (kept manual on purpose).
- Credentials-on-disk cleanup if a lane errors out (pre-existing pattern in `publish-android` / `publish-ios`; surfaces in both old and new lanes).
- The Play Store Listing Experiment itself (manual Play Console operation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)