### PR TITLE
ios: move Firebase to Swift Package Manager

### DIFF
--- a/ios/IOS.xcodeproj/project.pbxproj
+++ b/ios/IOS.xcodeproj/project.pbxproj
@@ -9,8 +9,10 @@
 /* Begin PBXBuildFile section */
 		176BF5230E082798AF0311E8 /* Pods_Dev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BD62BE06311E71CD991CE3F2 /* Pods_Dev.framework */; };
 		1AD1BA7496D8C335F2E6678D /* Pods_FamilyDev.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B2D21A15748E1394054B3DFC /* Pods_FamilyDev.framework */; };
+		1DC1BD23E00EC4DD41238D45 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = DF46A2984E82ABC856F26576 /* FirebaseCore */; };
 		2BAF43F98AE7367532A1363E /* Pods_Mocked.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCCAB443BAD3852B4A55923E /* Pods_Mocked.framework */; };
 		32C1008A7577A4987B004E84 /* Pods_Prod.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C94D6248881297B61CC2DF7 /* Pods_Prod.framework */; };
+		3DFA9F4792D51C716F8ED0D6 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = D7C7F707EE2359006E66B1A1 /* FirebaseCore */; };
 		47729E0622F447C800B9B36B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47729E0522F447C800B9B36B /* AppDelegate.swift */; };
 		47729E0D22F447CA00B9B36B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 47729E0C22F447CA00B9B36B /* Assets.xcassets */; };
 		47729E1022F447CA00B9B36B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 47729E0E22F447CA00B9B36B /* LaunchScreen.storyboard */; };
@@ -672,10 +674,14 @@
 		4EF8ED812B87AA3B00E6E607 /* ScanQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF8ED7D2B87AA3B00E6E607 /* ScanQrCodeView.swift */; };
 		4EF8ED822B87AA3B00E6E607 /* ScanQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF8ED7D2B87AA3B00E6E607 /* ScanQrCodeView.swift */; };
 		4EF8ED832B87AA3B00E6E607 /* ScanQrCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EF8ED7D2B87AA3B00E6E607 /* ScanQrCodeView.swift */; };
+		8187E5CC61B540A0F67B3E1E /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = CA05A15F2397A2ECD7A962E0 /* FirebaseMessaging */; };
 		81A14548F0971940140E60F7 /* Pods_FamilyProd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 172E613B3E5E2ECA63DB72B5 /* Pods_FamilyProd.framework */; };
+		9EE02E63D584674824D01B10 /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 22CAA4468AF49D1E84301553 /* FirebaseMessaging */; };
 		B2382A312E61E14300ED7415 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2A172760E400005A59F5 /* Constants.swift */; };
 		B2382A322E61E14300ED7415 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E2F2A172760E400005A59F5 /* Constants.swift */; };
+		C58396BD1C3831BDC8BA6CB5 /* FirebaseCore in Frameworks */ = {isa = PBXBuildFile; productRef = CCB9EEAE8489C4BFFF761842 /* FirebaseCore */; };
 		D457AF88E4351BB1D413F70B /* Pods_FamilyMocked.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39323AFF3B4C4CB93EF7EEB4 /* Pods_FamilyMocked.framework */; };
