### PR TITLE
ci(dependabot-auto-merge): allow ios/Gemfile(.lock) in changed-file allowlist

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -88,7 +88,7 @@ jobs:
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           # Flutter/Gradle/iOS dependency-file surface for this repo. Any
           # changed path outside this allowlist triggers REQUEST_CHANGES.
-          ALLOWED_FILES_REGEX: '^(common/pubspec\.(yaml|lock)|ios/(Podfile|Podfile\.lock)|android/(build\.gradle|settings\.gradle|gradle\.properties|gradle/wrapper/gradle-wrapper\.(jar|properties)|app/build\.gradle)|ios/BlockaWebExtension/(package\.json|package-lock\.json)|automation/appium/wdio/(package\.json|package-lock\.json)|\.github/dependabot\.yml|\.github/workflows/[^/]+\.ya?ml)$'
+          ALLOWED_FILES_REGEX: '^(common/pubspec\.(yaml|lock)|ios/(Podfile|Podfile\.lock|Gemfile|Gemfile\.lock)|android/(build\.gradle|settings\.gradle|gradle\.properties|gradle/wrapper/gradle-wrapper\.(jar|properties)|app/build\.gradle)|ios/BlockaWebExtension/(package\.json|package-lock\.json)|automation/appium/wdio/(package\.json|package-lock\.json)|\.github/dependabot\.yml|\.github/workflows/[^/]+\.ya?ml)$'
         run: |
           set -euo pipefail
           title=$(gh pr view "$PR" --repo "$REPO" --json title --jq .title)


### PR DESCRIPTION
## Problem

Dependabot bundler security-update PRs for the iOS toolchain change only `ios/Gemfile.lock`. That path was outside the auto-merge workflow's `ALLOWED_FILES_REGEX`, so the deterministic pre-check rejected each one with **REQUEST_CHANGES — touches non-dependency file ios/Gemfile.lock** before the major-bump and Claude checks ever ran.

Affected open PRs: #1084, #1088, #1089, #1090, #1091 (each touches only `ios/Gemfile.lock`).

## Fix

Add `Gemfile|Gemfile\.lock` to the iOS group of the allowlist regex. Verified the updated pattern matches `ios/Gemfile` / `ios/Gemfile.lock` while still rejecting actual code (e.g. `ios/Sources/Main.swift`).

## Upstream note

No change in `blokadaorg/workflows`: there the regex is a parameterized `workflow_call` input defaulting to the Go-repo surface, and its consumers (`api`, `blockadns`, `status-check`) have no Gemfile. The iOS regex lives only in this vendored copy (public repo can't call the private reusable workflow), so there's nothing to mirror.

## Follow-up after merge

The five PRs above were already rejected; re-run their CI (rebase / close-reopen) so the auto-merge workflow re-evaluates them against the updated allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)