### PR TITLE
build(deps): pin pigeon to 12.0.1 via dependency_overrides (hold pigeon 26)

### DIFF
--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -60,6 +60,15 @@ dependencies:
 
 dependency_overrides:
   intl: 0.20.2
+  # pigeon is HELD at 12 on purpose: pigeon 26 needs a native Swift/Kotlin codegen
+  # migration (setup->setUp call-site rename plus Kotlin enum / Swift PigeonError
+  # changes) judged disproportionate for a dev-only tool. The dependabot semver-major
+  # ignore and the flutter-dependencies group `exclude-patterns: [pigeon]` do NOT hold:
+  # grouping other bumps makes Dependabot's solver re-widen `pigeon: ^12.0.0` to
+  # `>=12.0.0 <27.0.0` and re-lock 26.3.2 (e.g. #1139), breaking `make gen-*` codegen.
+  # An override can't be widened by Dependabot, so it pins the lock. Drop this together
+  # with the ignore/exclude when the pigeon 26 native migration is scheduled.
+  pigeon: 12.0.1
   # adapty_flutter 3.17.0 (latest) hardcodes kotlinOptions.jvmTarget = '1.8' in its
   # android/build.gradle, but its Adapty native Android SDK (io.adapty:android-ui via
   # adapty-bom 3.17.1) is compiled for JVM 11 and exposes inline functions used by the


### PR DESCRIPTION
## Why

pigeon 26 needs a native Swift/Kotlin codegen migration (call-site `setup`→`setUp` rename + Kotlin enum / Swift `PigeonError` changes) and is **deliberately held** — too costly for a dev-only codegen tool.

The two existing guards do **not** actually hold the line:
- the top-level `ignore: pigeon / version-update:semver-major`, and
- the `flutter-dependencies` group `exclude-patterns: ["pigeon"]` (commit `a81dacb1`).

When Dependabot recreates the `flutter-dependencies` group for other bumps, its version solver re-widens `pigeon: ^12.0.0` → `">=12.0.0 <27.0.0"` and re-locks **26.3.2** to resolve the rest of the group. That breaks `make gen-ios` / `gen-android` codegen and fails the build:

```
lib/src/platform/command/command.dart:31:40: Error: Member not found: 'CommandEvents.setup'.
```

Most recently this sank **#1139** (Flutter analyze + iOS build red). It keeps recurring every cycle (#1106 / #1109 / #1114 / #1124 / #1139).

## Fix

Add `pigeon: 12.0.1` to `dependency_overrides`. A `dependency_overrides` entry **cannot be widened by Dependabot**, so the lock stays pinned regardless of group resolution. `exclude-patterns` only stops pigeon from being a *named* grouped update; it doesn't stop the solver from re-widening the constraint — the override does.

## Impact

- `flutter pub get` succeeds; **`pubspec.lock` is unchanged** (main already resolves pigeon to 12.0.1) — this only makes the pin durable.
- Drop this override together with the ignore/exclude when the pigeon 26 native migration is scheduled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)