### PR TITLE
Add dependency maintenance automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,127 @@
+version: 2
+updates:
+  - package-ecosystem: "pub"
+    directory: "/common"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    groups:
+      flutter-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      flutter-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "cocoapods"
+    directory: "/ios"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    groups:
+      ios-pods:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      ios-pods-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gradle"
+    directory: "/android"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    groups:
+      android-gradle:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      android-gradle-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/ios/BlockaWebExtension"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    groups:
+      safari-extension-npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      safari-extension-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/automation/appium/wdio"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    groups:
+      appium-wdio-npm:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      appium-wdio-npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:30"
+      timezone: "Europe/Madrid"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/appium-smoke.yml
+++ b/.github/workflows/appium-smoke.yml
@@ -1,20 +1,22 @@
 name: Appium smoke (iOS, physical device)
 
 on:
-  pull_request_target:
-    branches: [main]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
   contents: read
 
-# Per-PR group: a new push to a PR coalesces that PR's own pending run
-# (latest commit wins), but different PRs use different groups so none are
-# dropped. workflow_dispatch runs get a unique group (run_id) so they always
-# run. Cross-PR / cross-workflow device exclusion is provided by the single
-# self-hosted ios-physical runner (one job at a time), not by this group.
+# Per-branch group: a new push to a branch coalesces that branch's own pending
+# run after CI succeeds (latest commit wins), but different branches use
+# different groups so none are dropped. workflow_dispatch runs get a unique
+# group (run_id) so they always run. Cross-PR / cross-workflow device exclusion
+# is provided by the single self-hosted ios-physical runner (one job at a time),
+# not by this group.
 concurrency:
