### PR TITLE
fix(ios): sign plugin xcframework bundles with --timestamp (real ITMS-91065 fix)

### DIFF
--- a/scripts/sign-ios-frameworks.sh
+++ b/scripts/sign-ios-frameworks.sh
@@ -1,27 +1,33 @@
 #!/usr/bin/env bash
 #
-# Code-sign the add-to-app Flutter plugin xcframeworks before the host Xcode
-# archive embeds them.
+# Sign the add-to-app Flutter plugin XCFRAMEWORK BUNDLES (with a secure
+# timestamp) before the host Xcode archive consumes them.
 #
-# Why this exists:
+# Why this exists / what ITMS-91065 actually checks:
 #   `flutter build ios-framework` (see common/Makefile `build-ios`) emits every
-#   plugin as an UNSIGNED .xcframework. The host project embeds each with
-#   "Code Sign On Copy", but that runtime re-sign is unreliable for the device
-#   slice of a pre-built xcframework (flutter/flutter#148300, #179634), so the
-#   embedded framework can ship unsigned. App Store Connect then rejects the
-#   upload with ITMS-91065 ("Missing signature") for commonly-used SDKs such as
-#   sqflite (sqflite_darwin.framework), path_provider and shared_preferences.
+#   plugin as an UNSIGNED .xcframework. App Store Connect then rejects the upload
+#   with ITMS-91065 ("Missing signature") for commonly-used third-party SDKs such
+#   as sqflite (sqflite_darwin), path_provider and shared_preferences.
 #
-#   Signing the inner .framework of each slice here guarantees a valid signature
-#   is present regardless of whether Code-Sign-On-Copy runs: if Xcode re-signs on
-#   copy it harmlessly overwrites ours with the same Apple Distribution identity;
-#   if it skips the slice, our signature is what ships. Signing the .xcframework
-#   *wrapper* is NOT enough — it does not propagate to the inner frameworks that
-#   actually land in the app bundle.
+#   ITMS-91065 does NOT check the embedded framework's code signature — Xcode's
+#   embed/export step code-signs that on copy (verified separately by
+#   scripts/verify-ios-ipa-signatures.sh). It checks the XCFRAMEWORK's own
+#   *origin* signature, which the archive records into the IPA at
+#   `Signatures/<name>.xcframework-ios.signature` as `signed` / `isSecureTimestamp`.
+#   An unsigned .xcframework yields `signed=false` → ITMS-91065. (This is the
+#   feature documented in "Verifying the origin of your XCFrameworks", the page
+#   Apple's rejection email links to.)
 #
-# Scope: only used by the release archive targets in the root Makefile
-# (build-ios / build-ios-family / build-ios-six). Debug/simulator builds sign via
-# the normal dev identity on copy and do not go through here.
+#   The fix is Apple's canonical command — also the sqflite maintainer's accepted
+#   resolution (tekartik/sqflite#1129): sign the .xcframework *bundle* WITH
+#   `--timestamp`, so the recorded origin signature has `signed=true` AND
+#   `isSecureTimestamp=true`. Signing the inner per-slice .framework does NOT
+#   satisfy this (wrong artifact; the export re-signs it anyway) and additionally
+#   broke the archive's SignatureCollection step for Flutter (release 26.2.18).
+#
+# Scope: release archive targets only (build-ios / build-ios-family /
+#   build-ios-six). `--timestamp` contacts Apple's timestamp server, so this step
+#   needs network at build time.
 #
 # Override the signing identity or config via env:
 #   IOS_CODESIGN_IDENTITY="Apple Distribution: ... (TEAMID)"  CONFIG=Release
@@ -51,50 +57,49 @@ if ! security find-identity -v -p codesigning 2>/dev/null | grep -qF "$IDENTITY"
 	exit 1
 fi
 
