### PR TITLE
fix(ios): sign add-to-app plugin xcframeworks to fix ITMS-91065

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test-local:
 build:
 	$(MAKE) -C common/ build
 	$(MAKE) -C android/ build
-	$(MAKE) -C ios/ build
+	$(MAKE) build-ios
 
 # Build all android .aab apps from scratch (release)
 build-android:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ADAPTY_VER := 3_8.0
 	translate \
 	build-android build-android-family build-android-six \
 	build-ios build-ios-family build-ios-six build-ios-six-debug \
+	sign-ios-frameworks \
 	version version-clean \
 	publish-android gplay-key-unpack gplay-key-clean \
 	publish-ios appstore-key-unpack appstore-key-clean fastlane-match \
@@ -77,17 +78,27 @@ build-android-six:
 # Build all ios .ipa apps from scratch (release)
 build-ios:
 	$(MAKE) -C common/ build-ios
+	$(MAKE) sign-ios-frameworks
 	$(MAKE) -C ios/ build
 
 # Build ios family .ipa from scratch (release)
 build-ios-family:
 	$(MAKE) -C common/ build-ios
+	$(MAKE) sign-ios-frameworks
 	$(MAKE) -C ios/ build-family
 
 # Build ios six .ipa from scratch (release)
 build-ios-six:
 	$(MAKE) -C common/ build-ios
+	$(MAKE) sign-ios-frameworks
 	$(MAKE) -C ios/ build-six
+
+# Code-sign the unsigned Flutter plugin xcframeworks before the host archive
+# embeds them, so commonly-used SDKs (sqflite, path_provider, ...) ship with a
+# signature and App Store Connect accepts the upload (avoids ITMS-91065).
+# Release-only: debug/simulator builds sign via the dev identity on copy.
+sign-ios-frameworks:
+	./scripts/sign-ios-frameworks.sh
 
 # Build ios six .ipa from scratch (debug)
 build-ios-six-debug:

--- a/scripts/sign-ios-frameworks.sh
+++ b/scripts/sign-ios-frameworks.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# Code-sign the add-to-app Flutter plugin xcframeworks before the host Xcode
+# archive embeds them.
+#
+# Why this exists:
+#   `flutter build ios-framework` (see common/Makefile `build-ios`) emits every
+#   plugin as an UNSIGNED .xcframework. The host project embeds each with
+#   "Code Sign On Copy", but that runtime re-sign is unreliable for the device
+#   slice of a pre-built xcframework (flutter/flutter#148300, #179634), so the
+#   embedded framework can ship unsigned. App Store Connect then rejects the
+#   upload with ITMS-91065 ("Missing signature") for commonly-used SDKs such as
+#   sqflite (sqflite_darwin.framework), path_provider and shared_preferences.
+#
+#   Signing the inner .framework of each slice here guarantees a valid signature
+#   is present regardless of whether Code-Sign-On-Copy runs: if Xcode re-signs on
+#   copy it harmlessly overwrites ours with the same Apple Distribution identity;
+#   if it skips the slice, our signature is what ships. Signing the .xcframework
+#   *wrapper* is NOT enough — it does not propagate to the inner frameworks that
+#   actually land in the app bundle.
+#
+# Scope: only used by the release archive targets in the root Makefile
+# (build-ios / build-ios-family / build-ios-six). Debug/simulator builds sign via
+# the normal dev identity on copy and do not go through here.
+#
+# Override the signing identity or config via env:
+#   IOS_CODESIGN_IDENTITY="Apple Distribution: ... (TEAMID)"  CONFIG=Release
+set -euo pipefail
+
+CONFIG="${CONFIG:-Release}"
+# Default to the Blocka AB App Store distribution cert. This is the same team as
+# the host app's `match AppStore` profiles (ios/fastlane/); if `match` ever
+# provisions a differently-named cert, override with IOS_CODESIGN_IDENTITY.
+IDENTITY="${IOS_CODESIGN_IDENTITY:-Apple Distribution: Blocka AB (HQH5AFGB68)}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+FRAMEWORK_DIR="$ROOT_DIR/common/build/ios-framework/$CONFIG"
+
+if [ ! -d "$FRAMEWORK_DIR" ]; then
+	echo "error: $FRAMEWORK_DIR not found — run 'make -C common build-ios' first." >&2
+	exit 1
+fi
+
+# Preflight: fail with a clear message up front rather than an opaque codesign
+# error deep in the signing loop if the cert isn't available on this machine.
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"; then
+	echo "error: signing identity not found in keychain: '$IDENTITY'" >&2
+	echo "       unlock/import the App Store distribution cert, or set" >&2
+	echo "       IOS_CODESIGN_IDENTITY to the identity to use." >&2
+	exit 1
+fi
+
+# Gather the framework list first (tolerating a transient find error via `|| true`)
+# so the producer pipeline's exit status can't abort the run mid-loop under
+# `pipefail`. Sort deepest-first so any nested frameworks are signed before their
+# container (inside-out signing); the awk field is the slash count = path depth.
+frameworks="$(find "$FRAMEWORK_DIR" -type d -name '*.framework' 2>/dev/null \
+	| awk '{ print gsub(/\//, "/"), $0 }' | sort -rn | cut -d' ' -f2- || true)"
+
+if [ -z "$frameworks" ]; then
+	echo "error: no .framework bundles found under $FRAMEWORK_DIR" >&2
+	exit 1
+fi
+
+echo "sign-ios-frameworks: signing $CONFIG plugin frameworks as '$IDENTITY'"
+
+# `codesign --force` is idempotent — the frameworks may already carry a
+# _CodeSignature from a prior run; re-signing cleanly overwrites it.
+signed=0
+while IFS= read -r fw; do
+	[ -z "$fw" ] && continue
+	codesign --force -v --sign "$IDENTITY" "$fw"
+	signed=$((signed + 1))
+done <<< "$frameworks"
+
+# Verify every framework before the host archive consumes them, so a corrupt
+# signature is caught here rather than at App Store upload.
+while IFS= read -r fw; do
+	[ -z "$fw" ] && continue
+	codesign --verify --strict "$fw"
+done <<< "$frameworks"
+
+echo "sign-ios-frameworks: signed & verified $signed framework(s)"


