### PR TITLE
test(appium): paywall smoke scenario + automated account control

### DIFF
--- a/.github/workflows/appium-smoke.yml
+++ b/.github/workflows/appium-smoke.yml
@@ -50,6 +50,11 @@ jobs:
         env:
           IOS_AUTO_SELECT_FIRST: "1"
           SHOW_XCODE_LOG: "0"
+          # Dedicated dev accounts the specs restore via the support-chat command
+          # bus: paywall needs inactive (libre, non-freemium, non-family),
+          # DNS onboarding needs active (non-family).
+          BLOKADA_ACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_ACTIVE_ACCOUNT_ID }}
+          BLOKADA_INACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_INACTIVE_ACCOUNT_ID }}
         run: make appium-test
 
       - name: Upload appium screenshots on failure

--- a/automation/appium/README.md
+++ b/automation/appium/README.md
@@ -290,7 +290,22 @@ If the session drops unexpectedly, first suspect device auto-lock or lost foregr
 
 ## Extending the Suite
 
-- Add specs under `automation/appium/wdio/src/specs/`.  
+- Add specs under `automation/appium/wdio/src/specs/` **and register them in the
+  explicit `specs` list in `wdio.conf.ts`** (the glob was replaced so spec order
+  is deterministic). Order by account state: inactive-account scenarios first,
+  active-account scenarios last, so the suite ends with the device active.
+- Control account state with `flows/account.ts`: `ensureAccountActive()` /
+  `ensureAccountInactive()` restore a dedicated account via the support-chat
+  command bus (`cc restore <id>`), reading the ids from the
+  `BLOKADA_ACTIVE_ACCOUNT_ID` / `BLOKADA_INACTIVE_ACCOUNT_ID` env (GitHub
+  secrets in CI). `sendChatCommand(...)` can fire any `cc`-prefixed command.
+  These ids are typed into the support chat (and echoed as a bubble), so they
+  can appear in failure page-source / screenshot artifacts — use dedicated
+  throwaway dev accounts, never a real customer account.
+- Golden screenshots: `support/golden.ts` `compareToGolden(name, opts)`. Goldens
+  live in `src/specs/smoke/__golden__/` and are device-resolution specific.
+  Generate/refresh a baseline with `UPDATE_GOLDEN=1 make appium-test` on the
+  target device, then commit the PNG.
 - Use `driver.execute('mobile: ...')` helpers for Settings navigation (DNS/VPN flows).  
 - Once stable, wire `make appium-test` into CI with a dedicated device lane.  
 - When the app exposes stable accessibility identifiers, update selectors to drop the localization fallbacks.

--- a/automation/appium/wdio/package-lock.json
+++ b/automation/appium/wdio/package-lock.json
@@ -18,8 +18,11 @@
       "devDependencies": {
         "@types/chai": "^5.2.3",
         "@types/node": "^26.0.0",
+        "@types/pngjs": "^6.0.5",
         "appium": "^3.5.0",
         "chai": "^6.2.2",
+        "pixelmatch": "^7.1.0",
+        "pngjs": "^7.0.0",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
         "typescript": "^6.0.3"
@@ -2402,6 +2405,16 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
@@ -8078,6 +8091,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pixelmatch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.2.0.tgz",
+      "integrity": "sha512-xhcb4yHu9sM/G7foGzoLtXYcC0zHEaOXXjRKhGup0fw78Nf2Tkiapv4EQyMzrbcmQPsllAI7DbFY2UT7PlI9Pg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "pngjs": "^7.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
+    },
     "node_modules/plist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/plist/-/plist-4.0.0.tgz",
@@ -8100,6 +8126,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/pretty-format": {

