### PR TITLE
ci(dependabot): exclude pigeon from flutter-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,16 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        # pigeon's semver-major ignore (below) does not keep it out of this
+        # group's recreated PRs — when a grouped dep merges, Dependabot
+        # recreates the group and re-widens the pigeon constraint, re-bumping
+        # it to 26.x and going red on the setup→setUp break (closed #1106,
+        # #1109, #1114). Excluding pigeon from the group keeps the safe
+        # minor/patch bumps unblocked; pigeon minor/patch then gets its own
+        # PR and its major stays held by the ignore rule. Drop this together
+        # with the ignore when the pigeon 26 native migration is scheduled.
+        exclude-patterns:
+          - "pigeon"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Why

The `ignore: pigeon / version-update:semver-major` rule (commit `d80f302f`) does **not** keep pigeon out of the recreated *group* PR. When a grouped dep merges (e.g. adapty #1103), Dependabot recreates the `flutter-dependencies` group and re-widens the pigeon constraint (`^12.0.0` → `">=12.0.0 <27.0.0"`), re-bumping it to 26.x and going red on the known `CommandEvents.setup`→`setUp` break. This has now happened three times — closed #1106 (standalone), #1109 and #1114 (group recreations) — and will recur every cycle until the config changes.

## What

Add `exclude-patterns: ["pigeon"]` to the `flutter-dependencies` group. Pigeon is removed from the group entirely, so:

- the ~18 safe minor/patch bumps in the group are no longer blocked behind the held pigeon major;
- pigeon minor/patch (if any) gets its own standalone PR;
- pigeon's major stays held by the existing `ignore` rule.

Drop both the exclude and the ignore together when the pigeon 26 native Swift/Kotlin codegen migration is scheduled.

Surfaced by `/dep-validate 1114`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)