### PR TITLE
build(deps): bump pigeon from 12.0.1 to 26.3.2

### DIFF
--- a/common/lib/src/platform/command/command.dart
+++ b/common/lib/src/platform/command/command.dart
@@ -28,7 +28,7 @@ class CommandStore with Logging, Actor implements CommandEvents {
 
   void onRegister() {
     Core.register<CommandStore>(this);
-    if (Core.act.isProd) CommandEvents.setup(this);
+    if (Core.act.isProd) CommandEvents.setUp(this);
   }
 
   Future<void> acceptCommands(Marker m) async {

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: c209688d9f5a5f26b2fb47a188131a6fb9e876ae9e47af3737c0b4f58a93470d
       url: "https://pub.dev"
     source: hosted
-    version: "61.0.0"
+    version: "91.0.0"
   adapty_flutter:
     dependency: "direct main"
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: f51c8499b35f9b26820cfe914828a6a98a94efd5cc78b37bb7d03debae3a1d08
       url: "https://pub.dev"
     source: hosted
-    version: "5.13.0"
+    version: "8.4.1"
   animations:
     dependency: "direct main"
     description:
@@ -61,18 +61,18 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
+      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "4.0.6"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4ae2de3e1e67ea270081eaee972e1bd8f027d459f249e0f1186730784c2e7e33"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -81,30 +81,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.4"
-  build_resolvers:
-    dependency: transitive
-    description:
-      name: build_resolvers
-      sha256: "339086358431fa15d7eca8b6a36e5d783728cf025e559b834f4609a1fcfb7b0a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "028819cfb90051c6b5440c7e574d1896f8037e3c96cf17aaeb054c9311cfbf4d"
+      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.13"
-  build_runner_core:
-    dependency: transitive
-    description:
-      name: build_runner_core
-      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.3.2"
+    version: "2.15.0"
   built_collection:
     dependency: transitive
     description:
@@ -237,10 +221,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "1efa911ca7086affd35f463ca2fc1799584fb6aa89883cf0af8e3664d6a02d55"
+      sha256: a9c30492da18ff84efe2422ba2d319a89942d93e58eb0b73d32abe822ef54b7b
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "3.1.3"
   dartx:
     dependency: "direct main"
     description:
@@ -445,14 +429,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
-  frontend_server_client:
-    dependency: transitive
-    description:
-      name: frontend_server_client
-      sha256: f64a0333a82f30b0cca061bc3d143813a486dc086b574bfb233b7c1372427694
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.0.0"
   get_it:
     dependency: "direct main"
     description:
@@ -573,14 +549,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: transitive
     description:
@@ -689,18 +657,18 @@ packages:
     dependency: "direct dev"
     description:
       name: mobx_codegen
-      sha256: f605e04444c5dbf8503f354577e7ad1e06887cff30ba20f147365d6130d580f7
+      sha256: "471b02d0cf7f64d1366944e9dc64353674807d31e48faba2201918cc1601876d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.2"
+    version: "2.7.4"
   mockito:
     dependency: "direct main"
     description:
       name: mockito
-      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
+      sha256: eff30d002f0c8bf073b6f929df4483b543133fcafce056870163587b03f1d422
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.4"
+    version: "5.6.4"
   mocktail:
     dependency: "direct main"
     description:
@@ -817,10 +785,10 @@ packages:
     dependency: "direct dev"
     description:
       name: pigeon
-      sha256: "3e248ba5da5a47fae621549fe8730cee0a22bef4acc18291dc852e7dcc6457cc"
+      sha256: "2a4bfd279fac52b115818e93f5409d07955f7b3718d303fd5f100981be4de386"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.1"
+    version: "26.3.2"
   platform:
     dependency: transitive
     description:
@@ -1014,10 +982,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
+      sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "4.2.3"
   source_span:
     dependency: transitive
     description:
@@ -1170,14 +1138,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.7.1"
-  timing:
-    dependency: transitive
-    description:
-      name: timing
-      sha256: "62ee18aca144e4a9f29d212f5a4c6a053be252b895ab14b5821996cff4ed90fe"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
   tuple:
     dependency: transitive
     description:
@@ -1307,5 +1267,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <3.16.0"
+  dart: ">=3.9.0 <3.16.0"
   flutter: ">=3.35.0"

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -70,7 +70,7 @@ dev_dependencies:
   flutter_lints: ^2.0.0
   dependency_validator: ^3.0.0
   mobx_codegen: ^2.0.7+3
-  pigeon: ^12.0.0
+  pigeon: ^26.3.2
   web_socket_channel: ^3.0.3
   test_api: any
 


### PR DESCRIPTION
The last of the three majors split out of the stuck grouped Dependabot bump (#1082), now unblocked by the Flutter 3.35.2 / Dart 3.9 upgrade (pigeon ≥26.1.3 requires Dart ≥3.9.0).

## Change
- `pigeon ^12.0.0 → ^26.3.2`
- Pigeon's only breaking change affecting us is the Dart-side rename of the generated `FlutterApi` setup method: `CommandEvents.setup` → `setUp`. **Exactly one call site** (`common/lib/src/platform/command/command.dart:31`); the regenerated `channel.pg.dart` emits `static void setUp(...)`.
- Generated channel code (Dart/Swift/Kotlin) isn't tracked — it's regenerated at build — so the diff is just the constraint bump + lock + the one call-site rename.

## Verification
- `make test` → **all tests pass** (379)
- `fvm flutter analyze --no-fatal-warnings --no-fatal-infos` → exit 0 (same 6 pre-existing warnings)
- CI exercises the native iOS + Android builds, which regenerate the Swift/Kotlin channels under pigeon 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)