### PR TITLE
build(deps): bump adapty_flutter from 3.11.4 to 3.17.0

### DIFF
--- a/.github/workflows/appium-ai-explore.yml
+++ b/.github/workflows/appium-ai-explore.yml
@@ -44,7 +44,10 @@ jobs:
         working-directory: ios
         run: |
           bundle check || bundle install
-          bundle exec pod install
+          # --repo-update so the runner's CocoaPods spec cache picks up newly
+          # released pod versions; without it `pod install` fails on
+          # "out-of-date source repos" for fresh specs.
+          bundle exec pod install --repo-update
 
       - name: Unlock login keychain for codesign
         env:

--- a/.github/workflows/appium-smoke.yml
+++ b/.github/workflows/appium-smoke.yml
@@ -44,7 +44,10 @@ jobs:
         working-directory: ios
         run: |
           bundle check || bundle install
-          bundle exec pod install
+          # --repo-update so the runner's CocoaPods spec cache picks up newly
+          # released pod versions; without it `pod install` fails on
+          # "out-of-date source repos" for fresh specs.
+          bundle exec pod install --repo-update
 
       - name: Unlock login keychain for codesign
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,10 @@ jobs:
         working-directory: ios
         run: |
           bundle check || bundle install
-          bundle exec pod install
+          # --repo-update so the runner's CocoaPods spec cache picks up newly
+          # released pod versions (e.g. dependency bumps); without it `pod
+          # install` fails on "out-of-date source repos" for fresh specs.
+          bundle exec pod install --repo-update
 
       - name: Build iOS six debug
         run: make -C ios check CHECK_SCHEME=Dev CHECK_CONFIG=Debug

