### PR TITLE
build(deps): bump i18n_extension from 12.0.1 to 15.1.1

### DIFF
--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -424,6 +424,11 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
   flyer_chat_text_message:
     dependency: "direct main"
     description:
@@ -516,18 +521,18 @@ packages:
     dependency: "direct main"
     description:
       name: i18n_extension
-      sha256: "296f7b091b9feb7f682360cece9c335f5b0b35121c31bd1993bbdcf1985c272e"
+      sha256: "86f988fe3d1e4f26d85e92e4f3ba622ea40c6daa5bfbb71938bde7d256d167e1"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "15.1.1"
   i18n_extension_core:
     dependency: transitive
     description:
       name: i18n_extension_core
-      sha256: "5e140a8fb5541bafc6596c2866e92b131b90d8bf759d5f5a7c7c5de5744819db"
+      sha256: "5d17d355b95882e803f89c97cad610ab7967a798f8e519563d274f7888bc968e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "5.0.2"
   i18n_extension_importer:
     dependency: "direct main"
     description:
@@ -912,6 +917,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.8.5"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   shelf:
     dependency: transitive
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter_mobx: ^2.0.6+4
   countup: ^0.1.4
   snapping_sheet: ^3.1.0
-  i18n_extension: ^12.0.1
+  i18n_extension: ^15.1.1
   relative_scale: ^2.0.0
   get_it: ^7.7.0
   collection: ^1.17.0

--- a/common/test/tools.dart
+++ b/common/test/tools.dart
@@ -17,7 +17,14 @@ withTrace(Future Function(Marker m) fn) async {
   Core.config = CoreConfig();
 
   Translations.missingKeyCallback = (_, __) {};
-  Translations.missingTranslationCallback = (_, __) {};
+  // i18n_extension 15 changed this to a named-param callback returning a bool
+  // that decides whether to record the miss; return false to keep tests quiet.
+  Translations.missingTranslationCallback = (
+          {required key,
+          required locale,
+          required translations,
+          required supportedLocales}) =>
+      false;
 
   try {
     final m = (goldenFileComparator as LocalFileComparator).basedir.pathSegments;


### PR DESCRIPTION
Splits the **i18n_extension** major out of the stuck grouped Dependabot bump (#1082) so it can land on its own.

## What changed
- `i18n_extension` 12.0.1 → 15.1.1 (and transitive `i18n_extension_core` 2.0.7 → 5.0.2)
- `i18n_extension` 15 changed `Translations.missingTranslationCallback` from a positional `(_, __)` void callback into a **named-parameter callback returning `bool`** (`{required key, locale, translations, supportedLocales}) => bool`, where the bool decides whether to record the miss). Updated the test helper in `common/test/tools.dart` to match — returns `false` to keep the missing-translation log quiet during tests, preserving the prior no-op behavior.

## Why this is safe to land alone
- Resolves cleanly under the pinned **Flutter 3.32.1 / Dart 3.8.1** — no SDK bump required (unlike the pigeon major in #1082, which needs Dart ≥3.9.0).
- The only non-generated source change is in a **test helper**; no runtime/UI surface touched.

## Note for review
- i18n_extension 15 now persists the selected locale via `shared_preferences`, so `shared_preferences` (+ its platform implementations) and `flutter_web_plugins` appear as **new transitive dependencies** in `pubspec.lock`. The iOS build / Android assemble CI jobs exercise native plugin registration.

## Verification
- `make test` → **all tests pass**
- `fvm flutter analyze --no-fatal-warnings --no-fatal-infos` → exit 0 (6 pre-existing warnings/infos, none in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)