--- a/automation/appium/wdio/package.json
+++ b/automation/appium/wdio/package.json
@@ -23,8 +23,11 @@
   "devDependencies": {
     "@types/chai": "^5.2.3",
     "@types/node": "^26.0.0",
+    "@types/pngjs": "^6.0.5",
     "appium": "^3.5.0",
     "chai": "^6.2.2",
+    "pixelmatch": "^7.1.0",
+    "pngjs": "^7.0.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^6.0.3"

--- a/automation/appium/wdio/src/flows/account.ts
+++ b/automation/appium/wdio/src/flows/account.ts
@@ -1,0 +1,201 @@
+import { $, driver } from "@wdio/globals";
+
+import { AutomationIds } from "../support/automationIds.js";
+import { activateApp, terminateApp } from "./app.js";
+import { acceptNotificationAlert } from "./alerts.js";
+import { waitForPowerButton } from "./home.js";
+import { dismissRatePromptIfPresent } from "./modals.js";
+import { dismissIntroOverlayIfPresent } from "./onboarding.js";
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+
+const homeSettingsSelector = `~${AutomationIds.homeSettings}`;
+const settingsScreenSelector = `~${AutomationIds.screenSettings}`;
+const supportRowSelector = `~${AutomationIds.settingsSupport}`;
+
+// The support-chat composer comes from the third-party `flutter_chat_ui`
+// package and carries no automation ids, so we locate it structurally: the
+// chat screen has exactly one text input.
+const chatInputSelector =
+  "-ios predicate string: type == 'XCUIElementTypeTextField' OR type == 'XCUIElementTypeTextView'";
+const chatSendLabelSelectors = [
+  "~Send",
+  "-ios predicate string: type == 'XCUIElementTypeButton' AND (label CONTAINS[c] 'Send' OR name CONTAINS[c] 'Send')"
+];
+
+export interface AccountIds {
+  active: string;
+  inactive: string;
+}
+
+function readRequiredEnv(name: string): string {
+  const value = (process.env[name] ?? "").trim();
+  if (!value) {
+    throw new Error(
+      `Missing required env ${name}. Set it (CI: GitHub secret ${name}) to a ` +
+        `valid Blokada account id.`
+    );
+  }
+  return value;
+}
+
+/** Account ids from env; throws a clear, named error if a secret is missing. */
+export function getAccountIds(): AccountIds {
+  return {
+    active: readRequiredEnv("BLOKADA_ACTIVE_ACCOUNT_ID"),
+    inactive: readRequiredEnv("BLOKADA_INACTIVE_ACCOUNT_ID")
+  };
+}
+
+async function elementExists(selector: string): Promise<boolean> {
+  try {
+    return await (await $(selector)).isExisting();
+  } catch {
+    return false;
+  }
+}
+
+/** Navigate Home -> in-app Settings via the home gear (bottom-tab ids are unreliable). */
+export async function openSettingsScreen(timeout = 15000): Promise<void> {
+  const gear = await $(homeSettingsSelector);
+  await gear.waitForExist({ timeout });
+  await gear.click();
+  await (await $(settingsScreenSelector)).waitForExist({ timeout });
+}
+
+/** Navigate Home -> Settings -> Support chat and wait for the composer input. */
+export async function openSupportChat(timeout = 15000): Promise<void> {
+  await openSettingsScreen(timeout);
+  const row = await $(supportRowSelector);
+  await row.waitForExist({ timeout });
+  await row.click();
+  await (await $(chatInputSelector)).waitForExist({ timeout });
+}
+
+async function tapChatSend(): Promise<void> {
+  // The send IconButton (Icons.send) has no label; try a label match first,
+  // then fall back to tapping the far-right of the composer row (the send
+  // button sits to the right of the input). Device geometry is fixed in CI.
+  for (const selector of chatSendLabelSelectors) {
+    try {
+      const button = await $(selector);
+      if (await button.isExisting()) {
+        await button.click();
+        return;
+      }
+    } catch {
+      // try the next selector
+    }
+  }
+
+  const input = await $(chatInputSelector);
+  const location = await input.getLocation();
+  const size = await input.getSize();
+  const rect = await driver.getWindowRect();
+  await driver.execute("mobile: tap", {
+    x: Math.round(rect.width - 28),
+    y: Math.round(location.y + size.height / 2)
+  });
+}
+
+/**
+ * Drive the support chat to run a command through the app command bus. Any
+ * message prefixed `cc ` is routed to `command.onCommandString`, so this is a
+ * generic injection point (e.g. `restore <id>`, `route home`). Must be called
+ * from the Home screen.
+ */
+export async function sendChatCommand(command: string): Promise<void> {
+  await dismissRatePromptIfPresent(2000);
+  await openSupportChat();
+
+  const input = await $(chatInputSelector);
+  await input.waitForExist({ timeout: 10000 });
+  await input.click();
+  try {
+    await input.clearValue();
+  } catch {
+    // field may already be empty / not clearable — ignore
+  }
+  await input.setValue(`cc ${command}`);
+  await tapChatSend();
+
+  // The return key inserts a newline rather than submitting, so the tap above
+  // is the only submit path. Brief settle for the user bubble to echo; callers
+  // that need command completion (see restoreAccount) wait on a real signal.
+  await driver.pause(1000);
+}
+
+/**
+ * Switch the active account by id via `cc restore <id>`, then relaunch to a
+ * clean Home. Relaunch is deterministic regardless of the restore branch
+ * (active restore reroutes to Settings; inactive stays on the chat screen).
+ */
+export async function restoreAccount(accountId: string): Promise<void> {
+  await sendChatCommand(`restore ${accountId}`);
+
+  // Wait for the restore to complete before relaunching, so a slow network
+  // restore is not killed mid-persist. An active restore reroutes to the
+  // Settings screen only after the account API call + persist, which is a
+  // reliable, history-proof completion signal. An inactive restore stays on the
+  // chat with no nav and no dependable UI signal (the "OK" reply bubble can be
+  // a stale message from a prior run's persisted chat history), so fall back to
+  // a fixed settle covering the network round trip.
+  const rerouted = await driver
+    .waitUntil(async () => await elementExists(settingsScreenSelector), {
+      timeout: 8000,
+      interval: 400
+    })
+    .then(() => true)
+    .catch(() => false);
+  if (!rerouted) {
+    await driver.pause(4000);
+  }
+
+  await terminateApp(APP_BUNDLE_ID);
+  await activateApp(APP_BUNDLE_ID);
+  await dismissRatePromptIfPresent(5000);
+  await acceptNotificationAlert();
+  await dismissIntroOverlayIfPresent();
+  await waitForPowerButton();
+}
+
+/**
+ * Ensure the device is on the active (paid) account. Does NOT wait on the power
+ * toggle: an active account does not imply protection is ON — the DNS spec
+ * turns protection on and that flow is the authoritative active-account check.
+ */
+export async function ensureAccountActive(): Promise<void> {
+  await restoreAccount(getAccountIds().active);
+}
+
+/**
+ * Ensure the device is on the inactive (libre) account so the paywall appears
+ * on the next power tap. Switching to libre clears Plus, so protection should
+ * switch off; we wait for that as a coarse sanity check, but the paywall spec's
+ * tap-power assertion is the authoritative inactive check (the power toggle's
+ * value reflects protection on/off, not account state).
+ */
+export async function ensureAccountInactive(): Promise<void> {
+  await restoreAccount(getAccountIds().inactive);
+  // Best-effort settle: switching to libre clears Plus so protection should go
+  // off, but the toggle value reflects protection (not account) state, so this
+  // is only a coarse signal — never fail here. The paywall spec's tap-power
+  // assertion is the authoritative inactive check.
+  await driver
+    .waitUntil(
+      async () => {
+        if (!(await elementExists(`~${AutomationIds.powerToggle}`))) {
+          return false;
+        }
+        const value = await (await $(`~${AutomationIds.powerToggle}`)).getAttribute("value");
+        return typeof value === "string" && value.toLowerCase() === "inactive";
+      },
+      { timeout: 15000, interval: 500 }
+    )
+    .catch(() => {
+      console.warn(
+        "ensureAccountInactive: protection still appears on after restore; " +
+          "the paywall assertion will verify account state."
+      );
+    });
+}

--- a/automation/appium/wdio/src/specs/smoke/dns-onboarding.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/dns-onboarding.spec.ts
@@ -1,8 +1,9 @@
 import { driver } from "@wdio/globals";
 import { expect } from "chai";
 
-import { activateApp, switchToAppViaAppSwitcher } from "../../flows/app.js";
+import { activateApp, switchToAppViaAppSwitcher, terminateApp } from "../../flows/app.js";
 import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive } from "../../flows/account.js";
 import { getProtectionState, tapPowerButton, waitForPowerButton, waitForProtectionActive, waitForProtectionInactive } from "../../flows/home.js";
 import { dismissIntroOverlayIfPresent, openDnsSettingsFromSheet, waitForDnsOnboardingDismiss, waitForDnsOnboardingSheet } from "../../flows/onboarding.js";
 import { enableDnsProfile, waitForSettingsForeground, SETTINGS_BUNDLE_ID } from "../../flows/settings.js";
