### PR TITLE
Family: update linking device in place instead of recreating it

### DIFF
--- a/common/lib/src/app_variants/family/module/device_v3/actor.dart
+++ b/common/lib/src/app_variants/family/module/device_v3/actor.dart
@@ -137,7 +137,12 @@ class DeviceActor with Logging, Actor {
     }
   }
 
-  changeDeviceProfile(JsonDevice device, JsonProfile profile, Marker m) async {
+  // [select] also makes [profile] the currently selected one, rewriting this
+  // device's own filter config. That is wrong while linking a child device, so
+  // the link flow passes select: false to only post the device's new profile.
+  Future<JsonDevice> changeDeviceProfile(
+      JsonDevice device, JsonProfile profile, Marker m,
+      {bool select = true}) async {
     log(m).i("changing profile of ${device.deviceTag} to ${profile.alias}");
     final draft = JsonDevice(
       deviceTag: device.deviceTag,
@@ -152,7 +157,7 @@ class DeviceActor with Logging, Actor {
       final updated =
           await _devices.changeProfile(device, profile.profileId, m);
       _commit(updated);
-      await _profiles.selectProfile(m, profile);
+      if (select) await _profiles.selectProfile(m, profile);
       return updated;
     } catch (e) {
       _commit(old);

--- a/common/lib/src/app_variants/family/module/family/link_actor.dart
+++ b/common/lib/src/app_variants/family/module/family/link_actor.dart
@@ -52,6 +52,56 @@ class LinkActor with Logging, Actor {
     });
   }
 
+  // Updates the name and/or profile of the device currently being linked,
+  // without minting a new token or device tag. The token and QR stay valid, so
+  // a child that already scanned keeps linking, and the live profile picker
+  // keeps pointing at an existing device.
+  Future<LinkingDevice?> updateLinkingDevice({
+    String? name,
+    JsonProfile? profile,
+    required Marker m,
+  }) async {
+    return await log(m).trace("updateLinkingDevice", (m) async {
+      final current = _linkingDevice;
+      // The link can finish (heartbeat) or be cancelled (dispose) while an edit
+      // dialog is still open. A tap after that is a no-op, not an error thrown
+      // into the UI caller's uncaught Future.
+      if (current == null) return null;
+
+      // The session can finish, be cancelled, or be replaced by a newer edit
+      // while we await network calls below. If it does, abort instead of writing
+      // _linkingDevice back to a stale (or deleted) device. cancelLinkDevice
+      // already deleted that device, so resurrecting it would leak state.
+      bool sessionGone() => !identical(_linkingDevice, current);
+
+      var device = current.device;
+      if (name != null) {
+        device = await _device.renameDevice(device, name, m);
+        if (sessionGone()) return null;
+      }
+
+      var newProfile = current.profile;
+      if (profile != null && profile.profileId != device.profileId) {
+        // select: false, the linking device is a child, changing its profile
+        // must not rewrite this (parent) device's own filter config.
+        device = await _device.changeDeviceProfile(device, profile, m,
+            select: false);
+        if (sessionGone()) return null;
+        newProfile = profile;
+      }
+
+      final updated = LinkingDevice(
+        device: device,
+        relink: current.relink,
+        profile: newProfile,
+      );
+      updated.token = current.token;
+      updated.qrUrl = current.qrUrl;
+      _linkingDevice = updated;
+      return updated;
+    });
+  }
+
   cancelLinkDevice(Marker m) async {
     return await log(m).trace("cancelAddDevice", (m) async {
       if (_linkingDevice == null) return;

--- a/common/lib/src/app_variants/family/widget/home/link_device_sheet.dart
+++ b/common/lib/src/app_variants/family/widget/home/link_device_sheet.dart
@@ -62,6 +62,21 @@ class LinkDeviceSheetState extends State<LinkDeviceSheet> with Logging {
     });
   }
 
+  // Updates the device being linked in place. Unlike _setDeviceTemplate it does
+  // not recreate the device or token, so the QR stays valid and the profile
+  // picker keeps pointing at a live device (avoids the gray-area glitch and the
+  // already-scanned child being orphaned).
+  _updateDeviceTemplate({String? name, JsonProfile? profile}) async {
+    await log(Markers.ui).trace("updateDeviceAdding", (m) async {
+      // null when the link already finished or was cancelled; nothing to update.
+      final updated = await _familyLink.updateLinkingDevice(
+          name: name, profile: profile, m: m);
+      if (updated == null) return;
+      _payload = updated;
+      setState(() {});
+    });
+  }
+
   String _getProbablyUniqueRandomName() {
     final existing =
         _family.devices.now.entries.map((e) => e.device.alias).toSet();
@@ -167,10 +182,8 @@ class LinkDeviceSheetState extends State<LinkDeviceSheet> with Logging {
                                                   "device",
                                                   _payload.device.alias,
                                                   onConfirm: (name) =>
-                                                      _setDeviceTemplate(
-                                                          name: name,
-                                                          profile: _payload
-                                                              .profile));
+                                                      _updateDeviceTemplate(
+                                                          name: name));
                                             },
                                             icon: CupertinoIcons
                                                 .device_phone_portrait,
@@ -188,8 +201,7 @@ class LinkDeviceSheetState extends State<LinkDeviceSheet> with Logging {
                                               showSelectProfileDialog(context,
                                                   device: _payload.device,
                                                   onSelected: (p) {
-                                                _setDeviceTemplate(
-                                                    name: _payload.device.alias,
+                                                _updateDeviceTemplate(
                                                     profile: p);
                                               });
                                             },

--- a/common/test/app_variants/family/module/family/link_actor_test.dart
+++ b/common/test/app_variants/family/module/family/link_actor_test.dart
@@ -1,0 +1,211 @@
+import 'package:common/src/app_variants/family/module/auth/auth.dart';
+import 'package:common/src/app_variants/family/module/device_v3/device.dart';
+import 'package:common/src/app_variants/family/module/family/family.dart';
+import 'package:common/src/app_variants/family/module/profile/profile.dart';
+import 'package:common/src/core/core.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../tools.dart';
+
+@GenerateNiceMocks([
+  MockSpec<DeviceActor>(),
+  MockSpec<AuthActor>(),
+])
+import 'link_actor_test.mocks.dart';
+
+void main() {
+  group('LinkActor.updateLinkingDevice', () {
+    test('renames without minting a new token or device tag', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        Core.register<DeviceActor>(device);
+        Core.register<AuthActor>(auth);
+
+        final original = _device('tag-1', 'Old name', 'child-profile');
+        final profile = _profile('child-profile', 'Child');
+
+        when(device.addDevice(any, any, any)).thenAnswer(
+            (_) async => LinkingDevice(device: original, profile: profile));
+        when(auth.createToken(any, any)).thenAnswer((_) async => 'token-1');
+
+        final actor = LinkActor();
+        final linking =
+            await actor.initiateLinkDevice('Old name', profile, null, m);
+        expect(linking.token, 'token-1');
+
+        clearInteractions(auth);
+        clearInteractions(device);
+
+        final renamed = _device('tag-1', 'New name', 'child-profile');
+        when(device.renameDevice(any, any, any))
+            .thenAnswer((_) async => renamed);
+
+        final updated = await actor.updateLinkingDevice(name: 'New name', m: m);
+
+        expect(updated!.device.deviceTag, 'tag-1');
+        expect(updated!.device.alias, 'New name');
+        expect(updated!.token, 'token-1');
+        expect(updated!.qrUrl, linking.qrUrl);
+        verify(device.renameDevice(any, 'New name', any)).called(1);
+        verifyNever(auth.createToken(any, any));
+        verifyNever(device.deleteDevice(any, any));
+        verifyNever(device.addDevice(any, any, any));
+      });
+    });
+
+    test('changes profile without regenerating the token or selecting it globally',
+        () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        Core.register<DeviceActor>(device);
+        Core.register<AuthActor>(auth);
+
+        final original = _device('tag-1', 'Name', 'child-profile');
+        final childProfile = _profile('child-profile', 'Child');
+        final teenProfile = _profile('teen-profile', 'Teen');
+
+        when(device.addDevice(any, any, any)).thenAnswer((_) async =>
+            LinkingDevice(device: original, profile: childProfile));
+        when(auth.createToken(any, any)).thenAnswer((_) async => 'token-1');
+
+        final actor = LinkActor();
+        final linking =
+            await actor.initiateLinkDevice('Name', childProfile, null, m);
+
+        clearInteractions(auth);
+        clearInteractions(device);
+
+        final reprofiled = _device('tag-1', 'Name', 'teen-profile');
+        when(device.changeDeviceProfile(any, any, any,
+                select: anyNamed('select')))
+            .thenAnswer((_) async => reprofiled);
+
+        final updated =
+            await actor.updateLinkingDevice(profile: teenProfile, m: m);
+
+        expect(updated!.device.deviceTag, 'tag-1');
+        expect(updated!.device.profileId, 'teen-profile');
+        expect(updated!.profile?.profileId, 'teen-profile');
+        expect(updated!.token, 'token-1');
+        expect(updated!.qrUrl, linking.qrUrl);
+        verify(device.changeDeviceProfile(any, any, any, select: false))
+            .called(1);
+        verifyNever(auth.createToken(any, any));
+        verifyNever(device.deleteDevice(any, any));
+      });
+    });
+
+    test('skips the profile API call when the profile is unchanged', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        Core.register<DeviceActor>(device);
+        Core.register<AuthActor>(auth);
+
+        final original = _device('tag-1', 'Name', 'child-profile');
+        final childProfile = _profile('child-profile', 'Child');
+
+        when(device.addDevice(any, any, any)).thenAnswer((_) async =>
+            LinkingDevice(device: original, profile: childProfile));
+        when(auth.createToken(any, any)).thenAnswer((_) async => 'token-1');
+
+        final actor = LinkActor();
+        await actor.initiateLinkDevice('Name', childProfile, null, m);
+
+        clearInteractions(auth);
+        clearInteractions(device);
+
+        final updated =
+            await actor.updateLinkingDevice(profile: childProfile, m: m);
+
+        expect(updated!.device.profileId, 'child-profile');
+        expect(updated!.profile?.profileId, 'child-profile');
+        expect(updated!.token, 'token-1');
+        verifyNever(device.changeDeviceProfile(any, any, any,
+            select: anyNamed('select')));
+        verifyNever(auth.createToken(any, any));
+      });
+    });
+
+    test('is a no-op when nothing is being linked', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        Core.register<DeviceActor>(device);
+        Core.register<AuthActor>(auth);
+
+        // No initiateLinkDevice: the link finished or was cancelled. A late tap
+        // from a still-open edit dialog must not throw into the UI.
+        final actor = LinkActor();
+
+        final result = await actor.updateLinkingDevice(
+            profile: _profile('child-profile', 'Child'), m: m);
+
+        expect(result, isNull);
+        verifyNever(device.renameDevice(any, any, any));
+        verifyNever(device.changeDeviceProfile(any, any, any,
+            select: anyNamed('select')));
+      });
+    });
+
+    test('does not resurrect a session cancelled while awaiting', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        Core.register<DeviceActor>(device);
+        Core.register<AuthActor>(auth);
+
+        final original = _device('tag-1', 'Old name', 'child-profile');
+        final profile = _profile('child-profile', 'Child');
+
+        when(device.addDevice(any, any, any)).thenAnswer(
+            (_) async => LinkingDevice(device: original, profile: profile));
+        when(auth.createToken(any, any)).thenAnswer((_) async => 'token-1');
+
+        final actor = LinkActor();
+        await actor.initiateLinkDevice('Old name', profile, null, m);
+
+        // The link is cancelled (e.g. sheet disposed) while the rename network
+        // call is in flight. The in-place update must not write the device back.
+        when(device.renameDevice(any, any, any)).thenAnswer((_) async {
+          await actor.cancelLinkDevice(m);
+          return _device('tag-1', 'New name', 'child-profile');
+        });
+
+        final result = await actor.updateLinkingDevice(name: 'New name', m: m);
+        expect(result, isNull);
+
+        // Session stays cleared: a follow-up edit is also a no-op, proving the
+        // cancelled device was not resurrected into _linkingDevice.
+        clearInteractions(device);
+        final again =
+            await actor.updateLinkingDevice(name: 'Another', m: m);
+        expect(again, isNull);
+        verifyNever(device.renameDevice(any, any, any));
+      });
+    });
+  });
+}
+
+JsonDevice _device(String tag, String alias, String profileId) {
+  return JsonDevice(
+    deviceTag: tag,
+    alias: alias,
+    mode: JsonDeviceMode.on,
+    retention: '24h',
+    profileId: profileId,
+  );
+}
+
+JsonProfile _profile(String id, String alias) {
+  return JsonProfile(
+    profileId: id,
+    alias: alias,
+    lists: const [],
+    safeSearch: false,
+  );
+}


