### PR TITLE
fix(ios): don't re-sign Flutter/App xcframeworks (fixes broken release archive)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,18 +80,21 @@ build-ios:
 	$(MAKE) -C common/ build-ios
 	$(MAKE) sign-ios-frameworks
 	$(MAKE) -C ios/ build
+	./scripts/verify-ios-ipa-signatures.sh "ios/Blokada Family.ipa" "ios/Blokada 6.ipa"
 
 # Build ios family .ipa from scratch (release)
 build-ios-family:
 	$(MAKE) -C common/ build-ios
 	$(MAKE) sign-ios-frameworks
 	$(MAKE) -C ios/ build-family
+	./scripts/verify-ios-ipa-signatures.sh "ios/Blokada Family.ipa"
 
 # Build ios six .ipa from scratch (release)
 build-ios-six:
 	$(MAKE) -C common/ build-ios
 	$(MAKE) sign-ios-frameworks
 	$(MAKE) -C ios/ build-six
+	./scripts/verify-ios-ipa-signatures.sh "ios/Blokada 6.ipa"
 
 # Code-sign the unsigned Flutter plugin xcframeworks before the host archive
 # embeds them, so commonly-used SDKs (sqflite, path_provider, ...) ship with a

--- a/scripts/sign-ios-frameworks.sh
+++ b/scripts/sign-ios-frameworks.sh
@@ -51,11 +51,27 @@ if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"
 	exit 1
 fi
 
+# Do NOT sign Flutter's own first-party outputs. Flutter.framework and
+# App.framework come out of `flutter build ios-framework` ALREADY signed
+# (io.flutter.flutter / io.flutter.flutter.app) and are not on the unsigned-
+# plugin list ITMS-91065 flags. Re-signing them here breaks the host archive:
+# Xcode's ProcessXCFramework → SignatureCollection task on Flutter.xcframework
+# fails with `signature-collection failed ... SWBUtil.CodeSignatureInfo.Error
+# error 0` → ** ARCHIVE FAILED ** (release 26.2.18 regression). The host
+# add-to-app embedding signs Flutter/App itself, so leave them untouched.
+# FlutterPluginRegistrant is a static, link-only framework — never embedded in
+# the app bundle, so ITMS-91065 cannot fire on it and signing it is pointless.
+EXCLUDED_XCFRAMEWORKS=(Flutter App FlutterPluginRegistrant)
+
 # Gather the framework list first (tolerating a transient find error via `|| true`)
 # so the producer pipeline's exit status can't abort the run mid-loop under
 # `pipefail`. Sort deepest-first so any nested frameworks are signed before their
 # container (inside-out signing); the awk field is the slash count = path depth.
-frameworks="$(find "$FRAMEWORK_DIR" -type d -name '*.framework' 2>/dev/null \
+prune=()
+for x in "${EXCLUDED_XCFRAMEWORKS[@]}"; do
+	prune+=(-not -path "*/$x.xcframework/*")
+done
+frameworks="$(find "$FRAMEWORK_DIR" -type d -name '*.framework' "${prune[@]}" 2>/dev/null \
 	| awk '{ print gsub(/\//, "/"), $0 }' | sort -rn | cut -d' ' -f2- || true)"
 
 if [ -z "$frameworks" ]; then

