### PR TITLE
fix(appium): tolerate empty iOS-26 nav-bar title in Settings DNS descent

### DIFF
--- a/automation/appium/wdio/src/flows/settings.ts
+++ b/automation/appium/wdio/src/flows/settings.ts
@@ -169,6 +169,21 @@ async function getNavigationTitle(): Promise<string | undefined> {
     if (typeof label === "string" && label.trim().length > 0) {
       return label;
     }
+    // iOS large-title screens (e.g. General on iOS 26) can leave the nav-bar's
+    // own name/label empty while still rendering the title as a StaticText child
+    // of the bar. Fall back to that so section-arrival checks don't see an empty
+    // title and wrongly conclude navigation failed.
+    const titleText = await navBar.$(
+      "-ios class chain:**/XCUIElementTypeStaticText[1]"
+    );
+    if (await titleText.isExisting()) {
+      for (const attr of ["name", "value", "label"] as const) {
+        const value = await titleText.getAttribute(attr);
+        if (typeof value === "string" && value.trim().length > 0) {
+          return value;
+        }
+      }
+    }
   } catch (_) {
     // Navigation bar not available; ignore.
   }
@@ -322,6 +337,23 @@ async function openSettingsSection(
 
     const title = (await getNavigationTitle())?.toLowerCase() ?? "";
     if (expectedTitleHints.some((hint) => title.includes(hint))) {
+      return;
+    }
+
+    // iOS (26 / iPhone) sometimes reports an empty nav-bar title for a
+    // freshly-pushed screen (large title not yet committed), which previously
+    // made us wrongly conclude the tap failed and back out — breaking the
+    // General -> VPN & Device Management -> DNS descent. If the row we just
+    // tapped is gone, we *did* navigate into the section, so accept it. A
+    // genuinely wrong destination is still caught by the next section's
+    // scroll-search (or the later profile / switch steps).
+    let navigatedAway = false;
+    try {
+      navigatedAway = !(await target.isDisplayed());
+    } catch {
+      navigatedAway = true; // stale element reference -> we left the screen
+    }
+    if (navigatedAway) {
       return;
     }
 


### PR DESCRIPTION
Follow-up to #1147 (paywall smoke + account control, merged).

## Problem
The DNS onboarding spec navigates iOS Settings (General → VPN & Device Management → DNS) to install the Blokada DNS profile. On a **profile-less device** (the CI runner) this path runs for the first time and hit a latent bug: iOS 26 large-title screens (notably **General**) leave the nav-bar's own `name`/`label` empty, so `getNavigationTitle()` returned empty and `openSettingsSection()` wrongly concluded the tap failed, backed out, and ultimately threw `Failed to find General / Allmänt in Settings`.

This was masked on dev devices that already had the DNS profile installed — onboarding was skipped, so the Settings navigation never ran. The CI device, being clean, exercises the real first-time onboarding path and exposed it.

## Fix (`settings.ts`)
- `getNavigationTitle()`: fall back to the nav-bar's `StaticText` child when its own `name`/`label` are empty, so the large title is still read.
- `openSettingsSection()`: if the row we just tapped is gone, accept that we navigated regardless of title timing; a genuinely wrong destination is still caught by the next section's scroll-search.

## Validation
The `appium-smoke` workflow (physical-device runner, which lacks the DNS profile) is the real test — it runs after CI and should now complete the General → VPN & Device Management → DNS descent and enable protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)