### PR DESCRIPTION
## Problem

In the Family "link new device" flow, editing the device name or selecting a profile cancelled the link (deleting the in-flight device) and re-initiated it, minting a **new token, QR and device tag on every change**. Two bugs followed:

- Editing the name then quickly opening the profile picker showed a **gray area** — the picker was handed a device tag that had just been deleted mid-recreate, so its `build` dereferenced a missing tag.
- Changing the profile **after the child scanned the QR** deleted the tag the child had linked to, bouncing the child back to the start screen.

## Fix

- Add `LinkActor.updateLinkingDevice`, which renames / changes the profile on the **existing** device and keeps the same token, QR and device tag. No delete/add, no token regen, no heartbeat restart.
- The link sheet's name/profile edit callbacks now call this in-place update instead of the cancel+recreate path; `_setDeviceTemplate` (cancel+recreate) stays only for the initial device creation.
- `DeviceActor.changeDeviceProfile` gains a `select` flag (default `true`). The `selectProfile` side-effect rewrites *this* device's own filter config, which is wrong when configuring a child being linked, so the link flow passes `select: false`. The only other caller is unchanged.
- A late tap from a still-open edit dialog after the link finished or was cancelled is a no-op (`updateLinkingDevice` returns null) rather than throwing into the UI's uncaught Future.

## Tests

New `link_actor_test.dart`:
- rename keeps the same token + device tag (no `createToken`, no delete/add)
- profile change keeps the token and passes `select: false` (no global profile select)
- unchanged profile skips the API call
- no-op when nothing is being linked

All pass; analyzer clean on the changed files. (Run with the pinned fvm Flutter; generated `*.mocks.dart` is gitignored and regenerated by build_runner.)

Tracker: blokadaorg/issue-tracker#57

🤖 Generated with [Claude Code](https://claude.com/claude-code)