-# Do NOT sign Flutter's own first-party outputs. Flutter.framework and
-# App.framework come out of `flutter build ios-framework` ALREADY signed
-# (io.flutter.flutter / io.flutter.flutter.app) and are not on the unsigned-
-# plugin list ITMS-91065 flags. Re-signing them here breaks the host archive:
-# Xcode's ProcessXCFramework → SignatureCollection task on Flutter.xcframework
-# fails with `signature-collection failed ... SWBUtil.CodeSignatureInfo.Error
-# error 0` → ** ARCHIVE FAILED ** (release 26.2.18 regression). The host
-# add-to-app embedding signs Flutter/App itself, so leave them untouched.
-# FlutterPluginRegistrant is a static, link-only framework — never embedded in
-# the app bundle, so ITMS-91065 cannot fire on it and signing it is pointless.
+# Do NOT sign Flutter's own first-party xcframeworks. Flutter.xcframework already
+# carries a valid origin signature (Google signs it) and re-signing it breaks the
+# archive's SignatureCollection step (release 26.2.18). App.xcframework is the
+# app's own Dart code and FlutterPluginRegistrant is static/link-only — neither
+# is a third-party SDK, so ITMS-91065 never flags them.
 EXCLUDED_XCFRAMEWORKS=(Flutter App FlutterPluginRegistrant)
 
-# Gather the framework list first (tolerating a transient find error via `|| true`)
-# so the producer pipeline's exit status can't abort the run mid-loop under
-# `pipefail`. Sort deepest-first so any nested frameworks are signed before their
-# container (inside-out signing); the awk field is the slash count = path depth.
-prune=()
-for x in "${EXCLUDED_XCFRAMEWORKS[@]}"; do
-	prune+=(-not -path "*/$x.xcframework/*")
-done
-frameworks="$(find "$FRAMEWORK_DIR" -type d -name '*.framework' "${prune[@]}" 2>/dev/null \
-	| awk '{ print gsub(/\//, "/"), $0 }' | sort -rn | cut -d' ' -f2- || true)"
+is_excluded() {
+	local n="$1" ex
+	for ex in "${EXCLUDED_XCFRAMEWORKS[@]}"; do
+		[ "$n" = "$ex" ] && return 0
+	done
+	return 1
+}
 