--- a/scripts/verify-ios-ipa-signatures.sh
+++ b/scripts/verify-ios-ipa-signatures.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Verify that every framework embedded in a built .ipa carries a valid code
+# signature, before it is uploaded to App Store Connect.
+#
+# Why this exists:
+#   scripts/sign-ios-frameworks.sh signs the *unsigned* third-party plugin
+#   xcframeworks (sqflite_darwin, path_provider, shared_preferences, Adapty*)
+#   to satisfy ITMS-91065, and deliberately does NOT touch Flutter's own
+#   Flutter.framework / App.framework (they ship pre-signed; re-signing them
+#   breaks Xcode's ProcessXCFramework/SignatureCollection step). This check
+#   proves that assumption end-to-end: it cracks open the final .ipa and
+#   confirms EVERY embedded framework — Flutter and App included — is signed,
+#   so a missing signature is caught here instead of by App Store Connect.
+#
+# Usage: verify-ios-ipa-signatures.sh <path-to.ipa> [more.ipa ...]
+#
+# Kept POSIX-bash-3.2 friendly (no mapfile/readarray) so it runs under the
+# stock /bin/bash on the CI runner as well as a newer bash.
+set -euo pipefail
+
+if [ "$#" -eq 0 ]; then
+	echo "usage: $0 <path-to.ipa> [more.ipa ...]" >&2
+	exit 2
+fi
+
+# Frameworks that MUST be present and signed in an add-to-app .ipa. Their
+# absence would make an "all signed" pass vacuously true, so assert them.
+REQUIRED_FRAMEWORKS=(Flutter.framework App.framework)
+
+# A valid-but-wrong signature (ad-hoc, or a development cert) passes
+# `codesign --verify` yet App Store Connect still rejects it, so also assert the
+# signing authority is the App Store distribution identity. Substring match, to
+# tolerate the team-id suffix. Set IOS_EXPECTED_SIGN_AUTHORITY="" to check
+# presence only (e.g. when verifying a non-distribution build).
+EXPECTED_AUTHORITY="${IOS_EXPECTED_SIGN_AUTHORITY-Apple Distribution}"
+
+base="$(mktemp -d)"
+trap 'rm -rf "$base"' EXIT
+
+status=0
+for ipa in "$@"; do
+	if [ ! -f "$ipa" ]; then
+		echo "error: ipa not found: $ipa" >&2
+		exit 1
+	fi
+
+	echo "verify-ios-ipa-signatures: inspecting $ipa"
+	workdir="$base/$(basename "$ipa").extracted"
+	mkdir -p "$workdir"
+	unzip -q "$ipa" -d "$workdir"
+
+	# Every embedded framework anywhere in the payload — the .app and any nested
+	# .appex plug-ins (e.g. the WireGuard network extension).
+	frameworks="$(find "$workdir/Payload" -type d -name '*.framework' 2>/dev/null | sort || true)"
+	if [ -z "$frameworks" ]; then
+		echo "error: no embedded frameworks found in $ipa (unexpected)" >&2
+		exit 1
+	fi
+
+	unsigned=0
+	total=0
+	seen=""
+	while IFS= read -r fw; do
+		[ -z "$fw" ] && continue
+		total=$((total + 1))
+		name="$(basename "$fw")"
+		seen="$seen
+$name"
+		# `codesign --verify` fails both for a missing signature ("not signed at
+		# all" → ITMS-91065) and for a broken seal, so it is the right gate.
+		# Capture once (stderr carries the reason on failure).
+		if verr="$(codesign --verify --strict "$fw" 2>&1)"; then
+			authority="$(codesign -dvv "$fw" 2>&1 | awk -F'=' '/^Authority=/{print $2; exit}')"
+			if [ -n "$EXPECTED_AUTHORITY" ] && ! printf '%s' "$authority" | grep -qF "$EXPECTED_AUTHORITY"; then
+				echo "  FAIL $name  — signed by '${authority:-no authority}', expected authority containing '$EXPECTED_AUTHORITY'" >&2
+				unsigned=$((unsigned + 1))
+			else
+				echo "  OK   $name  [${authority:-no authority line}]"
+			fi
+		else
+			echo "  FAIL $name  — $(printf '%s' "$verr" | head -1)" >&2
+			unsigned=$((unsigned + 1))
+		fi
+	done <<< "$frameworks"
+
+	# Fail loudly if a framework we expect to be embedded is missing entirely.
+	for req in "${REQUIRED_FRAMEWORKS[@]}"; do
+		if ! printf '%s\n' "$seen" | grep -qx "$req"; then
+			echo "  MISSING $req — expected to be embedded but not found in $ipa" >&2
+			unsigned=$((unsigned + 1))
+		fi
+	done
+
+	if [ "$unsigned" -ne 0 ]; then
+		echo "verify-ios-ipa-signatures: $unsigned unsigned/missing framework(s) in $ipa — App Store would reject (ITMS-91065)" >&2
+		status=1
+	else
+		echo "verify-ios-ipa-signatures: all $total embedded framework(s) signed in $ipa"
+	fi
+done
+
+exit "$status"