### PR DESCRIPTION
## Problem

App Store Connect rejects the iOS upload with:

> **ITMS-91065: Missing signature** — Your app includes `Frameworks/sqflite_darwin.framework/sqflite_darwin`, which includes sqflite, a commonly used third-party SDK ... the SDK must include a signature file.

## Root cause

`flutter build ios-framework` (`common/Makefile` `build-ios`) emits every plugin as an **unsigned** `.xcframework`. The host project embeds them with "Code Sign On Copy", but that runtime re-sign is unreliable for the **device slice** of a pre-built xcframework (flutter/flutter#148300, #179634), so commonly-used SDKs ship unsigned → ITMS-91065.

This is new because of the CocoaPods→add-to-app migration (`f4f78dd5`): CocoaPods compiled/signed plugins inline, so there was never a standalone `sqflite_darwin.framework` for Apple to flag. Now each plugin is a discrete embedded framework. (sqflite itself is transitive — `cached_network_image` → `flutter_cache_manager` → sqflite, for the image-cache index DB.)

## Fix

- **`scripts/sign-ios-frameworks.sh`** — codesigns the **inner per-slice** `.framework` of every produced xcframework with the Apple Distribution identity (default `Apple Distribution: Blocka AB (HQH5AFGB68)`, override via `IOS_CODESIGN_IDENTITY`). Has an identity preflight, deepest-first (inside-out) signing, idempotent `--force` re-sign, and a `codesign --verify` pass.
- **`Makefile`** — new `sign-ios-frameworks` target, run between `make -C common build-ios` and the host archive in the **release** targets (`build-ios` / `build-ios-family` / `build-ios-six`). CI reaches it via `ci-build-ios-*`. The debug target is intentionally untouched.

> ⚠️ Signing the `.xcframework` **wrapper** does not propagate to the inner frameworks that land in the app bundle — the inner `ios-arm64/*.framework` must be signed directly (verified empirically). Self-signing with our own distribution cert satisfies ITMS-91065 (Apple allows it).

## Scope

The fix is not sqflite-specific — it signs all 11 embedded add-to-app frameworks uniformly, so `path_provider`, `shared_preferences`, and `Flutter` (also on Apple's list) are covered too. SPM deps (Firebase, Factory, CodeScanner) are **statically linked**, not embedded, so they cannot trigger ITMS-91065 and need no signing. New Flutter plugins are auto-covered since the script signs the whole output dir.

## Verification

- All 24 inner frameworks (12 xcframeworks × 2 slices) sign with the Apple Distribution chain; `codesign --verify --strict` passes; privacy bundles seal correctly — reproducing the known-good pre-migration IPA signature state.
- Idempotent re-run is clean; bogus-identity run fails fast with a clear message.
- End-to-end confirmation requires the next release archive + upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)