### PR TITLE
ios-sim: mock-traffic DoH generator for Mocked schemes

### DIFF
--- a/.agents/skills/appium/SKILL.md
+++ b/.agents/skills/appium/SKILL.md
@@ -34,6 +34,38 @@ Notes:
 - Appium does not manage iOS auto-lock for us. Before a long session, set Auto-Lock to `Never` or the longest available value and keep the device unlocked before starting.
 - The process stays open and accepts JSONL commands on stdin.
 
+## Simulator mode (mocked builds)
+
+The same explorer drives an iOS Simulator running a Mocked / FamilyMocked
+build, not just a physical device. Use this when verifying mocked-scheme work
+(`make run-{six,family}-mocked`) where there is no real tunnel and no connected
+phone. Opt in with `IOS_USE_SIM=1`; the harness then resolves the per-worktree
+sim from `make -C ios sim-status`, uses simulator capabilities (Appium-managed
+WDA, no signing identity), and skips the `devicectl` device-discovery the
+physical path needs. None of the "request elevated access" / connected-iPhone
+notes above apply in sim mode.
+
+```bash
+# interactive JSONL session against the per-worktree mocked sim
+IOS_USE_SIM=1 make appium-explore-session
+# family flavor
+IOS_USE_SIM=1 APP_FLAVOR=family make appium-explore-session
+# reuse an already-installed/running mocked build, skip rebuild+reinstall
+IOS_USE_SIM=1 APP_INSTALL=0 make appium-explore-session
+```
+
+Prerequisites and gotchas:
+- `make run-{six,family}-mocked` must have created the sim first;
+  `appium-explore-session` does not provision it.
+- `sim-status` derives the sim name from `SIM_BASE` (default `iPhone 17`). If
+  you created the sim with a non-default base, pass the **same** `SIM_BASE`
+  here or the UDID will not resolve, e.g.
+  `IOS_USE_SIM=1 SIM_BASE="iPhone 15" make appium-explore-session`.
+- Run from the repo root (the target `cd`s into `automation/appium/wdio`
+  itself); do not run it from inside `wdio/`.
+- See `ios/SIMULATOR.md` ("Appium targeting") for the full sim flow and a raw
+  `appium --udid ...` fallback.
+
 ## Drive the session
 
 Send one JSON object per line to stdin. Wait for the terminal `done` or `error` event before sending the next command.

--- a/common/lib/main.dart
+++ b/common/lib/main.dart
@@ -114,6 +114,8 @@ Future<void> _startMocked() async {
   ));
 
   MockedStart().start();
+
+  startMockTraffic(flavor);
 }
 
 Widget _buildHome(Flavor flavor) {

--- a/common/lib/main_mocked_shared.dart
+++ b/common/lib/main_mocked_shared.dart
@@ -1,5 +1,9 @@
+import 'package:common/mock_traffic.dart';
+import 'package:common/src/app_variants/family/module/family/family.dart';
 import 'package:common/src/core/core.dart';
 import 'package:common/src/platform/account/account.dart';
+import 'package:common/src/platform/device/device.dart';
+import 'package:common/src/platform/perm/dnscheck.dart';
 import 'package:common/src/platform/stage/stage.dart';
 
 const _rawAccountId = String.fromEnvironment('ACCOUNT_ID');
@@ -58,4 +62,39 @@ Future<void> seedDevAccount(Flavor flavor) async {
     'type': type,
     'payment_source': 'mocked',
   }, isBackup: true);