### PR DESCRIPTION
## Problem

The **Release from tag** archive for `26.2.18/family/ios` failed ([run 27819630775](https://github.com/blokadaorg/blokada/actions/runs/27819630775/job/82330476324)):

```
❌ error: signature-collection failed: The operation couldn't be completed.
   (SWBUtil.CodeSignatureInfo.Error error 0.)
   SignatureCollection .../Release-iphoneos/Flutter.xcframework-ios.signature
   ProcessXCFramework .../common/build/ios-framework/Release/Flutter.xcframework ...
** ARCHIVE FAILED **
```

(The `export_method mismatch` lines below it in the log are gym's post-failure fallback noise, not the cause.)

**Root cause:** the ITMS-91065 signing fix (#1133) used `find ... -name '*.framework'` and re-signed **every** framework under the `ios-framework` output — including Flutter's own first-party `Flutter.framework` and `App.framework`, which already ship signed (`io.flutter.flutter` / `io.flutter.flutter.app`). Re-signing those breaks Xcode's `ProcessXCFramework` → `SignatureCollection` step on `Flutter.xcframework`.

**Why it merged green:** the PR `CI` workflow is build + lint only and never runs the gym Release archive / `sign-ios-frameworks`. The script's first real exercise is the `Release from tag` workflow — so the regression only surfaced at release time. The previous release (`26.2.17`, pre-#1133) archived fine.

The signing log confirms the asymmetry — only the plugins came out unsigned on the device slice; Flutter/App were `replacing existing signature`:

| device slice | state out of `flutter build ios-framework` |
|---|---|
| `sqflite_darwin`, `path_provider_foundation`, `shared_preferences_foundation`, `Adapty*` | **unsigned** → genuinely need signing (ITMS-91065) |
| `Flutter`, `App` | **already signed** → must NOT be re-signed |

## Fix

- **`scripts/sign-ios-frameworks.sh`** — exclude `Flutter`, `App`, and the static link-only `FlutterPluginRegistrant` xcframeworks from the signing loop; keep signing the unsigned third-party plugins ITMS-91065 actually flags. (`FlutterPluginRegistrant` is link-only — verified it appears only in the Link phase of `project.pbxproj`, never an Embed phase — so it never lands in the bundle and ITMS-91065 can't fire on it.)
- **`scripts/verify-ios-ipa-signatures.sh`** (new) — post-archive gate: cracks the produced `.ipa` and asserts every embedded `*.framework` (incl. Flutter/App) is signed by the Apple Distribution identity, and that Flutter/App are actually present. Fails the build **before** upload rather than at App Store Connect. Override the expected authority with `IOS_EXPECTED_SIGN_AUTHORITY` (set empty to check presence only).
- **`Makefile`** — run the verifier after the host archive in `build-ios` / `build-ios-family` / `build-ios-six`.

This narrows the script to match what its own header comment already claims ("the add-to-app Flutter **plugin** xcframeworks") — the plugin signing that fixes the rejection is fully retained.

## Testing

- `sign-ios-frameworks.sh` prune logic tested against a synthetic tree: signs exactly the 9 plugin xcframeworks (both slices), excludes Flutter/App/FlutterPluginRegistrant.
- `verify-ios-ipa-signatures.sh` tested end-to-end with synthetic IPAs: passes when all embedded frameworks are validly signed; fails on an unsigned framework, a missing required framework, a wrong/ad-hoc signing identity, and aggregates failures across multiple IPAs.
- Both scripts parse and run under stock macOS `/bin/bash` 3.2 (CI runner); no bash-4 features.
- `make -n` confirms the verifier is wired with the correct IPA paths (`ios/Blokada Family.ipa`, `ios/Blokada 6.ipa`).

## Known follow-up (not in scope)

`release-tag.yml` tars `ios/*.ipa` (glob) while building a single flavor. It's safe today because `actions/checkout` runs `git clean -ffdx` and the IPAs are gitignored, but a stale opposite-flavor IPA could ship if `clean: false` were ever set. Worth an explicit `rm -f ios/*.ipa` or tarring the specific flavor in a separate change.

## Operator action required

Merge this **before** re-cutting the `26.2.18` iOS release tag — the current release build is broken without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)