### PR TITLE
TEST: translations_drift guard negative test (do not merge)

### DIFF
--- a/common/assets/translations/ui/en.json
+++ b/common/assets/translations/ui/en.json
@@ -711,5 +711,5 @@
     "notification weekly report toplist new body": "Blokada is blocking %s — now ranked #%s. Tap to see more.",
     "notification weekly report toplist move body": "%s moved to #%s (was #%s). Tap to see more.",
     "notification weekly report action see more": "See more",
-    "notification weekly report action opt out": "Turn off weekly reports"
+    "notification weekly report action opt out": "Turn off weekly reports DRIFTTEST322"
 }


### PR DESCRIPTION
Deliberate negative test for the `translations_drift` CI guard.

This edits `common/assets/translations/ui/en.json` (appends `DRIFTTEST322` to one
value) **without** changing the pinned `deps/translate` source. The `en.json drift`
job regenerates en.json from the pinned `v6/*.strings` and `git diff --exit-code`s,
so it must **fail** — proving a string can't reach the app by hand-editing en.json.

Heavy build jobs will be cancelled once the drift job reports; this PR will be closed.

Related: blokadaorg/issue-tracker#322