+		EAF13E21F04EA4DF15F3E95C /* FirebaseMessaging in Frameworks */ = {isa = PBXBuildFile; productRef = 066B82AD6C9B8945B4602DC0 /* FirebaseMessaging */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1096,6 +1102,8 @@
 				4E270DF62A80F30400D3484B /* Factory in Frameworks */,
 				4E58C1372AC1B7D7002CA1A3 /* CodeScanner in Frameworks */,
 				32C1008A7577A4987B004E84 /* Pods_Prod.framework in Frameworks */,
+				C58396BD1C3831BDC8BA6CB5 /* FirebaseCore in Frameworks */,
+				8187E5CC61B540A0F67B3E1E /* FirebaseMessaging in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1157,6 +1165,8 @@
 				4E58C1392AC1B8FB002CA1A3 /* CodeScanner in Frameworks */,
 				4E28ADDA2AB33169007445C8 /* Factory in Frameworks */,
 				2BAF43F98AE7367532A1363E /* Pods_Mocked.framework in Frameworks */,
+				3DFA9F4792D51C716F8ED0D6 /* FirebaseCore in Frameworks */,
+				9EE02E63D584674824D01B10 /* FirebaseMessaging in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1168,6 +1178,8 @@
 				4E270DF82A80F31600D3484B /* Factory in Frameworks */,
 				4EEDBBA42B6117C9004AB456 /* CodeScanner in Frameworks */,
 				176BF5230E082798AF0311E8 /* Pods_Dev.framework in Frameworks */,
+				1DC1BD23E00EC4DD41238D45 /* FirebaseCore in Frameworks */,
+				EAF13E21F04EA4DF15F3E95C /* FirebaseMessaging in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1710,6 +1722,8 @@
 			packageProductDependencies = (
 				4E270DF52A80F30400D3484B /* Factory */,
 				4E58C1362AC1B7D7002CA1A3 /* CodeScanner */,
+				CCB9EEAE8489C4BFFF761842 /* FirebaseCore */,
+				CA05A15F2397A2ECD7A962E0 /* FirebaseMessaging */,
 			);
 			productName = IOS;
 			productReference = 47729E0222F447C800B9B36B /* Blokada 6.app */;
@@ -1858,6 +1872,8 @@
 			packageProductDependencies = (
 				4E28ADD92AB33169007445C8 /* Factory */,
 				4E58C1382AC1B8FB002CA1A3 /* CodeScanner */,
+				D7C7F707EE2359006E66B1A1 /* FirebaseCore */,
+				22CAA4468AF49D1E84301553 /* FirebaseMessaging */,
 			);
 			productName = IOS;
 			productReference = 4E7FE9D8244DC28900851E9F /* Blokada Mocked.app */;
@@ -1886,6 +1902,8 @@
 			packageProductDependencies = (
 				4E270DF72A80F31600D3484B /* Factory */,
 				4EEDBBA32B6117C9004AB456 /* CodeScanner */,
+				DF46A2984E82ABC856F26576 /* FirebaseCore */,
+				066B82AD6C9B8945B4602DC0 /* FirebaseMessaging */,
 			);
 			productName = IOS;
 			productReference = 4E86520C2A3C968B0060AFB1 /* Dev.app */;
@@ -1992,6 +2010,7 @@
 			packageReferences = (
 				4E270DF42A80F30400D3484B /* XCRemoteSwiftPackageReference "Factory" */,
 				4E58C1352AC1B7D7002CA1A3 /* XCRemoteSwiftPackageReference "CodeScanner" */,
+				CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 47729E0322F447C800B9B36B /* Products */;
@@ -4592,9 +4611,27 @@
 				minimumVersion = 2.0.0;
 			};
 		};
+		CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.12.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		066B82AD6C9B8945B4602DC0 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		22CAA4468AF49D1E84301553 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
 		4E1275F82AE7D0FC00A94994 /* Factory */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4E1275F92AE7D0FC00A94994 /* XCRemoteSwiftPackageReference "Factory" */;
@@ -4654,6 +4691,26 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4E58C1352AC1B7D7002CA1A3 /* XCRemoteSwiftPackageReference "CodeScanner" */;
 			productName = CodeScanner;