+}
+
+// Mocked builds drive synthetic DoH lookups so the activity/stats UI has data
+// to show without a real tunnel. The endpoint resolver is flavor-specific.
+void startMockTraffic(Flavor flavor) {
+  if (flavor == Flavor.family) {
+    // Family DoH path is /{tag} — no alias component (see
+    // PrivateDnsCheck._getIosPrivateDnsStringFamily). Fire for the devices the
+    // parent app knows about (its own plus each linked kid), since there's no
+    // separate kid app running in the dev sim to generate their traffic. In
+    // linked/child mode the list is just this device, so it fires for itself.
+    // Capped to 5 tags so a dev account littered with throwaway devices doesn't
+    // fan out into excessive traffic.
+    MockTrafficGenerator(() {
+      return Core.get<FamilyDevicesValue>()
+          .now
+          .getTags()
+          .take(5)
+          .map((tag) => Uri.parse('https://cloud.blokada.org/$tag'))
+          .toList();
+    }).start();
+  } else {
+    // v6 DoH path is /{tag}/{alias} — the resolver uses both to identify the
+    // device. Delegate the exact URL construction to PrivateDnsCheck so the
+    // mock fires at the same path the production iOS app would set; building it
+    // here by hand drifted (it copied the Android alias rule, not the iOS one).
+    MockTrafficGenerator(() {
+      final device = Core.get<DeviceStore>();
+      final tag = device.deviceTag;
+      if (tag == null || tag.isEmpty) return const [];
+      final url = Core.get<PrivateDnsCheck>()
+          .getIosPrivateDnsStringV6(Markers.start, tag, device.deviceAlias);
+      return url.isEmpty ? const [] : [Uri.parse(url)];
+    }).start();
+  }
 }

--- a/common/lib/mock_traffic.dart
+++ b/common/lib/mock_traffic.dart
@@ -1,0 +1,141 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+
+// Mocked-only ambient traffic generator. Fires DoH queries straight at the
+// device's cloud.blokada.org DoH endpoint so the dev account's stats
+// pipeline records real queries and Privacy Pulse / Activity render with a
+// natural-looking 24h histogram and toplist. Without this the screens stay
+// on "waiting for data" because the simulator's OS DNS isn't routed through
+// Blokada (PrivateDnsService is mocked).
+//
+// Bypasses HttpChannel and uses package:http directly: that channel
+// serializes payloads via String.utf8 and only accepts 200, neither of
+// which fits a binary DNS wire-format request. Acceptable because this
+// module only runs under Core.act.isMocked.
+class MockTrafficGenerator {
+  // Returns the set of per-device DoH endpoints to POST queries to, empty if
+  // no device tag is resolved yet. Callers build the flavor-specific paths:
+  // family fans out across every known device tag (/{tag} per linked kid plus
+  // the parent's own), v6 is a single /{tag}/{alias-escaped}. The resolver
+  // associates queries with a device by parsing the path. Re-read every loop
+  // so devices linked/unlinked at runtime are picked up without a restart.
+  final List<Uri> Function() _resolveEndpoints;
+
+  final Random _rnd = Random();
+  bool _started = false;
+
+  MockTrafficGenerator(this._resolveEndpoints);
+
+  void start() {
+    if (_started) return;
+    _started = true;
+    unawaited(_runBurstLoop());
+  }
+
+  // Real DNS traffic isn't uniform: a page load fans out a burst of
+  // queries clustered in seconds, then the device idles. Mimic that so the
+  // 24h histogram in stats UI doesn't look like a metronome. Each burst is
+  // attributed to one randomly-picked device, so in family every linked kid
+  // row populates over time rather than only the parent's own device.
+  Future<void> _runBurstLoop() async {
+    while (true) {
+      final endpoints = _resolveEndpoints();
+      if (endpoints.isEmpty) {
+        await Future.delayed(const Duration(seconds: 1));
+        continue;
+      }
+      final endpoint = endpoints[_rnd.nextInt(endpoints.length)];
+      final burstSize = 3 + _rnd.nextInt(13); // 3..15
+      for (var i = 0; i < burstSize; i++) {
+        unawaited(_fireOne(endpoint, _pickDomain()));
+        await Future.delayed(Duration(milliseconds: 50 + _rnd.nextInt(400)));
+      }
+      await Future.delayed(Duration(seconds: 20 + _rnd.nextInt(160))); // 20s..3min
+    }
+  }
+
+  String _pickDomain() {
+    final pool = _rnd.nextDouble() < 0.25 ? _blockedPool : _allowedPool;
+    return pool[_rnd.nextInt(pool.length)];
+  }
+
+  Future<void> _fireOne(Uri endpoint, String domain) async {
+    try {
+      await http.post(
+        endpoint,
+        headers: const {'Content-Type': 'application/dns-message'},
+        body: _buildDohQuery(domain),
+      );
+    } catch (_) {
+      // Best-effort dev tool. Network blips, simulator offline, resolver
+      // 5xx — none of it should ever surface in the UI.
+    }
+  }
+}
+
+Uint8List _buildDohQuery(String domain) {
+  final b = BytesBuilder();
+  // Header: id=0, flags=0x0100 (standard query, RD=1), QDCOUNT=1, others=0.
+  // Resolver ignores the id on DoH, so a fixed zero is fine.
+  b.add(const [0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0]);
+  for (final label in domain.split('.')) {
+    final bytes = utf8.encode(label);
+    b.addByte(bytes.length);
+    b.add(bytes);
+  }
+  b.addByte(0); // root label
+  b.add(const [0, 1, 0, 1]); // QTYPE=A, QCLASS=IN
+  return b.toBytes();
+}
+
+// Domains verified against landing-github-pages/mirror/v5/oisd/small (v6
+// default) and d3host/standard (family default) on 2026-05-22. Categorical
+// picks (ad/analytics/attribution SDK endpoints) so the set is stable as
+// the lists evolve. If the natural-probability of blocked drifts, re-check
+// these against the same two lists.
+const _blockedPool = [
+  // d3host/standard — apex blocked, so every subdomain hits
+  'chartboost.com',
+  'criteo.com',
+  'googlesyndication.com',
+  'unityads.unity3d.com',
+  // oisd/small — specific subdomains
+  'adm.hotjar.com',
+  'api.mixpanel.com',
+  'decide.mixpanel.com',
+  'api.appsflyer.com',
+  'attr.appsflyer.com',
+  'api2.branch.io',
+  'census-app.scorecardresearch.com',
+  'doubleclick.de',
+];
+
+const _allowedPool = [
+  'apple.com',
+  'icloud.com',
+  'gstatic.com',
+  'wikipedia.org',
+  'github.com',
+  'cloudflare.com',
+  'reddit.com',
+  'news.ycombinator.com',
+  'nytimes.com',
+  'bbc.co.uk',
+  'spotify.com',
+  'youtube.com',
+  'stackoverflow.com',
+  'mozilla.org',
+  'archlinux.org',
+  'cnn.com',
+  'amazonaws.com',
+  'shopify.com',
+  'discord.com',
+  'twitch.tv',
+  'imgur.com',
+  'medium.com',
+  'duckduckgo.com',
+];