@@ -16,6 +17,21 @@ const APP_DISPLAY_NAME =
   (process.env.APP_DISPLAY_NAME ?? process.env.APP_NAME ?? "").trim();
 
 describe("Smoke: DNS onboarding flow", () => {
+  before(async () => {
+    // Self-heal the shared device: the paywall spec leaves it on the inactive
+    // account, so restore the active account before this flow (which assumes a
+    // paid account). Order-independent across runs.
+    // Relaunch first to dismiss any leftover native modal (e.g. the Adapty
+    // paywall the prior spec presented) — activateApp alone cannot close it.
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
   it("enables protection after provisioning DNS permissions", async () => {
     await activateApp(APP_BUNDLE_ID);
     await dismissRatePromptIfPresent(5000);

--- a/automation/appium/wdio/src/specs/smoke/paywall.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/paywall.spec.ts
@@ -1,0 +1,138 @@
+import { $, driver } from "@wdio/globals";
+
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountInactive } from "../../flows/account.js";
+import {
+  getProtectionState,
+  tapPowerButton,
+  waitForPowerButton,
+  waitForProtectionInactive
+} from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts, saveScreenshot } from "../../support/artifacts.js";
+import { compareToGolden } from "../../support/golden.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+
+const powerToggleSelector = `~${AutomationIds.powerToggle}`;
+const pauseSheetSelector = `~${AutomationIds.powerActionSheet}`;
+const dnsSheetSelector = `~${AutomationIds.dnsOnboardingSheet}`;
+// Adapty's paywall is dashboard-configured and carries no automation ids, so
+// the positive signal is a price/CTA control appearing over the home screen.
+const paywallCtaSelector =
+  "-ios predicate string: type == 'XCUIElementTypeButton' AND (" +
+  "label CONTAINS[c] 'Continue' OR label CONTAINS[c] 'Subscribe' OR " +
+  "label CONTAINS[c] 'Restore' OR label CONTAINS[c] 'Start' OR " +
+  "label CONTAINS[c] 'Try' OR label CONTAINS '$' OR label CONTAINS '€' OR " +
+  "label CONTAINS '£')";
+
+async function exists(selector: string): Promise<boolean> {
+  try {
+    return await (await $(selector)).isExisting();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Wait until the native Adapty paywall is presented after tapping power on an
+ * inactive account. Fails fast with a specific message if the account turns out
+ * not to be inactive/libre (protection activated, pause sheet, or DNS onboarding
+ * appeared instead).
+ */
+async function waitForPaywall(timeout = 20000): Promise<void> {
+  const end = Date.now() + timeout;
+  let toggleHiddenStreak = 0;
+  while (Date.now() < end) {
+    if (await exists(pauseSheetSelector)) {
+      throw new Error(
+        "Pause action sheet appeared instead of the paywall — account is " +
+          "active with protection ON, not inactive."
+      );
+    }
+    if (await exists(dnsSheetSelector)) {
+      throw new Error(
+        "DNS onboarding sheet appeared instead of the paywall — account is " +
+          "active (DNS not provisioned), not inactive."
+      );
+    }
+    // Strong signal: a price / CTA control from the paywall is present.
+    if (await exists(paywallCtaSelector)) {
+      return;
+    }
+
+    const toggle = await $(powerToggleSelector);
+    const toggleVisible = (await toggle.isExisting()) && (await toggle.isDisplayed());
+    if (!toggleVisible) {
+      // Weaker signal: home is covered. Require it to persist across two checks
+      // so a transient frame during the tap transition is not mistaken for the
+      // paywall.
+      toggleHiddenStreak += 1;
+      if (toggleHiddenStreak >= 2) {
+        return;
+      }
+    } else {
+      toggleHiddenStreak = 0;
+      const value = (await toggle.getAttribute("value"))?.toLowerCase();
+      if (value === "active") {
+        throw new Error(
+          "Protection activated instead of showing the paywall — account is " +
+            "active, not inactive."
+        );
+      }
+    }
+
+    await driver.pause(500);
+  }
+  throw new Error(
+    "Paywall did not appear within timeout (home screen never got covered and " +
+      "no paywall control was found)."
+  );
+}
+
+describe("Smoke: paywall on inactive account", () => {
+  before(async () => {
+    // Clean slate: relaunch closes any leftover Adapty modal from an
+    // interrupted prior run and resets the Flutter route to Home.
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountInactive();
+  });
+
+  it("presents the native paywall when enabling protection", async () => {
+    await waitForPowerButton();
+    await waitForProtectionInactive();
+    const startState = await getProtectionState();
+    if (startState !== "inactive") {
+      throw new Error(
+        `Expected protection to be inactive before tapping power, got ` +
+          `'${String(startState)}'.`
+      );
+    }
+
+    await tapPowerButton();
+    await waitForPaywall();
+
+    // Adapty settles the presented view (start.dart sleeps ~3s for non-freemium).
+    await driver.pause(4000);
+    await saveScreenshot("paywall.png");
+    await compareToGolden("paywall.png", { maskTopRatio: 0.06 });
+  });
+
+  after(async () => {
+    // Dismiss the native Adapty modal we presented so the device is not left
+    // covered for the next spec / manual use. Relaunch is the reliable way to
+    // close a native modal (activateApp cannot).
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID).catch(() => undefined);
+  });
+});

--- a/automation/appium/wdio/src/support/golden.ts
+++ b/automation/appium/wdio/src/support/golden.ts
@@ -1,0 +1,144 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { driver } from "@wdio/globals";
+import pixelmatch from "pixelmatch";
+import { PNG } from "pngjs";
+
+import { ensureDirectory } from "./files.js";
+
+// The WDIO process runs with cwd = automation/appium/wdio (see `make
+// appium-test`). Goldens live next to the specs and are committed to git;
+// transient diff/actual images go to the shared output dir CI uploads.
+const goldenDir = resolve(process.cwd(), "src", "specs", "smoke", "__golden__");
+const outputDir = resolve(process.cwd(), "..", "output");
+
+export interface GoldenOptions {
+  /** Max fraction of differing pixels tolerated before failing (default 0.02). */
+  maxDiffRatio?: number;
+  /** Top band masked out to ignore the status bar (clock/battery). 0..1, default 0.06. */
+  maskTopRatio?: number;
+  /** Extra rectangles to mask, expressed as 0..1 fractions of width/height. */
+  maskRegions?: Array<{ x: number; y: number; w: number; h: number }>;
+  /** Per-pixel colour delta sensitivity passed to pixelmatch (default 0.1). */
+  threshold?: number;
+}
+
+function maskRect(png: PNG, x: number, y: number, w: number, h: number): void {
+  const x0 = Math.max(0, Math.round(x));
+  const y0 = Math.max(0, Math.round(y));
+  const x1 = Math.min(png.width, Math.round(x + w));
+  const y1 = Math.min(png.height, Math.round(y + h));
+  for (let row = y0; row < y1; row++) {
+    for (let col = x0; col < x1; col++) {
+      const idx = (png.width * row + col) << 2;
+      png.data[idx] = 0;
+      png.data[idx + 1] = 0;
+      png.data[idx + 2] = 0;
+      png.data[idx + 3] = 255;
+    }
+  }
+}
+
+function applyMasks(png: PNG, options: GoldenOptions): void {
+  const maskTopRatio = options.maskTopRatio ?? 0.06;
+  if (maskTopRatio > 0) {
+    maskRect(png, 0, 0, png.width, png.height * maskTopRatio);
+  }
+  for (const region of options.maskRegions ?? []) {
+    maskRect(
+      png,
+      region.x * png.width,
+      region.y * png.height,
+      region.w * png.width,
+      region.h * png.height
+    );
+  }
+}
+
+function writePng(path: string, png: PNG): void {
+  ensureDirectory(path);
+  writeFileSync(path, PNG.sync.write(png));
+}
+
+/** `paywall.png` + `actual` -> `output/paywall-actual.png` (no double extension). */
+function artifactPath(name: string, suffix: string): string {
+  return resolve(outputDir, `${name.replace(/\.png$/i, "")}-${suffix}.png`);
+}
+
+/**
+ * Capture the current screen and compare it to a committed golden image.
+ *
+ * Strict: throws when the masked diff exceeds `maxDiffRatio`, when dimensions
+ * differ, or when no golden exists. Set `UPDATE_GOLDEN=1` to (re)generate the
+ * golden from the current screen instead of comparing — needed for the first
+ * baseline and after any intentional paywall change.
+ */
+export async function compareToGolden(
+  name: string,
+  options: GoldenOptions = {}
+): Promise<void> {
+  const goldenPath = resolve(goldenDir, name);
+  const actualPng = PNG.sync.read(
+    Buffer.from(await driver.takeScreenshot(), "base64")
+  );
+
+  if (process.env.UPDATE_GOLDEN === "1") {
+    writePng(goldenPath, actualPng);
+    console.warn(`Golden updated: ${goldenPath} (UPDATE_GOLDEN=1)`);
+    return;
+  }
+
+  if (!existsSync(goldenPath)) {
+    const actualPath = artifactPath(name, "actual");
+    writePng(actualPath, actualPng);
+    throw new Error(
+      `No golden for "${name}". Inspect ${actualPath}, then commit a baseline ` +
+        `by rerunning with UPDATE_GOLDEN=1.`
+    );
+  }
+
+  const goldenPng = PNG.sync.read(readFileSync(goldenPath));
+  if (goldenPng.width !== actualPng.width || goldenPng.height !== actualPng.height) {
+    const actualPath = artifactPath(name, "actual");
+    writePng(actualPath, actualPng);
+    throw new Error(
+      `Golden ${goldenPng.width}x${goldenPng.height} != actual ` +
+        `${actualPng.width}x${actualPng.height} for "${name}". Device or ` +
+        `orientation changed; regenerate with UPDATE_GOLDEN=1.`
+    );
+  }
+
+  applyMasks(goldenPng, options);
+  applyMasks(actualPng, options);
+
+  const { width, height } = goldenPng;
+  const diff = new PNG({ width, height });
+  const numDiffPixels = pixelmatch(
+    goldenPng.data,
+    actualPng.data,
+    diff.data,
+    width,
+    height,
+    { threshold: options.threshold ?? 0.1 }
+  );
+  const ratio = numDiffPixels / (width * height);
+  const maxDiffRatio = options.maxDiffRatio ?? 0.02;
+
+  if (ratio > maxDiffRatio) {
+    const diffPath = artifactPath(name, "diff");
+    const actualPath = artifactPath(name, "actual");
+    writePng(diffPath, diff);
+    writePng(actualPath, actualPng);
+    throw new Error(
+      `Golden mismatch for "${name}": ${(ratio * 100).toFixed(2)}% pixels ` +
+        `differ (max ${(maxDiffRatio * 100).toFixed(2)}%). See ${diffPath} and ` +
+        `${actualPath}. If this is an intentional change, regenerate with ` +
+        `UPDATE_GOLDEN=1.`
+    );
+  }
+
+  console.warn(
+    `Golden match for "${name}": ${(ratio * 100).toFixed(2)}% diff ` +
+      `(<= ${(maxDiffRatio * 100).toFixed(2)}%).`
+  );
+}

--- a/automation/appium/wdio/wdio.conf.ts
+++ b/automation/appium/wdio/wdio.conf.ts
@@ -9,7 +9,16 @@ const server = getAppiumServerConfig(process.env);
 
 const rawConfig = {
   runner: "local",
-  specs: ["./src/specs/smoke/**/*.ts"],
+  // Ordered by account-state lifecycle: inactive-account scenarios first,
+  // active-account scenarios last, so the suite ends in the active state (the
+  // default most scenarios / manual inspection expect) and mirrors the real
+  // user journey (inactive -> paywall -> activate). Each spec self-provisions
+  // its account state, so correctness is order-independent; this list just
+  // pins the resting state. New specs: insert in account-state order.
+  specs: [
+    "./src/specs/smoke/paywall.spec.ts", // inactive account
+    "./src/specs/smoke/dns-onboarding.spec.ts" // active account (leaves device active)
+  ],
   maxInstances: 1,
   hostname: server.host,
   port: server.port,


### PR DESCRIPTION
## What & why

Adds a second iOS Appium/WDIO smoke scenario: **open the Adapty paywall, screenshot it, and strict-compare to a committed golden**.

The paywall only appears for an **inactive (libre)** account — the opposite of the existing DNS-onboarding scenario, which needs an **active** account. Today the test device's account is pinned active by hand. So the core of this change is an **automated way to switch account state before each scenario**, replacing the manual pin.

## How account control works

It reuses the app's existing command bus through the support chat: any message prefixed `cc ` is routed to `command.onCommandString`, so `cc restore <id>` runs the `restore` command. This works on the real `six` debug build with **no app code change** and no gating.

- `flows/account.ts` — `ensureAccountActive()` / `ensureAccountInactive()` restore a dedicated account by id (`BLOKADA_ACTIVE_ACCOUNT_ID` / `BLOKADA_INACTIVE_ACCOUNT_ID`). Each spec self-provisions its state, so the suite is order-independent and self-healing. `restoreAccount` waits for a history-proof completion signal before relaunching to a clean Home.
- The power toggle's `value` reflects **protection on/off, not account state**, so account state is verified **behaviorally** (paywall appears for inactive; protection/DNS path for active), with negative guards that fail clearly if the account turns out wrong.

## What's included

- `specs/smoke/paywall.spec.ts` — restore inactive → tap power → assert native paywall presents → screenshot → strict golden compare.
- `support/golden.ts` — `pixelmatch` + `pngjs` comparison: status-bar masking, configurable threshold, `UPDATE_GOLDEN=1` to (re)generate, diff/actual artifacts on mismatch.
- `wdio.conf.ts` — explicit ordered `specs` (paywall first → suite ends with the device **active**, the default most scenarios expect). New specs must be registered here.
- `dns-onboarding.spec.ts` — added a self-healing `before` hook (`ensureAccountActive`) + relaunch to clear any leftover modal.
- `appium-smoke.yml` — passes the two account secrets to the run step.
- devDeps: `pixelmatch`, `pngjs`, `@types/pngjs`.

## Verification done

- `tsc --noEmit`: no errors in new/changed files (only pre-existing baseline noise).
- `make -C automation/appium test`: 100/100 harness unit tests pass.
- Golden mask + diff mechanics validated against synthetic PNGs.
- One code-review pass addressed (leftover-modal lifecycle, restore-race completion gate, strict-golden artifacts, false-pass guards). Not yet run end-to-end on a device.

## Operator actions required before this is green in CI

1. **Create two GitHub secrets**: `BLOKADA_ACTIVE_ACCOUNT_ID` (active, non-family) and `BLOKADA_INACTIVE_ACCOUNT_ID` (inactive/libre, non-freemium, non-family). Use **throwaway dev accounts** — the id is typed into the support chat and can appear in CI failure artifacts.
2. **Capture + commit the golden baseline** on the CI device: `UPDATE_GOLDEN=1 make appium-test`, then commit `automation/appium/wdio/src/specs/smoke/__golden__/paywall.png`. Strict compare fails until it exists. Regenerate after any intentional paywall change.
3. **Live-validate selectors** with the appium harness: home gear, support row, the unlabeled chat **send button** (coordinate-tap fallback — most fragile), and the Adapty paywall CTA predicate.

## Run locally before merge

```bash
export BLOKADA_ACTIVE_ACCOUNT_ID=... BLOKADA_INACTIVE_ACCOUNT_ID=... IOS_AUTO_SELECT_FIRST=1
make -C common build-ios
UPDATE_GOLDEN=1 make appium-test   # first time: writes the golden; inspect + commit it
make appium-test                   # strict compare, as CI runs it
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)