--- a/common/lib/src/features/payment/domain/adapty.dart
+++ b/common/lib/src/features/payment/domain/adapty.dart
@@ -18,15 +18,19 @@ class AdaptyPaymentChannel with Logging, PaymentChannel implements AdaptyUIObser
   init(Marker m, String apiKey, String? accountId, bool verboseLogs) async {
     _adaptyUi.setObserver(this);
 
-    await _adapty.activate(
-      configuration: AdaptyConfiguration(apiKey: apiKey)
-        ..withCustomerUserId(accountId)
-        ..withLogLevel(verboseLogs ? AdaptyLogLevel.debug : AdaptyLogLevel.warn)
-        ..withObserverMode(false)
-        ..withIpAddressCollectionDisabled(true)
-        ..withGoogleAdvertisingIdCollectionDisabled(true)
-        ..withAppleIdfaCollectionDisabled(true),
-    );
+    // Adapty 3.17 made withCustomerUserId require a non-null String. accountId
+    // can be null at activation (anonymous start); only bind it when present,
+    // which matches the old nullable behaviour. When an account id exists it is
+    // also bound separately via identify(), so attribution is unaffected.
+    final configuration = AdaptyConfiguration(apiKey: apiKey)
+      ..withLogLevel(verboseLogs ? AdaptyLogLevel.debug : AdaptyLogLevel.warn)
+      ..withObserverMode(false)
+      ..withIpAddressCollectionDisabled(true)
+      ..withGoogleAdvertisingIdCollectionDisabled(true)
+      ..withAppleIdfaCollectionDisabled(true);
+    if (accountId != null) configuration.withCustomerUserId(accountId);
+
+    await _adapty.activate(configuration: configuration);
 
     // Set Adapty fallback for any connection problems situations
     try {
@@ -44,7 +48,15 @@ class AdaptyPaymentChannel with Logging, PaymentChannel implements AdaptyUIObser
 
   @override
   logOnboardingStep(String name, OnboardingStep step) async {
-    await _adapty.logShowOnboarding(name: name, screenName: step.name, screenOrder: step.order);
+    // Adapty 3.17 removed Adapty.logShowOnboarding (the manual onboarding-step
+    // analytics API) in favour of its hosted AdaptyUI onboarding views, which
+    // we don't use — onboarding is rendered by the app. There is no drop-in
+    // replacement for logging a custom step. The native Android path already
+    // no-op'd this on Adapty Android 3.15.x, so the Adapty-side onboarding
+    // analytics is gone app-wide; local step tracking in
+    // PaymentActor.reportOnboarding is unaffected.
+    log(Markers.ui)
+        .t("Adapty: skipping onboarding step '$name/${step.name}' (logShowOnboarding removed in 3.17)");
   }
 
   @override

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -12,10 +12,11 @@ packages:
   adapty_flutter:
     dependency: "direct main"
     description:
-      name: adapty_flutter
-      sha256: "5bbe23c13d44ddb592ab067d7067fa69c6b1c766437dda5e0d8c18cc074050cd"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "3755e279485487f82833fae01462799f87594c62"
+      resolved-ref: "3755e279485487f82833fae01462799f87594c62"
+      url: "https://github.com/blokadaorg/AdaptySDK-Flutter.git"
+    source: git
     version: "3.17.0"
   analyzer:
     dependency: transitive

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: "direct main"
     description:
       name: adapty_flutter
-      sha256: "34535c1315578c4dae68e01e2c8a8efcec401a619c62a115087b8f3be7a5e864"
+      sha256: "5bbe23c13d44ddb592ab067d7067fa69c6b1c766437dda5e0d8c18cc074050cd"
       url: "https://pub.dev"
     source: hosted
-    version: "3.11.4"
+    version: "3.17.0"
   analyzer:
     dependency: transitive
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -62,6 +62,18 @@ dependencies:
 
 dependency_overrides:
   intl: 0.20.2
+  # adapty_flutter 3.17.0 (latest) hardcodes kotlinOptions.jvmTarget = '1.8' in its
+  # android/build.gradle, but its Adapty native Android SDK (io.adapty:android-ui via
+  # adapty-bom 3.17.1) is compiled for JVM 11 and exposes inline functions used by the
+  # native paywall/onboarding views. Kotlin refuses to inline JVM-11 bytecode into a
+  # JVM-1.8 target, so `flutter build aar` fails at :adapty_flutter:compileReleaseKotlin
+  # ("Cannot inline bytecode built with JVM target 11 ... built with JVM target 1.8").
+  # Pin to a blokadaorg fork of the 3.17.0 tag that only raises the plugin to JVM 11.
+  # Remove once upstream ships the fix: https://github.com/adaptyteam/AdaptySDK-Flutter
+  adapty_flutter:
+    git:
+      url: https://github.com/blokadaorg/AdaptySDK-Flutter.git
+      ref: 3755e279485487f82833fae01462799f87594c62
 
 dev_dependencies:
   flutter_test:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -55,7 +55,7 @@ dependencies:
   flutter_chat_ui: ^2.6.0
   flyer_chat_text_message: ^2.0.0
   logger: ^2.4.0
-  adapty_flutter: 3.11.4
+  adapty_flutter: 3.17.0
   input_code_field: ^2.0.2
   flutter_linkify: ^6.0.0
   cached_network_image: ^3.3.1

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,15 +1,24 @@
 PODS:
-  - Adapty (3.11.1)
-  - adapty_flutter (3.11.1):
-    - Adapty (= 3.11.1)
-    - AdaptyPlugin (= 3.11.1)
-    - AdaptyUI (= 3.11.1)
+  - Adapty (3.17.2):
+    - AdaptyLogger (= 3.17.2)
+    - AdaptyUIBuilder (= 3.17.2)
+  - adapty_flutter (3.17.0):
+    - Adapty (= 3.17.2)
+    - AdaptyPlugin (= 3.17.2)
+    - AdaptyUI (= 3.17.2)
     - Flutter
-  - AdaptyPlugin (3.11.1):
-    - Adapty (= 3.11.1)
-    - AdaptyUI (= 3.11.1)
-  - AdaptyUI (3.11.1):
-    - Adapty (= 3.11.1)
+  - AdaptyLogger (3.17.2)
+  - AdaptyPlugin (3.17.2):
+    - Adapty (= 3.17.2)
+    - AdaptyLogger (= 3.17.2)
+    - AdaptyUI (= 3.17.2)
+    - AdaptyUIBuilder (= 3.17.2)
+  - AdaptyUI (3.17.2):
+    - Adapty (= 3.17.2)
+    - AdaptyLogger (= 3.17.2)
+    - AdaptyUIBuilder (= 3.17.2)
+  - AdaptyUIBuilder (3.17.2):
+    - AdaptyLogger (= 3.17.2)
   - FirebaseCore (12.12.1):
     - FirebaseCoreInternal (~> 12.12.0)
     - GoogleUtilities/Environment (~> 8.1)
@@ -88,8 +97,10 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Adapty
+    - AdaptyLogger
     - AdaptyPlugin
     - AdaptyUI
+    - AdaptyUIBuilder
     - FirebaseCore
     - FirebaseCoreInternal
     - FirebaseInstallations
@@ -112,10 +123,12 @@ EXTERNAL SOURCES:
     :path: "../common/.ios/.symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  Adapty: acfd515166328461979c903a08aa0a9e55cf0d65
-  adapty_flutter: 5532acc582261290054d88ddf32b81d308ad8957
-  AdaptyPlugin: d1a6e35d9f1b7b750e8772adefc89583c0a4c7f7
-  AdaptyUI: 8dc77880549ff2be797bc7ecfd60c4ad3633bf4b
+  Adapty: fd1e8130a1298abba9bc084a69a63c80fcc5275a
+  adapty_flutter: e87ab51ee70c541de25ba602155e42a8c0a47ee6
+  AdaptyLogger: c59354e1e6b602d08eae91b79bd1492d78c46820
+  AdaptyPlugin: 87183239c885f4a251acbd354631fd2d6f281a5b
+  AdaptyUI: ecd9614d961257d4608315510e8030e40efbbcd5
+  AdaptyUIBuilder: 7425b23c8039d62f02463a4d236e86c8e08d61f8
   FirebaseCore: 86241206e656f5c80c995e370e6c975913b9b284
   FirebaseCoreInternal: 7c12fc3011d889085e765e317d7b9fd1cef97af9
   FirebaseInstallations: 4e6e162aa4abaaeeeb01dd00179dfc5ad9c2194e


### PR DESCRIPTION
Splits the **adapty_flutter** major out of the stuck grouped Dependabot bump (#1082). Resolves cleanly under the pinned **Flutter 3.32.1 / Dart 3.8.1** — no SDK bump, and the lock change is adapty-only (no new transitive deps).

⚠️ **Payment path.** Two breaking API changes in the Flutter (iOS / Android-Family) payment channel `common/lib/src/features/payment/domain/adapty.dart`, both migrated to preserve behavior. The test suite uses a mock channel and cannot exercise real purchases — **on-device validation required before merge** (checklist below).

## Migrations

**1. `withCustomerUserId` is now non-nullable** (`String?` → `String`).
`init()` receives a nullable `accountId` (anonymous at activation). The config is now built first and `withCustomerUserId(accountId)` is only called when `accountId != null`. This is equivalent to the old `withCustomerUserId(null)` — the JSON builder omits the key when unset, in both 3.11.4 and 3.17. The customer-user-id is still bound separately via `identify()` once the account becomes active (`PaymentActor` registers `_accountEphemeral.onChangeInstant → identify`), so paywall/purchase attribution is unaffected.

**2. `Adapty.logShowOnboarding` was removed.**
3.17 reworked onboarding into hosted AdaptyUI onboarding views (`createOnboardingView`/events observer), which this app doesn't use — onboarding is rendered by the app. There's no drop-in replacement for logging a custom onboarding step, so `logOnboardingStep` becomes a no-op trace. The **native Android path already no-op'd this on Adapty Android 3.15.x**, so the Adapty-side onboarding analytics is already gone app-wide; only the local funnel in `PaymentActor.reportOnboarding` matters and it is unaffected (its own gating + `_onboard.change` persistence stay intact).

## Scope notes
- The other `PaymentChannel` impl, `PlatformPaymentChannel` (`common/lib/src/platform/payment/channel.dart`), routes to the **native** Adapty SDK via pigeon ops and is versioned separately in `android/` (`adapty-bom:3.15.2`) — out of scope for this Flutter-package bump.
- All other Adapty APIs used in this file (`identify`, `getPaywall`, `setFallbackPaywalls`, `createPaywallView`, `updateProfile`, `AdaptyProfileParametersBuilder`, purchase-result/action variants) are signature-identical between 3.11.4 and 3.17.

## Follow-up (not in this PR)
- `AdaptyUI.setObserver` / `AdaptyUIObserver` are `@Deprecated` in 3.17 (replaced by `setPaywallsEventsObserver` / `AdaptyUIPaywallsEventsObserver`). They still work (delegate), and the deprecation is silenced by `analysis_options.yaml` (`deprecated_member_use: ignore`). Migrating the observer API is a separate change and a future-removal risk worth a ticket.

## Verification
- `make test` → **all tests pass**
- `fvm flutter analyze --no-fatal-warnings --no-fatal-infos` → exit 0 (6 pre-existing warnings/infos, none in changed files)

### On-device checklist before merge
- [x] iOS paywall presents (primary placement): preload → open → render
- [x] Purchase end-to-end → entitlement unlock (`checkoutSuccessfulPayment`)
- [x] Restore (success + failure paths)
- [x] Anonymous-start attribution: fresh install → activate with no customerUserId → later account activation → confirm `identify()` binds the account id in the Adapty dashboard
- [x] Fallback paywall loads with no network (`setFallbackPaywalls`) - paywall won't show with no network, it will recover once internet is back.
- [x] Android Family paywall/purchase/restore smoke test
- [x] Onboarding step progression still drives the local funnel (paywall opens at the right step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)