--- a/common/lib/src/platform/perm/dnscheck.dart
+++ b/common/lib/src/platform/perm/dnscheck.dart
@@ -19,7 +19,7 @@ class PrivateDnsCheck with Actor, Logging {
 
     log(m).pair("current dns", line);
 
-    var expected = _getIosPrivateDnsStringV6(m, tag, alias);
+    var expected = getIosPrivateDnsStringV6(m, tag, alias);
 
     if (Core.act.isAndroid && Core.act.flavor == Flavor.family) {
       expected = getAndroidPrivateDnsStringFamily(m, tag);
@@ -54,7 +54,7 @@ class PrivateDnsCheck with Actor, Logging {
     }
   }
 
-  String _getIosPrivateDnsStringV6(Marker m, DeviceTag tag, String alias) {
+  String getIosPrivateDnsStringV6(Marker m, DeviceTag tag, String alias) {
     try {
       final name = _escapeAlias(alias);
       return "https://cloud.blokada.org/$tag/$name";

--- a/ios/SIMULATOR.md
+++ b/ios/SIMULATOR.md
@@ -64,10 +64,12 @@ From `ios/`:
 ACCOUNT_ID=xxx make run-six-mocked      # or run-family-mocked
 ```
 
-First invocation auto-clones a sim named `iPhone 16 - <parent-dir>`.
+First invocation auto-clones a sim named `iPhone 17 - <parent-dir>`.
 Worktrees each get their own, so two checkouts can run in parallel.
 
 Overrides: `SIM_BASE="iPhone 15"`, `NAME=custom`, `SIM_TEMPLATE="warm sim"`.
+`SIM_BASE` defaults to `iPhone 17` (what a current Xcode installs); if that
+model isn't installed, pass one from `xcrun simctl list devices available`.
 
 ## When to use what
 
@@ -94,7 +96,10 @@ IOS_USE_SIM=1 APP_INSTALL=0 make appium-explore-session
 ```
 
 `make run-{six,family}-mocked` must have been run at least once for the sim
-to exist; `appium-explore-session` does not provision the sim itself.
+to exist; `appium-explore-session` does not provision the sim itself. If you
+created the sim with a non-default `SIM_BASE`, pass the same value here so
+`sim-status` resolves the matching UDID (e.g.
+`IOS_USE_SIM=1 SIM_BASE="iPhone 15" make appium-explore-session`).
 
 Raw bash equivalent if you'd rather drive Appium directly:
 
@@ -105,7 +110,7 @@ appium --udid "$SIM_UDID" ...
 
 ## Warm-state template
 
-Default clones from a fresh `iPhone 16`, so first launch in each new
+Default clones from a fresh `iPhone 17`, so first launch in each new
 checkout has to redo onboarding. To skip that, pre-warm one sim and
 point clones at it via `SIM_TEMPLATE`:
 

--- a/ios/make/sim-helpers.mk
+++ b/ios/make/sim-helpers.mk
@@ -9,13 +9,16 @@
 #
 # Variables (override on the make command line):
 #   NAME         per-checkout label; defaults to basename of CURDIR/..
-#   SIM_BASE     iPhone model used in the sim name (default: iPhone 16)
+#   SIM_BASE     iPhone model used in the sim name (default: iPhone 17).
+#                Must be an installed simulator model — check with
+#                `xcrun simctl list devices available`. iPhone 17 is what a
+#                current Xcode installs by default; override if yours differs.
 #   SIM_TEMPLATE source sim to clone from (default: $(SIM_BASE) — fresh)
 #                Set to a pre-warmed sim name to seed each new clone
 #                with that sim's state (onboarding, logged in, etc.).
 
 NAME         ?= $(notdir $(abspath $(CURDIR)/..))
-SIM_BASE     ?= iPhone 16
+SIM_BASE     ?= iPhone 17
 SIM_TEMPLATE ?= $(SIM_BASE)
 SIM_NAME     := $(SIM_BASE) - $(NAME)
 


### PR DESCRIPTION
## Summary

Mocked / FamilyMocked sim builds have no real tunnel, so the activity and stats UI starts empty. This adds a synthetic DoH traffic generator that fires real DNS-over-HTTPS lookups against the per-device Blokada endpoint, populating the stats backend so the live UI shows data while iterating on UX.

- `mock_traffic.dart`: `MockTrafficGenerator` fires binary DNS wire-format DoH queries in bursts against an endpoint resolver, drawing from blocked/allowed domain pools. Errors are swallowed so a flaky network never disrupts a session.
- `main_mocked_shared.dart`: `startMockTraffic(Flavor)` wires the generator with a flavor-specific resolver (family `/{tag}`, v6 `/{tag}/{alias}` via `PrivateDnsCheck`). Kept out of `main.dart` so release entrypoints stay free of mock wiring.
- `dnscheck.dart`: exposes `getIosPrivateDnsStringV6` so the v6 resolver reuses the canonical URL builder instead of reconstructing it.

Tooling and docs (defaulting the sim and documenting Appium against it, motivated by an Xcode runtime upgrade that dropped iPhone 16):

- `sim-helpers.mk`: `SIM_BASE` default iPhone 16 to iPhone 17 (current Xcode default), with a note to override if the model isn't installed.
- `SIMULATOR.md`, appium `SKILL.md`: document running the Appium explorer against the per-worktree mocked sim (`IOS_USE_SIM=1`), with the `SIM_BASE`-must-match gotcha.

## Verification

- Booted a fresh mocked sim clone (v6 dev account seeded), confirmed `appStatus = AppStatus.activatedCloud`.
- Drove the live UI via Appium: home blocked counters incrementing, Privacy Pulse donut populated, Activity feed streaming the mock-pool domains timestamped live.
- Re-verified after moving the wiring out of `main.dart`.

## Notes

- Mocked is Debug-only and the generator only starts in mocked builds; dead-code-eliminated from release AOT.
- The generator hits production DoH endpoints for the seeded dev account, same as any real device on that account.