### PR TITLE
fix(ios): gate ITMS-91065 on signed=true, warn on missing secure timestamp

### DIFF
--- a/scripts/verify-ios-ipa-signatures.sh
+++ b/scripts/verify-ios-ipa-signatures.sh
@@ -7,10 +7,10 @@
 #      XCFRAMEWORK must carry an *origin* signature. The archive records this in
 #      Signatures/<name>.xcframework-ios.signature as `signed` / `isSecureTimestamp`.
 #      An unsigned .xcframework → signed=false → ITMS-91065 "Missing signature".
-#      scripts/sign-ios-frameworks.sh signs the plugin .xcframework bundles WITH
-#      `--timestamp` to make these signed=true AND isSecureTimestamp=true; this
-#      asserts the result. Flutter/App/FlutterPluginRegistrant are not third-party
-#      SDKs (Apple does not flag them), so they are not required here.
+#      scripts/sign-ios-frameworks.sh signs the plugin .xcframework bundles to
+#      make these signed=true. We gate hard on `signed`; a missing secure
+#      timestamp only WARNs (see below). Flutter/App/FlutterPluginRegistrant are
+#      not third-party SDKs (Apple does not flag them), so they are not checked.
 #
 #   2. Embedded code signatures (defensive): every framework embedded in the app
 #      should be validly code-signed by the App Store distribution identity. Not
@@ -131,10 +131,21 @@ $name"
 			[ "$skip" -eq 1 ] && continue
 			is_signed="$(plutil -extract signed raw -o - "$sigf" 2>/dev/null || echo false)"
 			is_ts="$(plutil -extract isSecureTimestamp raw -o - "$sigf" 2>/dev/null || echo false)"
-			if [ "$is_signed" = "true" ] && [ "$is_ts" = "true" ]; then
-				echo "  OK   $xcname.xcframework  [origin: signed + secure timestamp]"
+			# `signed=true` is the documented ITMS-91065 requirement (the SDK "must
+			# include a signature file"). A secure timestamp is best-practice (Apple's
+			# example signs with --timestamp) but is NOT confirmed to be required, and
+			# Xcode's archive does not reliably record one onto the recorded origin
+			# signature even when the .xcframework was signed with --timestamp. So gate
+			# hard on `signed`, and only WARN when the timestamp is missing — let App
+			# Store Connect be the authority on whether it is mandatory.
+			if [ "$is_signed" = "true" ]; then
+				if [ "$is_ts" = "true" ]; then
+					echo "  OK   $xcname.xcframework  [origin: signed + secure timestamp]"
+				else
+					echo "  WARN $xcname.xcframework  [origin: signed=true, isSecureTimestamp=false — uploading anyway; ITMS-91065 may still flag it]" >&2
+				fi
 			else
-				echo "  FAIL $xcname.xcframework  — origin signature signed=$is_signed isSecureTimestamp=$is_ts (ITMS-91065)" >&2
+				echo "  FAIL $xcname.xcframework  — origin signature signed=$is_signed (ITMS-91065: SDK xcframework not signed)" >&2
 				unsigned=$((unsigned + 1))
 			fi
 		done


### PR DESCRIPTION
## Why 26.2.21 failed

It failed at **our verify gate, not Apple** — and that's actually good news, because the signing fix from #1137 *worked*:

```
FAIL sqflite_darwin.xcframework — origin signature signed=true isSecureTimestamp=false (ITMS-91065)
```

- `signed=true` for all 9 plugin xcframeworks (was `signed=false` in 26.2.20) → **bundle-signing fixed the core problem.** The `sign-ios-frameworks` step confirms it signed each bundle *with* a secure timestamp.
- But the archive recorded `isSecureTimestamp=false`, and the gate required both → it blocked the build before upload (no Apple round-trip wasted).

## The judgment call

`signed=true` is the **documented** ITMS-91065 requirement ("the SDK must include a signature file"). `isSecureTimestamp=true` is best-practice (Apple's example signs with `--timestamp`) but is **not confirmed to be required**, and Xcode's `SignatureCollection` does not reliably record `isSecureTimestamp=true` onto the origin signature even when the `.xcframework` was signed with `--timestamp` (we sign with it; the recorded value is still false). Requiring it blocks a build that already satisfies the documented rule.

## Change

In `verify-ios-ipa-signatures.sh`, gate hard on `signed=true` and downgrade a missing secure timestamp to a **WARNING** (still printed, doesn't fail the build). This lets the next release upload so App Store Connect — the only authority on whether the timestamp is mandatory — gives the verdict.

- `signed=true`, `isSecureTimestamp=true` → OK
- `signed=true`, `isSecureTimestamp=false` → **WARN, uploads** (the 26.2.21 case)
- `signed=false` → **FAIL** (the genuine ITMS-91065 condition)

Tested against the real rejected IPA's signature files: passes-with-warning when `signed=true`, fails when `signed=false`.

## Next step / two outcomes

This is the fastest way to resolve the remaining uncertainty:
- If Apple **accepts** the next build → `signed=true` was sufficient; done.
- If Apple **still flags ITMS-91065** → the secure timestamp *is* required; we'll then target it specifically (likely signing the inner slice with `--timestamp` and/or `OTHER_CODE_SIGN_FLAGS=--timestamp` so `SignatureCollection` records it), now with a confirmed requirement instead of a guess.

## Operator action required

Merge, then cut a new iOS release tag (e.g. `26.2.22`). The build will upload with `signed=true`; watch for the App Store Connect processing result (ITMS email arrives within minutes if it's still unhappy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)