### PR TITLE
fix(ios+automation): restore device log fetching on Xcode 26.5

### DIFF
--- a/.agents/skills/device-log/SKILL.md
+++ b/.agents/skills/device-log/SKILL.md
@@ -49,7 +49,7 @@ Supported variables:
 ## Behavior
 
 - `ARTIFACT=log`:
-  - pulls the share-log file from the app group container `group.net.blocka.app`
+  - pulls the share-log file from the app group container `group.net.blocka.app`, under `Library/Application Support/Blokada/` (devicectl on Xcode 26.5+ cannot list or copy files at the container root, only inside the standard `Library/` hierarchy)
   - chooses the newest matching file for the selected bundle:
     - `net.blocka.app` -> `blokada-i6x*.log`
     - `net.blocka.app.family` -> `blokada-iFx*.log`

--- a/automation/device/lib/log.mjs
+++ b/automation/device/lib/log.mjs
@@ -105,6 +105,9 @@ export function getCrashReportPrefix(bundleId = "net.blocka.app") {
 export function selectNewestCrashReport(files, bundleId) {
   const prefix = getCrashReportPrefix(bundleId);
   const matches = files.filter((file) => {
+    // Crash reports are flat filenames in the systemCrashLogs domain, so match
+    // the full name here (unlike selectNewestLogFile, which matches a basename
+    // because share logs live in a subdirectory).
     const name = file?.name ?? file?.relativePath ?? "";
     const isDirectory = file?.resources?.isDirectory === true;
     return !isDirectory && name.startsWith(prefix) && name.endsWith(".ips");
@@ -123,8 +126,11 @@ export function selectNewestLogFile(files, bundleId) {
   const prefix = getShareLogPrefix(bundleId);
   const matches = files.filter((file) => {
     const name = file?.name ?? file?.relativePath ?? "";
+    // The app writes logs into a subdirectory of the group container (under
+    // Library/), so match on the basename rather than the full relativePath.
+    const base = name.split("/").pop() ?? "";
     const isDirectory = file?.resources?.isDirectory === true;
-    return !isDirectory && name.startsWith(prefix) && name.endsWith(".log");
+    return !isDirectory && base.startsWith(prefix) && base.endsWith(".log");
   });
 
   matches.sort((left, right) => {
@@ -233,6 +239,9 @@ async function runDevicectlJson(args, execFileSyncImpl = execFileSync) {
 }
 
 async function listAppGroupFiles(device, execFileSyncImpl = execFileSync) {
+  // Omit `--subdirectory`: passing "." makes CoreDevice on Xcode 26.5+ reject
+  // the listing with "ActionError error 3" for container domains. Without it,
+  // the root listing is returned recursively with relativePaths.
   const payload = await runDevicectlJson(
     [
       "devicectl",
@@ -244,9 +253,7 @@ async function listAppGroupFiles(device, execFileSyncImpl = execFileSync) {
       "--domain-type",
       "appGroupDataContainer",
       "--domain-identifier",
-      APP_GROUP_ID,
-      "--subdirectory",
-      "."
+      APP_GROUP_ID
     ],
     execFileSyncImpl
   );

--- a/automation/device/tests/log.test.mjs
+++ b/automation/device/tests/log.test.mjs
@@ -47,24 +47,27 @@ test("normalizeLines defaults to 400 and caps invalid values", () => {
   assert.equal(normalizeLines("0"), 400);
 });
 
-test("selectNewestLogFile chooses the newest matching share log", () => {
+test("selectNewestLogFile chooses the newest matching share log by basename", () => {
+  // The app writes into a subdirectory of the group container, so the listing
+  // returns subdirectory-prefixed relativePaths; selection matches on the
+  // basename and ignores blokada.log (wrong prefix) even though it is newer.
   const selected = selectNewestLogFile(
     [
       {
-        name: "blokada-i6xR.log",
-        relativePath: "blokada-i6xR.log",
+        name: "Library/Application Support/Blokada/blokada-i6xR.log",
+        relativePath: "Library/Application Support/Blokada/blokada-i6xR.log",
         metadata: { lastModDate: "2026-03-13T12:00:00.000Z" },
         resources: { isDirectory: false }
       },
       {
-        name: "blokada-i6xD.log",
-        relativePath: "blokada-i6xD.log",
+        name: "Library/Application Support/Blokada/blokada-i6xD.log",
+        relativePath: "Library/Application Support/Blokada/blokada-i6xD.log",
         metadata: { lastModDate: "2026-03-13T13:00:00.000Z" },
         resources: { isDirectory: false }
       },
       {
-        name: "blokada.log",
-        relativePath: "blokada.log",
+        name: "Library/Application Support/Blokada/blokada.log",
+        relativePath: "Library/Application Support/Blokada/blokada.log",
         metadata: { lastModDate: "2026-03-13T14:00:00.000Z" },
         resources: { isDirectory: false }
       }
@@ -72,7 +75,7 @@ test("selectNewestLogFile chooses the newest matching share log", () => {
     "net.blocka.app"
   );
 
-  assert.equal(selected.relativePath, "blokada-i6xD.log");
+  assert.equal(selected.relativePath, "Library/Application Support/Blokada/blokada-i6xD.log");
 });
 
 test("selectNewestCrashReport chooses the newest matching crash artifact", () => {
@@ -190,8 +193,8 @@ test("pullRecentDeviceLog saves full and filtered artifacts", async () => {
             result: {
               files: [
                 {
-                  name: "blokada-i6xR.log",
-                  relativePath: "blokada-i6xR.log",
+                  name: "Library/Application Support/Blokada/blokada-i6xR.log",
+                  relativePath: "Library/Application Support/Blokada/blokada-i6xR.log",
                   metadata: { lastModDate: "2026-03-13T13:00:00.000Z" },
                   resources: { isDirectory: false }
                 }
@@ -217,13 +220,35 @@ test("pullRecentDeviceLog saves full and filtered artifacts", async () => {
     window: "1h"
   });
 
-  assert.equal(result.sourceFile, "blokada-i6xR.log");
+  assert.equal(result.sourceFile, "Library/Application Support/Blokada/blokada-i6xR.log");
   assert.match(result.text, /copied log/);
   assert.equal(calls.length, 2);
   assert.match(result.fullArtifactPath, /blokada-i6x-1h\.full\.log$/);
   assert.match(result.artifactPath, /blokada-i6x-1h\.log$/);
   assert.equal(await readFile(result.fullArtifactPath, "utf8"), copiedText);
   assert.equal(await readFile(result.artifactPath, "utf8"), result.text);
+  // The list call must not pass `--subdirectory "."`, which CoreDevice on
+  // Xcode 26.5+ rejects with ActionError error 3. (`--json-output <path>` is
+  // appended by runDevicectlJson, so only assert the stable prefix.)
+  assert.deepEqual(
+    calls[0][1].slice(0, 10),
+    [
+      "devicectl",
+      "device",
+      "info",
+      "files",
+      "--device",
+      "abc",
+      "--domain-type",
+      "appGroupDataContainer",
+      "--domain-identifier",
+      "group.net.blocka.app"
+    ]
+  );
+  assert.ok(
+    !calls[0][1].includes("--subdirectory"),
+    "list call must not pass --subdirectory"
+  );
   assert.deepEqual(
     calls[1][1],
     [
@@ -238,7 +263,7 @@ test("pullRecentDeviceLog saves full and filtered artifacts", async () => {
       "--domain-identifier",
       "group.net.blocka.app",
       "--source",
-      "blokada-i6xR.log",
+      "Library/Application Support/Blokada/blokada-i6xR.log",
       "--destination",
       result.fullArtifactPath
     ]

--- a/ios/App/Binding/CoreBinding.swift
+++ b/ios/App/Binding/CoreBinding.swift
@@ -157,9 +157,34 @@ class CoreBinding: CoreOps {
 
     func getFilename(_ file: String) -> URL? {
         let fileManager = FileManager.default
-        return fileManager.containerURL(
+        guard let container = fileManager.containerURL(
             forSecurityApplicationGroupIdentifier: "group.net.blocka.app"
-        )?.appendingPathComponent(file)
+        ) else {
+            return nil
+        }
+
+        // Keep logs in the shared group (the network extension writes here too)
+        // but under the standard Library hierarchy: devicectl on Xcode 26.5+ can
+        // only list/copy files inside Library/, not files at the container root
+        // or in custom top-level dirs, so those are unreachable for host-side
+        // log fetching.
+        let logsDir = container.appendingPathComponent(LoggerSaver.logSubdirectory, isDirectory: true)
+        try? fileManager.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        guard !file.isEmpty else {
+            return logsDir
+        }
+
+        let target = logsDir.appendingPathComponent(file)
+
+        // Preserve the existing append-only log previously written to the root.
+        let legacy = container.appendingPathComponent(file)
+        if fileManager.fileExists(atPath: legacy.path),
+           !fileManager.fileExists(atPath: target.path) {
+            try? fileManager.moveItem(at: legacy, to: target)
+        }
+
+        return target
     }
 
     // Persistence

--- a/ios/App/ServiceImpl/LoggerSaver.swift
+++ b/ios/App/ServiceImpl/LoggerSaver.swift
@@ -14,10 +14,31 @@ import Foundation
 
 class LoggerSaver {
 
+    // Logs live in the shared group (so the network extension can write too) but
+    // under the standard Library hierarchy: devicectl on Xcode 26.5+ can only
+    // list/copy files inside the standard Library/ subtree, not files at the
+    // container root or in custom top-level directories. Must match the
+    // extension's NELogger copy and CoreBinding.
+    static let logSubdirectory = "Library/Application Support/Blokada"
+
     static var logFile: URL? {
         let fileManager = FileManager.default
-        return fileManager.containerURL(
-            forSecurityApplicationGroupIdentifier: "group.net.blocka.app")?.appendingPathComponent("blokada.log")
+        guard let container = fileManager.containerURL(
+            forSecurityApplicationGroupIdentifier: "group.net.blocka.app") else {
+            return nil
+        }
+
+        let logsDir = container.appendingPathComponent(logSubdirectory, isDirectory: true)
+        try? fileManager.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        let target = logsDir.appendingPathComponent("blokada.log")
+        let legacy = container.appendingPathComponent("blokada.log")
+        if fileManager.fileExists(atPath: legacy.path),
+           !fileManager.fileExists(atPath: target.path) {
+            try? fileManager.moveItem(at: legacy, to: target)
+        }
+
+        return target
     }
 
     private static var formatter: DateFormatter {

--- a/ios/WireguardCopiedFilesExtension/NELogger.swift
+++ b/ios/WireguardCopiedFilesExtension/NELogger.swift
@@ -58,10 +58,30 @@ enum LogPrio: Int {
 }
 
 class LoggerSaver {
+    // Must match the app's LoggerSaver/CoreBinding subdirectory. Logs stay in
+    // the shared group but under the standard Library hierarchy because
+    // devicectl on Xcode 26.5+ can only list/copy files inside Library/, not
+    // the container root or custom top-level directories.
+    static let logSubdirectory = "Library/Application Support/Blokada"
+
     static var logFile: URL? {
         let fileManager = FileManager.default
-        return fileManager.containerURL(
-            forSecurityApplicationGroupIdentifier: "group.net.blocka.app")?.appendingPathComponent("blokada.log")
+        guard let container = fileManager.containerURL(
+            forSecurityApplicationGroupIdentifier: "group.net.blocka.app") else {
+            return nil
+        }
+
+        let logsDir = container.appendingPathComponent(logSubdirectory, isDirectory: true)
+        try? fileManager.createDirectory(at: logsDir, withIntermediateDirectories: true)
+
+        let target = logsDir.appendingPathComponent("blokada.log")
+        let legacy = container.appendingPathComponent("blokada.log")
+        if fileManager.fileExists(atPath: legacy.path),
+           !fileManager.fileExists(atPath: target.path) {
+            try? fileManager.moveItem(at: legacy, to: target)
+        }
+
+        return target
     }
 
     private static var formatter: DateFormatter {


### PR DESCRIPTION
## Summary

On Xcode 26.5 / iOS 26.5, `devicectl` can only list or copy files inside the app group's standard `Library/` hierarchy, not the container root. The app wrote its logs to the group root, so host-side fetching (the device-log automation / AI skill) broke with CoreDevice "ActionError error 3". The in-app Share log was unaffected.

- relocate logs into the group's `Library/Application Support/Blokada/` consistently across the Dart core logger (`CoreBinding`), the app native logger (`LoggerSaver`), and the network extension logger (`NELogger`); migrate existing root files so append-only history is preserved
- logs stay in the shared app group so the network extension (separate process) keeps writing to one place; the in-app Share log path is unchanged
- device-log automation: stop passing the rejected `--subdirectory .` and match the share log by basename so the subdirectory path is selected and copied

Tracker: blokadaorg/issue-tracker#314

## Test plan

- [x] `node --test automation/device/tests/*.test.mjs` (13/13)
- [x] built and ran a dev build on a physical iPhone (iOS 26.5); the tool fetched the real relocated logfile (`blokada-i6xR.log` + `blokada.log` under `Library/Application Support/Blokada/`)
- [ ] sanity check on the Family flavor
- [ ] confirm after a release ships (production builds write to the old root until then)