-  group: appium-smoke-${{ github.event.pull_request.number || github.run_id }}
+  group: appium-smoke-${{ github.event.workflow_run.head_branch || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -23,8 +25,9 @@ jobs:
     timeout-minutes: 30
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event.workflow_run.event == 'pull_request' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
@@ -32,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Bootstrap Flutter common lib
         run: make -C common build-ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  flutter_analyze:
+    name: Flutter analyze
+    runs-on: [self-hosted, macOS, ARM64, build-only]
+    timeout-minutes: 45
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Analyze Flutter module
+        working-directory: common
+        run: |
+          make pub gen
+          fvm flutter analyze --no-fatal-warnings --no-fatal-infos
+
+  ios_build:
+    name: iOS build
+    runs-on: [self-hosted, macOS, ARM64, build-only]
+    timeout-minutes: 120
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      SHOW_XCODE_LOG: "0"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Bootstrap Flutter common lib
+        run: make -C common build-ios
+
+      - name: Install iOS pods
+        working-directory: ios
+        run: |
+          bundle check || bundle install
+          bundle exec pod install
+
+      - name: Build iOS six debug
+        run: make -C ios check CHECK_SCHEME=Dev CHECK_CONFIG=Debug
+
+      - name: Build iOS family debug
+        run: make -C ios check CHECK_SCHEME=FamilyDev CHECK_CONFIG=Debug
+
+  android_assemble:
+    name: Android assemble
+    runs-on: [self-hosted, macOS, ARM64, build-only]
+    timeout-minutes: 120
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      LANG: en_US.UTF-8
+      LC_ALL: en_US.UTF-8
+      GRADLE_OPTS: -Dorg.gradle.unsafe.disable.watch-fs=true -Dorg.gradle.vfs.watch=false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Build Flutter Android debug library
+        run: make regen-android
+
+      - name: Assemble Android debug apps
+        run: make -C android apk-family-debug apk-six-debug

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -7,6 +7,11 @@ on:
 
 jobs:
   dependabot-auto-merge:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot auto-merge
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  dependabot-auto-merge:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pull-requests: read
+    uses: blokadaorg/workflows/.github/workflows/dependabot-auto-merge.yml@main
+    with:
+      allowed_files_regex: >-
+        ^(common/pubspec\.(yaml|lock)|ios/(Podfile|Podfile\.lock)|android/(build\.gradle|settings\.gradle|gradle\.properties|gradle/wrapper/gradle-wrapper\.(jar|properties)|app/build\.gradle)|ios/BlockaWebExtension/(package\.json|package-lock\.json)|automation/appium/wdio/(package\.json|package-lock\.json)|\.github/dependabot\.yml|\.github/workflows/[^/]+\.ya?ml)$
+    secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 
 ios/Pods
-ios/Podfile.lock
 
 local.properties
 keystore.properties
@@ -26,6 +25,8 @@ automation/appium/.appium/
 automation/appium/wdio/node_modules/
 automation/appium/wdio/.npmrc
 automation/device/output/
+ios/BlockaWebExtension/node_modules/
+ios/BlockaWebExtension/tests/node_modules/
 !.appiumrc.yaml
 
 *.log
@@ -40,4 +41,3 @@ ios/*.dSYM.zip
 
 # Local-only planning artifacts (Claude / superpowers)
 docs/superpowers/plans/
-

--- a/common/analysis_options.yaml
+++ b/common/analysis_options.yaml
@@ -9,6 +9,8 @@ analyzer:
     - lib/main-widgets.dart
     - libgen/**
     - build/**
+    - "**/*.g.dart"
+    - "**/*.mocks.dart"
   errors:
     file_names: ignore
     # Re-enable unused code signals to keep the codebase tidy.

--- a/ios/BlockaWebExtension/Makefile
+++ b/ios/BlockaWebExtension/Makefile
@@ -7,19 +7,19 @@ test:
 
 e2e: e2e-setup
 	@echo "Running E2E tests with screenshots..."
-	cd tests && npm test
-	@echo "✅ E2E tests complete!"
-	@echo "📸 Screenshots saved to: tests/ui/screenshots/"
+	npm test
+	@echo "E2E tests complete"
+	@echo "Screenshots saved to: tests/ui/screenshots/"
 
 e2e-setup:
 	@echo "Setting up E2E tests..."
-	@if [ ! -d "tests/node_modules" ]; then \
+	@if [ ! -d "node_modules" ]; then \
 		echo "Installing dependencies..."; \
-		cd tests && npm install; \
+		npm install; \
 	fi
-	@if [ ! -f "tests/node_modules/.bin/playwright" ] || [ ! -d "tests/node_modules/@playwright/test/lib/server/chromium" ]; then \
+	@if [ ! -f "node_modules/.bin/playwright" ] || [ ! -d "node_modules/@playwright/test/lib/server/chromium" ]; then \
 		echo "Installing Playwright browsers..."; \
-		cd tests && npm run install-playwright; \
+		npm run install-playwright; \
 	fi
 
 # Generate Safari Web Extension rules from domain lists

--- a/ios/BlockaWebExtension/package.json
+++ b/ios/BlockaWebExtension/package.json
@@ -4,11 +4,11 @@
   "type": "module",
   "description": "UI tests for BlockaWeb Safari extension popup",
   "scripts": {
-    "test": "playwright test",
-    "test:headed": "playwright test --headed",
-    "test:ui": "playwright test --ui",
+    "test": "playwright test -c tests/playwright.config.js",
+    "test:headed": "playwright test -c tests/playwright.config.js --headed",
+    "test:ui": "playwright test -c tests/playwright.config.js --ui",
     "test:clean": "npm run clean && npm test",
-    "clean": "rm -rf ui/screenshots/* test-results/* test-results.json test-results.xml",
+    "clean": "rm -rf tests/ui/screenshots/* tests/test-results/* tests/test-results.json tests/test-results.xml",
     "install-playwright": "playwright install webkit"
   },
   "devDependencies": {

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,134 @@
+PODS:
+  - Adapty (3.11.1)
+  - adapty_flutter (3.11.1):
+    - Adapty (= 3.11.1)
+    - AdaptyPlugin (= 3.11.1)
+    - AdaptyUI (= 3.11.1)
+    - Flutter
+  - AdaptyPlugin (3.11.1):
+    - Adapty (= 3.11.1)
+    - AdaptyUI (= 3.11.1)
+  - AdaptyUI (3.11.1):
+    - Adapty (= 3.11.1)
+  - FirebaseCore (12.12.1):
+    - FirebaseCoreInternal (~> 12.12.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Logger (~> 8.1)
+  - FirebaseCoreInternal (12.12.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
+  - FirebaseInstallations (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (12.12.0):
+    - FirebaseCore (~> 12.12.0)
+    - FirebaseInstallations (~> 12.12.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/Reachability (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
+  - Flutter (1.0.0)
+  - FlutterPluginRegistrant (0.0.1):
+    - adapty_flutter
+    - Flutter
+    - path_provider_foundation
+    - sqflite_darwin
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (8.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - PromisesObjC (2.4.0)
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - adapty_flutter (from `../common/.ios/.symlinks/plugins/adapty_flutter/ios`)
+  - FirebaseCore
+  - FirebaseMessaging
+  - Flutter (from `../common/.ios/Flutter`)
+  - FlutterPluginRegistrant (from `../common/.ios/Flutter/FlutterPluginRegistrant`)
+  - path_provider_foundation (from `../common/.ios/.symlinks/plugins/path_provider_foundation/darwin`)
+  - sqflite_darwin (from `../common/.ios/.symlinks/plugins/sqflite_darwin/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - Adapty
+    - AdaptyPlugin
+    - AdaptyUI
+    - FirebaseCore
+    - FirebaseCoreInternal
+    - FirebaseInstallations
+    - FirebaseMessaging
+    - GoogleDataTransport
+    - GoogleUtilities
+    - nanopb
+    - PromisesObjC
+
+EXTERNAL SOURCES:
+  adapty_flutter:
+    :path: "../common/.ios/.symlinks/plugins/adapty_flutter/ios"
+  Flutter:
+    :path: "../common/.ios/Flutter"
+  FlutterPluginRegistrant:
+    :path: "../common/.ios/Flutter/FlutterPluginRegistrant"
+  path_provider_foundation:
+    :path: "../common/.ios/.symlinks/plugins/path_provider_foundation/darwin"
+  sqflite_darwin:
+    :path: "../common/.ios/.symlinks/plugins/sqflite_darwin/darwin"
+
+SPEC CHECKSUMS:
+  Adapty: acfd515166328461979c903a08aa0a9e55cf0d65
+  adapty_flutter: 5532acc582261290054d88ddf32b81d308ad8957
+  AdaptyPlugin: d1a6e35d9f1b7b750e8772adefc89583c0a4c7f7
+  AdaptyUI: 8dc77880549ff2be797bc7ecfd60c4ad3633bf4b
+  FirebaseCore: 86241206e656f5c80c995e370e6c975913b9b284
+  FirebaseCoreInternal: 7c12fc3011d889085e765e317d7b9fd1cef97af9
+  FirebaseInstallations: 4e6e162aa4abaaeeeb01dd00179dfc5ad9c2194e
+  FirebaseMessaging: 341004946fa7ffc741344b20f1b667514fc93e31
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  FlutterPluginRegistrant: 4460963b523c8c665ce9e4c50cf31b979e869b35
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+
+PODFILE CHECKSUM: aa0b9301ebdc4887e479cad78bb18143509e8888
+
+COCOAPODS: 1.16.2


### PR DESCRIPTION
## Summary

  Adds first-class dependency maintenance automation for Blokada.

  This introduces PR-time CI, explicit Dependabot coverage for all dependency
  surfaces, and a Dependabot auto-merge wrapper using the shared `blokadaorg/
  workflows` reusable workflow.

  ## Changes

  - Add `.github/workflows/ci.yml`
    - Runs on PRs targeting `main`
    - Runs Flutter generation + analyzer
    - Builds iOS `Dev` and `FamilyDev` Debug simulator targets
    - Assembles Android `familyDebug` and `sixDebug`

  - Add `.github/dependabot.yml`
    - Covers Flutter/pub in `common/`
    - Covers CocoaPods in `ios/`
    - Covers Gradle in `android/`
    - Covers npm in `ios/BlockaWebExtension/`
    - Covers npm in `automation/appium/wdio/`
    - Covers GitHub Actions
    - Uses grouped minor/patch/security updates to reduce PR noise

  - Add `.github/workflows/dependabot-auto-merge.yml`
    - Runs after successful `CI`
    - Calls `blokadaorg/workflows/.github/workflows/dependabot-auto-merge.yml@main`
    - Passes a Blokada-specific dependency-file allowlist

  - Normalize Safari extension npm layout
    - Moves `ios/BlockaWebExtension/tests/package.json` to `ios/BlockaWebExtension/
  package.json`
    - Keeps Playwright tests/config under `tests/`
    - Updates Makefile npm commands accordingly

  - Start tracking `ios/Podfile.lock`
    - Removes it from `.gitignore`
    - Adds regenerated lockfile so CocoaPods Dependabot PRs have deterministic diffs

  - Analyzer adjustment
    - Excludes generated Dart files (`*.g.dart`, `*.mocks.dart`) from source
  analyzer checks so CI gates real source issues instead of generated MobX/mock
  output

## Stale Dependabot PR Cleanup

  Closed the existing stale Dependabot security PRs so they can regenerate under the
  new config and CI flow:

  - #1015
  - #1016
  - #1017
  - #1019

  ## Validation

  Ran:

  - YAML parse for new workflow/config files
  - `git diff --check`
  - `make pub gen`
  - `fvm flutter analyze --no-fatal-warnings --no-fatal-infos`
  - `make -C common build-ios`
  - `bundle exec pod install`
  - `make -C ios check CHECK_SCHEME=Dev CHECK_CONFIG=Debug`
  - `make -C ios check CHECK_SCHEME=FamilyDev CHECK_CONFIG=Debug`
  - `make regen-android`
  - `make -C android apk-family-debug apk-six-debug`
  - `npm --prefix ios/BlockaWebExtension ci --ignore-scripts`
  - `npm --prefix ios/BlockaWebExtension test -- --list`

  ## Notes

  `npm ci` for the Safari extension reports 2 high severity vulnerabilities. This is
  expected to be picked up by the newly added Dependabot npm coverage.