### PR TITLE
ci(dependabot): ignore pigeon major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,13 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      # pigeon 26 needs a native Swift/Kotlin codegen migration (Kotlin enum
+      # renames + Swift PigeonError collision) that's disproportionate for a
+      # dev-only codegen tool; held — see closed PR #1106. Remove this when
+      # that migration is scheduled.
+      - dependency-name: "pigeon"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "gradle"
     directory: "/android"


### PR DESCRIPTION
Stops Dependabot from re-proposing **pigeon** major updates every week while it's held.

## Why
pigeon 26 is unblocked at the Dart level (Flutter 3.35/Dart 3.9) but carries substantial **native** codegen breaking changes — 29 Kotlin enum-rename references across 6 files, plus a Swift `PigeonError` ambiguity — disproportionate for a dev-only codegen tool. Held in [#1106](https://github.com/blokadaorg/blokada/pull/1106) (closed).

## Change
Adds to the `pub` (`/common`) Dependabot config:
```yaml
ignore:
  - dependency-name: "pigeon"
    update-types: ["version-update:semver-major"]
```
Remove this entry when the pigeon native migration is scheduled. Minor/patch pigeon updates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)