-if [ -z "$frameworks" ]; then
-	echo "error: no .framework bundles found under $FRAMEWORK_DIR" >&2
+echo "sign-ios-frameworks: signing $CONFIG plugin xcframeworks (with secure timestamp) as '$IDENTITY'"
+
+shopt -s nullglob
+signed=0
+for xcf in "$FRAMEWORK_DIR"/*.xcframework; do
+	name="$(basename "$xcf" .xcframework)"
+	is_excluded "$name" && continue
+
+	# Sign the bundle. `--timestamp` is REQUIRED: the origin signature must record
+	# isSecureTimestamp=true (codesign contacts Apple's TSA → needs network).
+	# `--force` is idempotent — overwrites any signature from a prior run.
+	codesign --force --timestamp -v --sign "$IDENTITY" "$xcf"
+
+	# Verify before the archive consumes it: a valid signature AND a secure
+	# timestamp present, so a TSA failure is caught here rather than at upload.
+	# `grep` reads a here-string (not a pipeline) to avoid a SIGPIPE/pipefail abort.
+	codesign --verify --strict "$xcf"
+	if ! grep -q '^Timestamp=' <<< "$(codesign -dvv "$xcf" 2>&1 || true)"; then
+		echo "error: $name.xcframework signed without a secure timestamp (Apple TSA unreachable?)" >&2
+		exit 1
+	fi
+	echo "  signed $name.xcframework (secure timestamp)"
+	signed=$((signed + 1))
+done
+
+if [ "$signed" -eq 0 ]; then
+	echo "error: no plugin .xcframework bundles found under $FRAMEWORK_DIR" >&2
 	exit 1
 fi
 
-echo "sign-ios-frameworks: signing $CONFIG plugin frameworks as '$IDENTITY'"
-
-# `codesign --force` is idempotent — the frameworks may already carry a
-# _CodeSignature from a prior run; re-signing cleanly overwrites it.
-signed=0
-while IFS= read -r fw; do
-	[ -z "$fw" ] && continue
-	codesign --force -v --sign "$IDENTITY" "$fw"
-	signed=$((signed + 1))
-done <<< "$frameworks"
-
-# Verify every framework before the host archive consumes them, so a corrupt
-# signature is caught here rather than at App Store upload.
-while IFS= read -r fw; do
-	[ -z "$fw" ] && continue
-	codesign --verify --strict "$fw"
-done <<< "$frameworks"
-
-echo "sign-ios-frameworks: signed & verified $signed framework(s)"
+echo "sign-ios-frameworks: signed & verified $signed plugin xcframework(s) with secure timestamp"

--- a/scripts/verify-ios-ipa-signatures.sh
+++ b/scripts/verify-ios-ipa-signatures.sh
@@ -1,17 +1,20 @@
 #!/usr/bin/env bash
 #
-# Verify that every framework embedded in a built .ipa carries a valid code
-# signature, before it is uploaded to App Store Connect.
+# Verify a built .ipa is signed the way App Store Connect requires, before it is
+# uploaded. Two independent checks:
 #
-# Why this exists:
-#   scripts/sign-ios-frameworks.sh signs the *unsigned* third-party plugin
-#   xcframeworks (sqflite_darwin, path_provider, shared_preferences, Adapty*)
-#   to satisfy ITMS-91065, and deliberately does NOT touch Flutter's own
-#   Flutter.framework / App.framework (they ship pre-signed; re-signing them
-#   breaks Xcode's ProcessXCFramework/SignatureCollection step). This check
-#   proves that assumption end-to-end: it cracks open the final .ipa and
-#   confirms EVERY embedded framework — Flutter and App included — is signed,
-#   so a missing signature is caught here instead of by App Store Connect.
+#   1. ITMS-91065 (the real gate): each commonly-used third-party SDK's
+#      XCFRAMEWORK must carry an *origin* signature. The archive records this in
+#      Signatures/<name>.xcframework-ios.signature as `signed` / `isSecureTimestamp`.
+#      An unsigned .xcframework → signed=false → ITMS-91065 "Missing signature".
+#      scripts/sign-ios-frameworks.sh signs the plugin .xcframework bundles WITH
+#      `--timestamp` to make these signed=true AND isSecureTimestamp=true; this
+#      asserts the result. Flutter/App/FlutterPluginRegistrant are not third-party
+#      SDKs (Apple does not flag them), so they are not required here.
+#
+#   2. Embedded code signatures (defensive): every framework embedded in the app
+#      should be validly code-signed by the App Store distribution identity. Not
+#      what ITMS-91065 checks, but a cheap guard against an unsigned/ad-hoc slice.
 #
 # Usage: verify-ios-ipa-signatures.sh <path-to.ipa> [more.ipa ...]
 #
@@ -27,6 +30,11 @@ fi
 # Frameworks that MUST be present and signed in an add-to-app .ipa. Their
 # absence would make an "all signed" pass vacuously true, so assert them.
 REQUIRED_FRAMEWORKS=(Flutter.framework App.framework)
+
+# XCFrameworks NOT required to carry a third-party-SDK origin signature: Flutter
+# is already Google-signed, App is the app's own code, FlutterPluginRegistrant is
+# static/link-only. Keep in sync with sign-ios-frameworks.sh.
+EXCLUDED_XCFRAMEWORKS=(Flutter App FlutterPluginRegistrant)
 
 # A valid-but-wrong signature (ad-hoc, or a development cert) passes
 # `codesign --verify` yet App Store Connect still rejects it, so also assert the
@@ -106,6 +114,33 @@ $name"
 			unsigned=$((unsigned + 1))
 		fi
 	done
+
+	# --- ITMS-91065 gate: third-party SDK xcframework ORIGIN signatures ---
+	# Apple reads Signatures/<name>.xcframework-ios.signature, recorded by the
+	# archive. Each non-excluded (third-party SDK) xcframework must be signed=true
+	# AND isSecureTimestamp=true, else App Store Connect rejects with ITMS-91065.
+	sigdir="$workdir/Signatures"
+	if [ -d "$sigdir" ]; then
+		for sigf in "$sigdir"/*.xcframework-ios.signature; do
+			[ -e "$sigf" ] || continue
+			xcname="$(basename "$sigf" .xcframework-ios.signature)"
+			skip=0
+			for ex in "${EXCLUDED_XCFRAMEWORKS[@]}"; do
+				[ "$xcname" = "$ex" ] && skip=1
+			done
+			[ "$skip" -eq 1 ] && continue
+			is_signed="$(plutil -extract signed raw -o - "$sigf" 2>/dev/null || echo false)"
+			is_ts="$(plutil -extract isSecureTimestamp raw -o - "$sigf" 2>/dev/null || echo false)"
+			if [ "$is_signed" = "true" ] && [ "$is_ts" = "true" ]; then
+				echo "  OK   $xcname.xcframework  [origin: signed + secure timestamp]"
+			else
+				echo "  FAIL $xcname.xcframework  — origin signature signed=$is_signed isSecureTimestamp=$is_ts (ITMS-91065)" >&2
+				unsigned=$((unsigned + 1))
+			fi
+		done
+	else
+		echo "  WARNING: no Signatures/ in $ipa — cannot verify xcframework origin signatures (ITMS-91065)" >&2
+	fi
 
 	if [ "$unsigned" -ne 0 ]; then
 		echo "verify-ios-ipa-signatures: $unsigned unsigned/missing framework(s) in $ipa — App Store would reject (ITMS-91065)" >&2


### PR DESCRIPTION
## TL;DR

ITMS-91065 kept rejecting `sqflite_darwin` across **26.2.18 → 26.2.20** even though the embedded framework was validly code-signed. By inspecting the actual rejected IPA I found ITMS-91065 reads a *different* artifact than we'd been fixing. This signs the right one.

## Root cause (from the rejected 26.2.20 IPA, build 669000012)

ITMS-91065 does **not** check the embedded framework's code signature. It checks each commonly-used third-party SDK's **xcframework origin signature**, which the archive records into the IPA at `Signatures/<name>.xcframework-ios.signature`. For sqflite that file said:

```
{ "signed" => false, "isSecureTimestamp" => false,
  "metadata" => { "library" => "sqflite_darwin.framework", "platform" => "ios" } }
```

`signed=false` → "Missing signature." We'd been signing the inner `.framework`, but the `.xcframework` **bundle** stayed unsigned. (And the host export re-signs the embedded slice at export time anyway, so the inner signing was a no-op that never reached the shipped binary — which is why #1133/#1135 didn't move the needle.)

This is exactly the feature behind the doc Apple's rejection links to ("Verifying the origin of your XCFrameworks"), and the same `SignatureCollection` step that originally crashed the archive.

## Fix

Apple's canonical command — and the sqflite maintainer's accepted fix ([tekartik/sqflite#1129](https://github.com/tekartik/sqflite/issues/1129)): sign the `.xcframework` **bundle** with `--timestamp`.

- **`sign-ios-frameworks.sh`**: sign the plugin `.xcframework` bundles with `codesign --force --timestamp --sign …` (was: inner per-slice `.framework`, no timestamp). Still excludes `Flutter` (already Google-signed; re-signing it crashed the archive in 26.2.18), `App`, and `FlutterPluginRegistrant` (not third-party SDKs). Verifies each carries a secure timestamp before the archive runs.
- **`verify-ios-ipa-signatures.sh`**: add the **real ITMS-91065 gate** — parse `Signatures/*.xcframework-ios.signature` and require `signed=true` + `isSecureTimestamp=true` for each non-excluded SDK xcframework. The embedded code-signature check stays as a defensive secondary check.

No Makefile change — same `sign-ios-frameworks` target and verify wiring from #1135.

## On reverting #1135 / #1136 (you asked)

Neither should be reverted:
- **#1136** (SIGPIPE fix) — pure correctness fix to the verifier we keep; reverting reintroduces `make Error 141`.
- **#1135** — keep the Flutter/App exclusion, the verify gate, and the Makefile wiring. Only its *inner-framework signing* was the wrong target; this PR replaces that in place. The exclusion is still load-bearing (signing Flutter's xcframework crashes the archive).

## Testing

- Verified against the **actual rejected 26.2.20 IPA**: the new gate FAILs it on all 9 plugin origin signatures (`signed=false`), and PASSes once the origin signatures are corrected.
- Confirmed locally that `codesign --force --timestamp --sign "Apple Distribution: …" sqflite_darwin.xcframework` yields `signed`=valid with a secure `Timestamp=` and passes `codesign --verify`.
- Selection logic signs the 9 plugin xcframeworks and skips Flutter/App/FlutterPluginRegistrant.
- Both scripts parse under stock `/bin/bash` 3.2.

## Confidence & residual risk

High confidence on the diagnosis (the `.signature` file literally says `signed=false`) and that signing the bundle with `--timestamp` flips it. The one thing only a real archive can confirm is that Xcode's `SignatureCollection` records `signed=true`/`isSecureTimestamp=true` from the signed bundle — **the verify gate now checks exactly that in CI and fails the build before upload if it didn't**, so the next release either ships clean or fails safely without burning an Apple round-trip.

## Operator action required

Merge, then cut a new iOS release tag (e.g. `26.2.21`). The build's verify step will confirm the origin signatures before upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)