### PR TITLE
fix(ios): make IPA signature verifier SIGPIPE-safe (fixes make Error 141)

### DIFF
--- a/scripts/verify-ios-ipa-signatures.sh
+++ b/scripts/verify-ios-ipa-signatures.sh
@@ -70,23 +70,38 @@ $name"
 		# `codesign --verify` fails both for a missing signature ("not signed at
 		# all" → ITMS-91065) and for a broken seal, so it is the right gate.
 		# Capture once (stderr carries the reason on failure).
+		#
+		# NB: everything below parses captured strings via here-strings / bash
+		# builtins, never `cmd | awk/grep/head`. With `set -o pipefail`, a
+		# downstream consumer that exits early (awk `exit`, grep -q, head) closes
+		# the pipe and the producer (e.g. codesign) dies with SIGPIPE → the
+		# pipeline returns 141 and `set -e` kills the whole script. That is
+		# exactly what broke the first release attempt (make ... Error 141).
 		if verr="$(codesign --verify --strict "$fw" 2>&1)"; then
-			authority="$(codesign -dvv "$fw" 2>&1 | awk -F'=' '/^Authority=/{print $2; exit}')"
-			if [ -n "$EXPECTED_AUTHORITY" ] && ! printf '%s' "$authority" | grep -qF "$EXPECTED_AUTHORITY"; then
-				echo "  FAIL $name  — signed by '${authority:-no authority}', expected authority containing '$EXPECTED_AUTHORITY'" >&2
-				unsigned=$((unsigned + 1))
+			info="$(codesign -dvv "$fw" 2>&1 || true)"
+			authority="$(awk -F'=' '/^Authority=/{print $2; exit}' <<< "$info")"
+			if [ -n "$EXPECTED_AUTHORITY" ]; then
+				case "$authority" in
+					*"$EXPECTED_AUTHORITY"*)
+						echo "  OK   $name  [${authority:-no authority line}]" ;;
+					*)
+						echo "  FAIL $name  — signed by '${authority:-no authority}', expected authority containing '$EXPECTED_AUTHORITY'" >&2
+						unsigned=$((unsigned + 1)) ;;
+				esac
 			else
 				echo "  OK   $name  [${authority:-no authority line}]"
 			fi
 		else
-			echo "  FAIL $name  — $(printf '%s' "$verr" | head -1)" >&2
+			echo "  FAIL $name  — ${verr%%$'\n'*}" >&2
 			unsigned=$((unsigned + 1))
 		fi
 	done <<< "$frameworks"
 
 	# Fail loudly if a framework we expect to be embedded is missing entirely.
+	# `grep` reads a here-string (not a pipeline), so its early exit on a match
+	# cannot trigger the SIGPIPE/pipefail trap described above.
 	for req in "${REQUIRED_FRAMEWORKS[@]}"; do
-		if ! printf '%s\n' "$seen" | grep -qx "$req"; then
+		if ! grep -qx "$req" <<< "$seen"; then
 			echo "  MISSING $req — expected to be embedded but not found in $ipa" >&2
 			unsigned=$((unsigned + 1))
 		fi


### PR DESCRIPTION
## Problem

Follow-up to #1135. With that merged, the `26.2.19/six/ios` release archive **now succeeds** ([run 27822354018](https://github.com/blokadaorg/blokada/actions/runs/27822354018)) — `sign-ios-frameworks: signed & verified 18 framework(s)` and `fastlane.tools finished successfully 🎉`. The Flutter/App exclusion fixed the `SignatureCollection` crash.

But the new post-archive verifier then died:

```
verify-ios-ipa-signatures: inspecting ios/Blokada 6.ipa
make[1]: *** [build-ios-six] Error 141
```

Exit `141` = `128 + 13` = **SIGPIPE**. The verifier ran `codesign -dvv "$fw" 2>&1 | awk '/^Authority=/{…; exit}'`. awk's early `exit` closes the pipe, `codesign` is still writing → SIGPIPE, and `set -o pipefail` + `set -e` propagate `141` and abort the script. My local test frameworks were tiny, so codesign finished before awk exited and the bug never showed; the large real frameworks in CI kept codesign writing past awk's exit.

The same hazard existed in three other spots (`printf | grep -qF`, `printf | head -1`, `printf | grep -qx`).

## Fix

Parse captured strings with here-strings / bash builtins instead of piping into early-exiting consumers:
- `info="$(codesign -dvv … || true)"` then `awk … <<< "$info"` (no pipeline).
- authority substring match via `case` instead of `printf | grep -qF`.
- first verify-error line via `${verr%%$'\n'*}` instead of `printf | head -1`.
- required-framework check via `grep -qx … <<< "$seen"` (here-string, not a pipeline).

## Testing

- Reproduced the mechanism under `set -euo pipefail`: `seq 1 200000 | awk '…exit'` → exit `141`; the here-string form → exit `0`. Confirms cause and fix.
- Re-ran the synthetic-IPA suite (all-signed pass; unsigned-framework fail; missing-required fail; wrong/ad-hoc identity fail; presence-only mode) — all behave correctly, exit codes as expected.
- `/bin/bash -n` parses under stock macOS bash 3.2.

## Operator action required

Merge, then re-run the `Release from tag` workflow for the iOS flavor — the archive is confirmed working; this only unblocks the final verification gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)