+		};
+		CA05A15F2397A2ECD7A962E0 /* FirebaseMessaging */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseMessaging;
+		};
+		CCB9EEAE8489C4BFFF761842 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+		D7C7F707EE2359006E66B1A1 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
+		};
+		DF46A2984E82ABC856F26576 /* FirebaseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CFCB1ADAFCFE628257F71256 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCore;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -14,8 +14,7 @@ target 'Dev' do
   use_frameworks!
 
   # Pods for Dev
-  pod 'FirebaseCore'
-  pod 'FirebaseMessaging'
+  # FirebaseCore / FirebaseMessaging are now provided via Swift Package Manager.
   install_all_flutter_pods(flutter_application_path)
 end
 
@@ -24,8 +23,7 @@ target 'Prod' do
   use_frameworks!
 
   # Pods for Prod
-  pod 'FirebaseCore'
-  pod 'FirebaseMessaging'
+  # FirebaseCore / FirebaseMessaging are now provided via Swift Package Manager.
   install_all_flutter_pods(flutter_application_path)
 end
 
@@ -34,8 +32,7 @@ target 'Mocked' do
   use_frameworks!
 
   # Pods for Mocked
-  pod 'FirebaseCore'
-  pod 'FirebaseMessaging'
+  # FirebaseCore / FirebaseMessaging are now provided via Swift Package Manager.
   install_all_flutter_pods(flutter_application_path)
 end
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -19,79 +19,29 @@ PODS:
     - AdaptyUIBuilder (= 3.17.2)
   - AdaptyUIBuilder (3.17.2):
     - AdaptyLogger (= 3.17.2)
-  - FirebaseCore (12.12.1):
-    - FirebaseCoreInternal (~> 12.12.0)
-    - GoogleUtilities/Environment (~> 8.1)
-    - GoogleUtilities/Logger (~> 8.1)
-  - FirebaseCoreInternal (12.12.0):
-    - "GoogleUtilities/NSData+zlib (~> 8.1)"
-  - FirebaseInstallations (12.12.0):
-    - FirebaseCore (~> 12.12.0)
-    - GoogleUtilities/Environment (~> 8.1)
-    - GoogleUtilities/UserDefaults (~> 8.1)
-    - PromisesObjC (~> 2.4)
-  - FirebaseMessaging (12.12.0):
-    - FirebaseCore (~> 12.12.0)
-    - FirebaseInstallations (~> 12.12.0)
-    - GoogleDataTransport (~> 10.1)
-    - GoogleUtilities/AppDelegateSwizzler (~> 8.1)
-    - GoogleUtilities/Environment (~> 8.1)
-    - GoogleUtilities/Reachability (~> 8.1)
-    - GoogleUtilities/UserDefaults (~> 8.1)
-    - nanopb (~> 3.30910.0)
   - Flutter (1.0.0)
   - FlutterPluginRegistrant (0.0.1):
     - adapty_flutter
     - Flutter
     - path_provider_foundation
+    - shared_preferences_foundation
     - sqflite_darwin
-  - GoogleDataTransport (10.1.0):
-    - nanopb (~> 3.30910.0)
-    - PromisesObjC (~> 2.4)
-  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
-    - GoogleUtilities/Environment
-    - GoogleUtilities/Logger
-    - GoogleUtilities/Network
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Environment (8.1.0):
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Logger (8.1.0):
-    - GoogleUtilities/Environment
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Network (8.1.0):
-    - GoogleUtilities/Logger
-    - "GoogleUtilities/NSData+zlib"
-    - GoogleUtilities/Privacy
-    - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (8.1.0)":
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/Privacy (8.1.0)
-  - GoogleUtilities/Reachability (8.1.0):
-    - GoogleUtilities/Logger
-    - GoogleUtilities/Privacy
-  - GoogleUtilities/UserDefaults (8.1.0):
-    - GoogleUtilities/Logger
-    - GoogleUtilities/Privacy
-  - nanopb (3.30910.0):
-    - nanopb/decode (= 3.30910.0)
-    - nanopb/encode (= 3.30910.0)
-  - nanopb/decode (3.30910.0)
-  - nanopb/encode (3.30910.0)
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - PromisesObjC (2.4.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - sqflite_darwin (0.0.4):
     - Flutter
     - FlutterMacOS
 
 DEPENDENCIES:
   - adapty_flutter (from `../common/.ios/.symlinks/plugins/adapty_flutter/ios`)
-  - FirebaseCore
-  - FirebaseMessaging
   - Flutter (from `../common/.ios/Flutter`)
   - FlutterPluginRegistrant (from `../common/.ios/Flutter/FlutterPluginRegistrant`)
   - path_provider_foundation (from `../common/.ios/.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `../common/.ios/.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqflite_darwin (from `../common/.ios/.symlinks/plugins/sqflite_darwin/darwin`)
 
 SPEC REPOS:
@@ -101,14 +51,6 @@ SPEC REPOS:
     - AdaptyPlugin
     - AdaptyUI
     - AdaptyUIBuilder
-    - FirebaseCore
-    - FirebaseCoreInternal
-    - FirebaseInstallations
-    - FirebaseMessaging
-    - GoogleDataTransport
-    - GoogleUtilities
-    - nanopb
-    - PromisesObjC
 
 EXTERNAL SOURCES:
   adapty_flutter:
@@ -119,6 +61,8 @@ EXTERNAL SOURCES:
     :path: "../common/.ios/Flutter/FlutterPluginRegistrant"
   path_provider_foundation:
     :path: "../common/.ios/.symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: "../common/.ios/.symlinks/plugins/shared_preferences_foundation/darwin"
   sqflite_darwin:
     :path: "../common/.ios/.symlinks/plugins/sqflite_darwin/darwin"
 
@@ -129,19 +73,12 @@ SPEC CHECKSUMS:
   AdaptyPlugin: 87183239c885f4a251acbd354631fd2d6f281a5b
   AdaptyUI: ecd9614d961257d4608315510e8030e40efbbcd5
   AdaptyUIBuilder: 7425b23c8039d62f02463a4d236e86c8e08d61f8
-  FirebaseCore: 86241206e656f5c80c995e370e6c975913b9b284
-  FirebaseCoreInternal: 7c12fc3011d889085e765e317d7b9fd1cef97af9
-  FirebaseInstallations: 4e6e162aa4abaaeeeb01dd00179dfc5ad9c2194e
-  FirebaseMessaging: 341004946fa7ffc741344b20f1b667514fc93e31
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  FlutterPluginRegistrant: 4460963b523c8c665ce9e4c50cf31b979e869b35
-  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
-  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  FlutterPluginRegistrant: 0142b30e7798741b38fb06d13ebfc4611592d75e
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
-  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
-PODFILE CHECKSUM: aa0b9301ebdc4887e479cad78bb18143509e8888
+PODFILE CHECKSUM: be7cf9307274447122fb3f8bdf83a5e759627d9b
 
 COCOAPODS: 1.16.2


### PR DESCRIPTION
Moves `FirebaseCore` + `FirebaseMessaging` from CocoaPods to Swift Package Manager, following the existing `Factory`/`CodeScanner` SPM precedent. First of two staged PRs to remove CocoaPods from the iOS build.

## What
- Add `firebase-ios-sdk` as an `XCRemoteSwiftPackageReference` (upToNextMajor from `12.12.0`, matching the previously resolved pod versions).
- Link `FirebaseCore` + `FirebaseMessaging` into the **Dev / Prod / Mocked** targets (Family flavors don't use Firebase).
- Remove the `pod 'FirebaseCore'` / `pod 'FirebaseMessaging'` declarations from `ios/Podfile`; `Podfile.lock` drops Firebase and its transitive pods.

`AppDelegate`'s `#if canImport(FirebaseCore)` / `canImport(FirebaseMessaging)` guards are unchanged and resolve against the SPM modules.

## Notes
- `Podfile.lock` also picks up pre-existing drift (`shared_preferences_foundation`, refreshed Flutter/FlutterPluginRegistrant checksums) because the committed lock was stale vs the current plugin set — this is what `pod install` now produces.
- The Flutter module stays on CocoaPods in this PR; PR 2 removes it.

## Verification
Dev / Prod / Mocked build on the simulator with `FIRApp`/`FIRMessaging` statically linked and the Firebase resource bundles embedded; FamilyDev still builds. Device FCM push smoke is an operator step.

Tracker: blokadaorg/issue-tracker#317

🤖 Generated with [Claude Code](https://claude.com/claude-code)