### PR TITLE
test(appium): functional smoke specs + JUnit run summary

### DIFF
--- a/.github/workflows/appium-smoke.yml
+++ b/.github/workflows/appium-smoke.yml
@@ -22,7 +22,9 @@ concurrency:
 jobs:
   smoke:
     runs-on: [self-hosted, macOS, ARM64, ios-physical]
-    timeout-minutes: 30
+    # Single device → scenarios run serially. Per-scenario steps add a little
+    # session-startup overhead over the old single run; allow headroom.
+    timeout-minutes: 45
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.event == 'pull_request' &&
@@ -31,6 +33,13 @@ jobs:
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
+      IOS_AUTO_SELECT_FIRST: "1"
+      SHOW_XCODE_LOG: "0"
+      # Dedicated dev accounts the specs restore via the support-chat command
+      # bus: paywall needs inactive (libre, non-freemium, non-family),
+      # the active-account scenarios need active (paid, non-family).
+      BLOKADA_ACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_ACTIVE_ACCOUNT_ID }}
+      BLOKADA_INACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_INACTIVE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -46,25 +55,44 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.MAC_KEYCHAIN_PASSWORD }}
         run: security unlock-keychain -p "$KEYCHAIN_PASSWORD" ~/Library/Keychains/login.keychain-db
 
-      - name: "Run appium smoke (flavor: six)"
-        env:
-          IOS_AUTO_SELECT_FIRST: "1"
-          SHOW_XCODE_LOG: "0"
-          # Dedicated dev accounts the specs restore via the support-chat command
-          # bus: paywall needs inactive (libre, non-freemium, non-family),
-          # DNS onboarding needs active (non-family).
-          BLOKADA_ACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_ACTIVE_ACCOUNT_ID }}
-          BLOKADA_INACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_INACTIVE_ACCOUNT_ID }}
-        run: make appium-test
+      - name: Prepare app (build + install once)
+        # Builds + installs the app on the device once and resets JUnit output.
+        # The per-scenario steps below reuse this install (APP_INSTALL=0).
+        run: make appium-prepare
 
-      - name: Upload appium screenshots on failure
-        if: failure()
-        uses: actions/upload-artifact@v7
-        with:
-          name: appium-screenshots-${{ github.run_id }}
-          path: automation/appium/output/*.png
-          if-no-files-found: warn
-          retention-days: 14
+      # One step per scenario so each shows separately in the job timeline with
+      # its own pass/fail + duration. continue-on-error lets every scenario run
+      # even when an earlier one fails; the gate step at the end fails the job if
+      # any scenario failed. Order follows the account-state lifecycle.
+      - name: "smoke: paywall"
+        id: spec_paywall
+        continue-on-error: true
+        run: make appium-run-spec SPEC=./src/specs/smoke/paywall.spec.ts
+
+      - name: "smoke: dns-onboarding"
+        id: spec_dns
+        continue-on-error: true
+        run: make appium-run-spec SPEC=./src/specs/smoke/dns-onboarding.spec.ts
+
+      - name: "smoke: tab-navigation"
+        id: spec_tab
+        continue-on-error: true
+        run: make appium-run-spec SPEC=./src/specs/smoke/tab-navigation.spec.ts
+
+      - name: "smoke: settings-navigation"
+        id: spec_settings
+        continue-on-error: true
+        run: make appium-run-spec SPEC=./src/specs/smoke/settings-navigation.spec.ts
+
+      - name: "smoke: power-pause"
+        id: spec_power
+        continue-on-error: true
+        run: make appium-run-spec SPEC=./src/specs/smoke/power-pause.spec.ts
+
+      - name: Publish per-scenario summary
+        if: always()
+        continue-on-error: true
+        run: node automation/appium/wdio/scripts/junit-summary.mjs >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload appium smoke artifacts
         if: always()
@@ -72,8 +100,22 @@ jobs:
         with:
           name: appium-smoke-${{ github.run_id }}
           path: |
+            automation/appium/output/junit/*.xml
             automation/appium/output/*.xml
             automation/appium/output/*.log
             automation/appium/output/*.png
           if-no-files-found: warn
           retention-days: 14
+
+      - name: Smoke gate (fail if any scenario failed)
+        if: always()
+        run: |
+          fail=0
+          check() { if [ "$2" != "success" ]; then echo "::error::scenario $1 outcome=$2"; fail=1; fi; }
+          check paywall "${{ steps.spec_paywall.outcome }}"
+          check dns-onboarding "${{ steps.spec_dns.outcome }}"
+          check tab-navigation "${{ steps.spec_tab.outcome }}"
+          check settings-navigation "${{ steps.spec_settings.outcome }}"
+          check power-pause "${{ steps.spec_power.outcome }}"
+          if [ "$fail" -ne 0 ]; then echo "One or more smoke scenarios failed"; exit 1; fi
+          echo "All smoke scenarios passed"

--- a/.github/workflows/appium-smoke.yml
+++ b/.github/workflows/appium-smoke.yml
@@ -22,9 +22,7 @@ concurrency:
 jobs:
   smoke:
     runs-on: [self-hosted, macOS, ARM64, ios-physical]
-    # Single device → scenarios run serially. Per-scenario steps add a little
-    # session-startup overhead over the old single run; allow headroom.
-    timeout-minutes: 45
+    timeout-minutes: 30
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.event == 'pull_request' &&
@@ -33,13 +31,6 @@ jobs:
     env:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
-      IOS_AUTO_SELECT_FIRST: "1"
-      SHOW_XCODE_LOG: "0"
-      # Dedicated dev accounts the specs restore via the support-chat command
-      # bus: paywall needs inactive (libre, non-freemium, non-family),
-      # the active-account scenarios need active (paid, non-family).
-      BLOKADA_ACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_ACTIVE_ACCOUNT_ID }}
-      BLOKADA_INACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_INACTIVE_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -55,44 +46,32 @@ jobs:
           KEYCHAIN_PASSWORD: ${{ secrets.MAC_KEYCHAIN_PASSWORD }}
         run: security unlock-keychain -p "$KEYCHAIN_PASSWORD" ~/Library/Keychains/login.keychain-db
 
-      - name: Prepare app (build + install once)
-        # Builds + installs the app on the device once and resets JUnit output.
-        # The per-scenario steps below reuse this install (APP_INSTALL=0).
-        run: make appium-prepare
-
-      # One step per scenario so each shows separately in the job timeline with
-      # its own pass/fail + duration. continue-on-error lets every scenario run
-      # even when an earlier one fails; the gate step at the end fails the job if
-      # any scenario failed. Order follows the account-state lifecycle.
-      - name: "smoke: paywall"
-        id: spec_paywall
-        continue-on-error: true
-        run: make appium-run-spec SPEC=./src/specs/smoke/paywall.spec.ts
-
-      - name: "smoke: dns-onboarding"
-        id: spec_dns
-        continue-on-error: true
-        run: make appium-run-spec SPEC=./src/specs/smoke/dns-onboarding.spec.ts
-
-      - name: "smoke: tab-navigation"
-        id: spec_tab
-        continue-on-error: true
-        run: make appium-run-spec SPEC=./src/specs/smoke/tab-navigation.spec.ts
-
-      - name: "smoke: settings-navigation"
-        id: spec_settings
-        continue-on-error: true
-        run: make appium-run-spec SPEC=./src/specs/smoke/settings-navigation.spec.ts
-
-      - name: "smoke: power-pause"
-        id: spec_power
-        continue-on-error: true
-        run: make appium-run-spec SPEC=./src/specs/smoke/power-pause.spec.ts
+      - name: "Run appium smoke (flavor: six)"
+        env:
+          IOS_AUTO_SELECT_FIRST: "1"
+          SHOW_XCODE_LOG: "0"
+          # Dedicated dev accounts the specs restore via the support-chat command
+          # bus: paywall needs inactive (libre, non-freemium, non-family),
+          # DNS onboarding needs active (non-family).
+          BLOKADA_ACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_ACTIVE_ACCOUNT_ID }}
+          BLOKADA_INACTIVE_ACCOUNT_ID: ${{ secrets.BLOKADA_INACTIVE_ACCOUNT_ID }}
+        run: make appium-test
 
       - name: Publish per-scenario summary
+        # Renders the per-scenario JUnit results (one row per spec, with timing)
+        # into the run summary. Never fails the job — the smoke step is the gate.
         if: always()
         continue-on-error: true
         run: node automation/appium/wdio/scripts/junit-summary.mjs >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload appium screenshots on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: appium-screenshots-${{ github.run_id }}
+          path: automation/appium/output/*.png
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Upload appium smoke artifacts
         if: always()
@@ -106,16 +85,3 @@ jobs:
             automation/appium/output/*.png
           if-no-files-found: warn
           retention-days: 14
-
-      - name: Smoke gate (fail if any scenario failed)
-        if: always()
-        run: |
-          fail=0
-          check() { if [ "$2" != "success" ]; then echo "::error::scenario $1 outcome=$2"; fail=1; fi; }
-          check paywall "${{ steps.spec_paywall.outcome }}"
-          check dns-onboarding "${{ steps.spec_dns.outcome }}"
-          check tab-navigation "${{ steps.spec_tab.outcome }}"
-          check settings-navigation "${{ steps.spec_settings.outcome }}"
-          check power-pause "${{ steps.spec_power.outcome }}"
-          if [ "$fail" -ne 0 ]; then echo "One or more smoke scenarios failed"; exit 1; fi
-          echo "All smoke scenarios passed"

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ADAPTY_VER := 3_8.0
 	adapty-paywalls \
 	appium-explore-session \
 	appium-ai-explore \
-	appium-test \
+	appium-test appium-prepare appium-run-spec \
 
 translate:
 	$(TRANSLATE_SCRIPT)
@@ -124,6 +124,36 @@ appium-test:
 		echo "appium-test: device wake FAILED (continuing; WDA will activate)" >&2; \
 	fi; \
 	node scripts/run-wdio.mjs
+
+# Prepare the device for per-scenario smoke runs: install deps, build + install
+# the app once, wake it, and reset the JUnit output dir. CI runs this once, then
+# `appium-run-spec SPEC=... APP_INSTALL=0` per scenario so each shows separately.
+appium-prepare:
+	@set -euo pipefail; \
+	cd automation/appium/wdio && \
+	npm ci >/dev/null && \
+	rm -rf ../output/junit && mkdir -p ../output/junit; \
+	eval "$$(IOS_AUTO_SELECT_FIRST=1 node scripts/setup-session.mjs)"; \
+	$(MAKE) -C ../../../ios "$$APPIUM_APP_INSTALL_TARGET" IOS_UDID="$$IOS_UDID" IOS_DEVICE_NAME="$$IOS_DEVICE_NAME"; \
+	echo "appium-prepare: waking device $$IOS_UDID ($$APP_BUNDLE_ID)" >&2; \
+	xcrun devicectl device process launch --terminate-existing --device "$$IOS_UDID" "$$APP_BUNDLE_ID" >/dev/null 2>&1 || true
+
+# Run a single smoke spec, e.g.:
+#   make appium-run-spec SPEC=./src/specs/smoke/paywall.spec.ts
+# Skips the app build/install by default (APP_INSTALL=0; run `appium-prepare`
+# first, or pass APP_INSTALL=1 for a standalone run). Writes a per-scenario JUnit
+# file under automation/appium/output/junit (consumed by scripts/junit-summary.mjs).
+appium-run-spec:
+	@set -euo pipefail; \
+	if [ -z "$(SPEC)" ]; then echo "appium-run-spec: set SPEC=./src/specs/smoke/<name>.spec.ts" >&2; exit 2; fi; \
+	cd automation/appium/wdio && \
+	[ -d node_modules ] || npm ci >/dev/null; \
+	export IOS_AUTO_SELECT_FIRST="$${IOS_AUTO_SELECT_FIRST:-1}"; \
+	eval "$$(node scripts/setup-session.mjs)"; \
+	if [ "$(or $(APP_INSTALL),0)" != "0" ]; then \
+		$(MAKE) -C ../../../ios "$$APPIUM_APP_INSTALL_TARGET" IOS_UDID="$$IOS_UDID" IOS_DEVICE_NAME="$$IOS_DEVICE_NAME"; \
+	fi; \
+	WDIO_SPEC="$(SPEC)" node scripts/run-wdio.mjs
 
 # Run the AI-driven exploratory pass against an already installed/onboarded app.
 # Intended CI usage: run this immediately after make appium-test with APP_INSTALL=0.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ ADAPTY_VER := 3_8.0
 	adapty-paywalls \
 	appium-explore-session \
 	appium-ai-explore \
-	appium-test appium-prepare appium-run-spec \
+	appium-test \
 
 translate:
 	$(TRANSLATE_SCRIPT)
@@ -114,6 +114,7 @@ appium-test:
 	@set -euo pipefail; \
 	cd automation/appium/wdio && \
 	npm ci >/dev/null && \
+	rm -rf ../output/junit && mkdir -p ../output/junit && \
 	eval "$$(IOS_AUTO_SELECT_FIRST=1 node scripts/setup-session.mjs)"; \
 	export IOS_AUTO_SELECT_FIRST=1; \
 	$(MAKE) -C ../../../ios "$$APPIUM_APP_INSTALL_TARGET" IOS_UDID="$$IOS_UDID" IOS_DEVICE_NAME="$$IOS_DEVICE_NAME"; \
@@ -124,36 +125,6 @@ appium-test:
 		echo "appium-test: device wake FAILED (continuing; WDA will activate)" >&2; \
 	fi; \
 	node scripts/run-wdio.mjs
-
-# Prepare the device for per-scenario smoke runs: install deps, build + install
-# the app once, wake it, and reset the JUnit output dir. CI runs this once, then
-# `appium-run-spec SPEC=... APP_INSTALL=0` per scenario so each shows separately.
-appium-prepare:
-	@set -euo pipefail; \
-	cd automation/appium/wdio && \
-	npm ci >/dev/null && \
-	rm -rf ../output/junit && mkdir -p ../output/junit; \
-	eval "$$(IOS_AUTO_SELECT_FIRST=1 node scripts/setup-session.mjs)"; \
-	$(MAKE) -C ../../../ios "$$APPIUM_APP_INSTALL_TARGET" IOS_UDID="$$IOS_UDID" IOS_DEVICE_NAME="$$IOS_DEVICE_NAME"; \
-	echo "appium-prepare: waking device $$IOS_UDID ($$APP_BUNDLE_ID)" >&2; \
-	xcrun devicectl device process launch --terminate-existing --device "$$IOS_UDID" "$$APP_BUNDLE_ID" >/dev/null 2>&1 || true
-
-# Run a single smoke spec, e.g.:
-#   make appium-run-spec SPEC=./src/specs/smoke/paywall.spec.ts
-# Skips the app build/install by default (APP_INSTALL=0; run `appium-prepare`
-# first, or pass APP_INSTALL=1 for a standalone run). Writes a per-scenario JUnit
-# file under automation/appium/output/junit (consumed by scripts/junit-summary.mjs).
-appium-run-spec:
-	@set -euo pipefail; \
-	if [ -z "$(SPEC)" ]; then echo "appium-run-spec: set SPEC=./src/specs/smoke/<name>.spec.ts" >&2; exit 2; fi; \
-	cd automation/appium/wdio && \
-	[ -d node_modules ] || npm ci >/dev/null; \
-	export IOS_AUTO_SELECT_FIRST="$${IOS_AUTO_SELECT_FIRST:-1}"; \
-	eval "$$(node scripts/setup-session.mjs)"; \
-	if [ "$(or $(APP_INSTALL),0)" != "0" ]; then \
-		$(MAKE) -C ../../../ios "$$APPIUM_APP_INSTALL_TARGET" IOS_UDID="$$IOS_UDID" IOS_DEVICE_NAME="$$IOS_DEVICE_NAME"; \
-	fi; \
-	WDIO_SPEC="$(SPEC)" node scripts/run-wdio.mjs
 
 # Run the AI-driven exploratory pass against an already installed/onboarded app.
 # Intended CI usage: run this immediately after make appium-test with APP_INSTALL=0.

--- a/automation/appium/wdio/package-lock.json
+++ b/automation/appium/wdio/package-lock.json
@@ -19,6 +19,7 @@
         "@types/chai": "^5.2.3",
         "@types/node": "^26.0.1",
         "@types/pngjs": "^6.0.5",
+        "@wdio/junit-reporter": "^9.29.1",
         "appium": "^3.5.0",
         "chai": "^6.2.2",
         "pixelmatch": "^7.1.0",
@@ -2621,6 +2622,22 @@
         "webdriverio": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@wdio/junit-reporter": {
+      "version": "9.29.1",
+      "resolved": "https://registry.npmjs.org/@wdio/junit-reporter/-/junit-reporter-9.29.1.tgz",
+      "integrity": "sha512-TEwgQqtDMlW1Z96yahGCXyo0PkgFxDQk6KQzy//1rVQ980n+cCa/JNTuxaUDzjOnrqNyOjTEKhERLEDYigAxsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@wdio/reporter": "9.29.1",
+        "@wdio/types": "9.29.1",
+        "json-stringify-safe": "^5.0.1",
+        "junit-report-builder": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=18.20.0"
       }
     },
     "node_modules/@wdio/local-runner": {
@@ -6603,6 +6620,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6662,6 +6686,21 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/junit-report-builder": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/junit-report-builder/-/junit-report-builder-5.1.2.tgz",
+      "integrity": "sha512-HzvLbEQcoqN2LmGnloShxu2hLadi/rkOTU3zt61UeMICLS0wGDvbf8neIi6+bGkxMnAePIcFMFnbqV+r6YvwxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.18.1",
+        "make-dir": "^3.1.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/klaw": {
@@ -7014,6 +7053,32 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {

--- a/automation/appium/wdio/package.json
+++ b/automation/appium/wdio/package.json
@@ -24,6 +24,7 @@
     "@types/chai": "^5.2.3",
     "@types/node": "^26.0.1",
     "@types/pngjs": "^6.0.5",
+    "@wdio/junit-reporter": "^9.29.1",
     "appium": "^3.5.0",
     "chai": "^6.2.2",
     "pixelmatch": "^7.1.0",

--- a/automation/appium/wdio/scripts/junit-summary.mjs
+++ b/automation/appium/wdio/scripts/junit-summary.mjs
@@ -3,7 +3,14 @@
 // Render a per-scenario Markdown table from the JUnit XML the wdio junit reporter
 // writes to automation/appium/output/junit. Intended for the CI run summary:
 //   node scripts/junit-summary.mjs >> "$GITHUB_STEP_SUMMARY"
-// Always exits 0 (the CI gate decides pass/fail from step outcomes, not this).
+// Always exits 0 (the smoke step is the gate; this is reporting only).
+//
+// Per-scenario "Duration" is the JUnit <testsuite time> — the scenario's
+// wall-clock including before/after hooks (app relaunch + account restore) and
+// the per-spec WebDriverAgent session startup. "Test exec" is the <testcase
+// time> (the it() body alone), which is much smaller. Neither includes the
+// one-time npm install + app build/install that runs once before all scenarios,
+// so the total here is below the full CI step time.
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -39,65 +46,83 @@ function formatDuration(seconds) {
   return `${mins}m ${secs}s`;
 }
 
-/** Parse one JUnit XML string into rows of {suite, name, status, time}. */
-export function parseTestcases(xml) {
-  const rows = [];
+/**
+ * Parse one JUnit XML string into per-suite rows:
+ *   { suite, status, duration (suite wall-clock), testTime (sum of it() bodies) }
+ */
+export function parseSuites(xml) {
+  const suites = [];
   const suiteRe = /<testsuite\b([^>]*)>([\s\S]*?)<\/testsuite>/g;
   let suiteMatch;
   while ((suiteMatch = suiteRe.exec(xml)) !== null) {
-    const suite = attr(suiteMatch[1], "name");
+    const suiteAttrs = suiteMatch[1];
     const body = suiteMatch[2];
+    // Prefer the unsanitized suiteName property; the testsuite name attr has
+    // ':' and '/' stripped by the reporter.
+    const prop = body.match(/<property\b[^>]*\bname="suiteName"[^>]*\bvalue="([^"]*)"/);
+    const suite = prop ? unescapeXml(prop[1]) : attr(suiteAttrs, "name");
+    const duration = Number.parseFloat(attr(suiteAttrs, "time")) || 0;
+
+    let testTime = 0;
+    let total = 0;
+    let failed = 0;
+    let skipped = 0;
     const caseRe = /<testcase\b([^>]*?)(\/>|>([\s\S]*?)<\/testcase>)/g;
     let caseMatch;
     while ((caseMatch = caseRe.exec(body)) !== null) {
-      const caseAttrs = caseMatch[1];
+      total += 1;
+      testTime += Number.parseFloat(attr(caseMatch[1], "time")) || 0;
       const caseBody = caseMatch[3] ?? "";
-      let status = "passed";
-      if (/<failure\b/.test(caseBody)) status = "failed";
-      else if (/<error\b/.test(caseBody)) status = "error";
-      else if (/<skipped\b/.test(caseBody)) status = "skipped";
-      rows.push({
-        suite: suite || attr(caseAttrs, "classname"),
-        name: attr(caseAttrs, "name"),
-        status,
-        time: Number.parseFloat(attr(caseAttrs, "time")) || 0
-      });
+      if (/<failure\b/.test(caseBody) || /<error\b/.test(caseBody)) failed += 1;
+      else if (/<skipped\b/.test(caseBody)) skipped += 1;
     }
+
+    let status = "passed";
+    if (failed > 0) status = "failed";
+    else if (total === 0 || skipped === total) status = "skipped";
+    suites.push({ suite, status, duration, testTime });
   }
-  return rows;
+  return suites;
 }
 
-const ICON = { passed: "✅", failed: "❌", error: "❌", skipped: "⏭️" };
+const ICON = { passed: "✅", failed: "❌", skipped: "⏭️" };
 
-/** Build the Markdown summary from already-parsed rows. */
-export function buildMarkdown(rows) {
-  if (rows.length === 0) {
+/** Build the Markdown summary from already-parsed suite rows. */
+export function buildMarkdown(suites) {
+  if (suites.length === 0) {
     return "## Appium smoke — scenario results\n\n_No JUnit results found._\n";
   }
   const lines = [
     "## Appium smoke — scenario results",
     "",
-    "| | Scenario | Test | Duration |",
-    "| :-: | --- | --- | --- |"
+    "| | Scenario | Duration | Test exec |",
+    "| :-: | --- | --: | --: |"
   ];
-  for (const r of rows) {
+  for (const s of suites) {
     lines.push(
-      `| ${ICON[r.status] ?? "❔"} | ${r.suite || "—"} | ${r.name || "—"} | ${formatDuration(r.time)} |`
+      `| ${ICON[s.status] ?? "❔"} | ${s.suite || "—"} | ${formatDuration(s.duration)} | ${formatDuration(s.testTime)} |`
     );
   }
-  const passed = rows.filter((r) => r.status === "passed").length;
-  const failed = rows.filter((r) => r.status === "failed" || r.status === "error").length;
-  const skipped = rows.filter((r) => r.status === "skipped").length;
-  const total = rows.reduce((sum, r) => sum + r.time, 0);
-  const noun = rows.length === 1 ? "scenario" : "scenarios";
-  const parts = [`**${rows.length} ${noun}** — ${passed} passed`];
+  const passed = suites.filter((s) => s.status === "passed").length;
+  const failed = suites.filter((s) => s.status === "failed").length;
+  const skipped = suites.filter((s) => s.status === "skipped").length;
+  const total = suites.reduce((sum, s) => sum + s.duration, 0);
+  const noun = suites.length === 1 ? "scenario" : "scenarios";
+  const parts = [`**${suites.length} ${noun}** — ${passed} passed`];
   if (failed) parts.push(`${failed} failed`);
   if (skipped) parts.push(`${skipped} skipped`);
   lines.push("", `${parts.join(", ")} · total ${formatDuration(total)}`);
+  lines.push(
+    "",
+    "_Duration is per-scenario wall-clock (app relaunch, account restore, " +
+      "WebDriverAgent startup, hooks); Test exec is the test body alone. The " +
+      "one-time npm + app build/install runs once before all scenarios and is " +
+      "not attributed here, so the total is below the full step time._"
+  );
   return `${lines.join("\n")}\n`;
 }
 
-function readJunitRows(junitDir) {
+function readSuites(junitDir) {
   let files;
   try {
     files = readdirSync(junitDir)
@@ -109,7 +134,7 @@ function readJunitRows(junitDir) {
   }
   return files.flatMap((file) => {
     try {
-      return parseTestcases(readFileSync(file, "utf8"));
+      return parseSuites(readFileSync(file, "utf8"));
     } catch {
       return []; // skip an unreadable/disappeared file rather than fail the job
     }
@@ -120,7 +145,7 @@ function main() {
   const junitDir = process.env.JUNIT_DIR
     ? resolve(process.env.JUNIT_DIR)
     : defaultJunitDir;
-  process.stdout.write(buildMarkdown(readJunitRows(junitDir)));
+  process.stdout.write(buildMarkdown(readSuites(junitDir)));
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/automation/appium/wdio/scripts/junit-summary.mjs
+++ b/automation/appium/wdio/scripts/junit-summary.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+
+// Render a per-scenario Markdown table from the JUnit XML the wdio junit reporter
+// writes to automation/appium/output/junit. Intended for the CI run summary:
+//   node scripts/junit-summary.mjs >> "$GITHUB_STEP_SUMMARY"
+// Always exits 0 (the CI gate decides pass/fail from step outcomes, not this).
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultJunitDir = resolve(scriptDir, "..", "..", "output", "junit");
+
+const ENTITIES = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&apos;": "'",
+  "&#39;": "'"
+};
+
+function unescapeXml(value) {
+  return value.replace(/&(amp|lt|gt|quot|apos|#39);/g, (m) => ENTITIES[m] ?? m);
+}
+
+function attr(attrs, name) {
+  // \b so `name` does not match inside `classname`.
+  const match = attrs.match(new RegExp(`\\b${name}="([^"]*)"`));
+  return match ? unescapeXml(match[1]) : "";
+}
+
+function formatDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) return "—";
+  if (seconds < 60) return `${seconds.toFixed(1)}s`;
+  const mins = Math.floor(seconds / 60);
+  const secs = Math.round(seconds % 60);
+  return `${mins}m ${secs}s`;
+}
+
+/** Parse one JUnit XML string into rows of {suite, name, status, time}. */
+export function parseTestcases(xml) {
+  const rows = [];
+  const suiteRe = /<testsuite\b([^>]*)>([\s\S]*?)<\/testsuite>/g;
+  let suiteMatch;
+  while ((suiteMatch = suiteRe.exec(xml)) !== null) {
+    const suite = attr(suiteMatch[1], "name");
+    const body = suiteMatch[2];
+    const caseRe = /<testcase\b([^>]*?)(\/>|>([\s\S]*?)<\/testcase>)/g;
+    let caseMatch;
+    while ((caseMatch = caseRe.exec(body)) !== null) {
+      const caseAttrs = caseMatch[1];
+      const caseBody = caseMatch[3] ?? "";
+      let status = "passed";
+      if (/<failure\b/.test(caseBody)) status = "failed";
+      else if (/<error\b/.test(caseBody)) status = "error";
+      else if (/<skipped\b/.test(caseBody)) status = "skipped";
+      rows.push({
+        suite: suite || attr(caseAttrs, "classname"),
+        name: attr(caseAttrs, "name"),
+        status,
+        time: Number.parseFloat(attr(caseAttrs, "time")) || 0
+      });
+    }
+  }
+  return rows;
+}
+
+const ICON = { passed: "✅", failed: "❌", error: "❌", skipped: "⏭️" };
+
+/** Build the Markdown summary from already-parsed rows. */
+export function buildMarkdown(rows) {
+  if (rows.length === 0) {
+    return "## Appium smoke — scenario results\n\n_No JUnit results found._\n";
+  }
+  const lines = [
+    "## Appium smoke — scenario results",
+    "",
+    "| | Scenario | Test | Duration |",
+    "| :-: | --- | --- | --- |"
+  ];
+  for (const r of rows) {
+    lines.push(
+      `| ${ICON[r.status] ?? "❔"} | ${r.suite || "—"} | ${r.name || "—"} | ${formatDuration(r.time)} |`
+    );
+  }
+  const passed = rows.filter((r) => r.status === "passed").length;
+  const failed = rows.filter((r) => r.status === "failed" || r.status === "error").length;
+  const skipped = rows.filter((r) => r.status === "skipped").length;
+  const total = rows.reduce((sum, r) => sum + r.time, 0);
+  const noun = rows.length === 1 ? "scenario" : "scenarios";
+  const parts = [`**${rows.length} ${noun}** — ${passed} passed`];
+  if (failed) parts.push(`${failed} failed`);
+  if (skipped) parts.push(`${skipped} skipped`);
+  lines.push("", `${parts.join(", ")} · total ${formatDuration(total)}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function readJunitRows(junitDir) {
+  let files;
+  try {
+    files = readdirSync(junitDir)
+      .filter((f) => f.startsWith("results-") && f.endsWith(".xml"))
+      .map((f) => resolve(junitDir, f))
+      .sort((a, b) => statSync(a).mtimeMs - statSync(b).mtimeMs);
+  } catch {
+    return [];
+  }
+  return files.flatMap((file) => {
+    try {
+      return parseTestcases(readFileSync(file, "utf8"));
+    } catch {
+      return []; // skip an unreadable/disappeared file rather than fail the job
+    }
+  });
+}
+
+function main() {
+  const junitDir = process.env.JUNIT_DIR
+    ? resolve(process.env.JUNIT_DIR)
+    : defaultJunitDir;
+  process.stdout.write(buildMarkdown(readJunitRows(junitDir)));
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/automation/appium/wdio/scripts/tests/junit-summary.test.mjs
+++ b/automation/appium/wdio/scripts/tests/junit-summary.test.mjs
@@ -1,48 +1,56 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { parseTestcases, buildMarkdown } from "../junit-summary.mjs";
+import { parseSuites, buildMarkdown } from "../junit-summary.mjs";
 
+// Mirrors the real wdio junit output: testsuite time (wall-clock incl. hooks +
+// WDA startup) is much larger than the testcase time (it() body), and the nice
+// suite name lives in the suiteName property (the name attr is sanitized).
 const PASS_XML = `<?xml version="1.0"?>
 <testsuites>
-  <testsuite name="Smoke: Home hub navigation" tests="1" failures="0" time="41.2">
-    <testcase classname="home" name="opens each main screen from Home and returns" time="41.2"/>
+  <testsuite name="Smoke Home hub navigation" time="129.792" tests="1" failures="0">
+    <properties><property name="suiteName" value="Smoke: Home hub navigation"/></properties>
+    <testcase classname="home" name="opens each main screen from Home and returns" time="10.013"/>
   </testsuite>
 </testsuites>`;
 
 const FAIL_XML = `<?xml version="1.0"?>
 <testsuites>
-  <testsuite name="Smoke: power pause / turn-off" tests="1" failures="1" time="112">
-    <testcase classname="power" name="turns protection off" time="112">
+  <testsuite name="Smoke power pause turn off" time="126.879" tests="1" failures="1">
+    <properties><property name="suiteName" value="Smoke: power pause / turn-off"/></properties>
+    <testcase classname="power" name="turns protection off" time="7.176">
       <failure message="boom">stack</failure>
     </testcase>
   </testsuite>
 </testsuites>`;
 
-test("parseTestcases reads a passing testcase", () => {
-  const rows = parseTestcases(PASS_XML);
-  assert.equal(rows.length, 1);
-  assert.deepEqual(rows[0], {
+test("parseSuites uses suite wall-clock as duration and the property suite name", () => {
+  const suites = parseSuites(PASS_XML);
+  assert.equal(suites.length, 1);
+  assert.deepEqual(suites[0], {
     suite: "Smoke: Home hub navigation",
-    name: "opens each main screen from Home and returns",
     status: "passed",
-    time: 41.2
+    duration: 129.792,
+    testTime: 10.013
   });
 });
 
-test("parseTestcases detects failures", () => {
-  const rows = parseTestcases(FAIL_XML);
-  assert.equal(rows.length, 1);
-  assert.equal(rows[0].status, "failed");
-  assert.equal(rows[0].suite, "Smoke: power pause / turn-off");
+test("parseSuites detects failures", () => {
+  const suites = parseSuites(FAIL_XML);
+  assert.equal(suites.length, 1);
+  assert.equal(suites[0].status, "failed");
+  assert.equal(suites[0].suite, "Smoke: power pause / turn-off");
+  assert.equal(suites[0].duration, 126.879);
 });
 
-test("buildMarkdown summarizes mixed results", () => {
-  const md = buildMarkdown([...parseTestcases(PASS_XML), ...parseTestcases(FAIL_XML)]);
+test("buildMarkdown shows duration + test exec and totals by suite time", () => {
+  const md = buildMarkdown([...parseSuites(PASS_XML), ...parseSuites(FAIL_XML)]);
   assert.match(md, /Appium smoke — scenario results/);
-  assert.match(md, /✅/);
-  assert.match(md, /❌/);
+  assert.match(md, /Duration \| Test exec/);
+  assert.match(md, /2m 10s/); // 129.792 suite time
+  assert.match(md, /10\.0s/); // 10.013 test exec
   assert.match(md, /\*\*2 scenarios\*\* — 1 passed, 1 failed/);
+  assert.match(md, /total 4m 17s/); // 129.792 + 126.879 = 256.671s
 });
 
 test("buildMarkdown handles no results", () => {

--- a/automation/appium/wdio/scripts/tests/junit-summary.test.mjs
+++ b/automation/appium/wdio/scripts/tests/junit-summary.test.mjs
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { parseTestcases, buildMarkdown } from "../junit-summary.mjs";
+
+const PASS_XML = `<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="Smoke: Home hub navigation" tests="1" failures="0" time="41.2">
+    <testcase classname="home" name="opens each main screen from Home and returns" time="41.2"/>
+  </testsuite>
+</testsuites>`;
+
+const FAIL_XML = `<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="Smoke: power pause / turn-off" tests="1" failures="1" time="112">
+    <testcase classname="power" name="turns protection off" time="112">
+      <failure message="boom">stack</failure>
+    </testcase>
+  </testsuite>
+</testsuites>`;
+
+test("parseTestcases reads a passing testcase", () => {
+  const rows = parseTestcases(PASS_XML);
+  assert.equal(rows.length, 1);
+  assert.deepEqual(rows[0], {
+    suite: "Smoke: Home hub navigation",
+    name: "opens each main screen from Home and returns",
+    status: "passed",
+    time: 41.2
+  });
+});
+
+test("parseTestcases detects failures", () => {
+  const rows = parseTestcases(FAIL_XML);
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].status, "failed");
+  assert.equal(rows[0].suite, "Smoke: power pause / turn-off");
+});
+
+test("buildMarkdown summarizes mixed results", () => {
+  const md = buildMarkdown([...parseTestcases(PASS_XML), ...parseTestcases(FAIL_XML)]);
+  assert.match(md, /Appium smoke — scenario results/);
+  assert.match(md, /✅/);
+  assert.match(md, /❌/);
+  assert.match(md, /\*\*2 scenarios\*\* — 1 passed, 1 failed/);
+});
+
+test("buildMarkdown handles no results", () => {
+  assert.match(buildMarkdown([]), /No JUnit results found/);
+});

--- a/automation/appium/wdio/src/flows/home.ts
+++ b/automation/appium/wdio/src/flows/home.ts
@@ -85,3 +85,29 @@ export async function getProtectionState(): Promise<string | undefined> {
   const value = await element.getAttribute("value");
   return typeof value === "string" ? value.toLowerCase() : undefined;
 }
+
+// --- Pause action sheet ---
+// Tapping power while protection is ON (active, non-freemium account) opens an
+// action sheet to pause or turn off. Inactive / freemium taps toggle directly.
+
+const pauseSheetSelector = `~${AutomationIds.powerActionSheet}`;
+const turnOffSelector = `~${AutomationIds.powerActionTurnOff}`;
+const cancelActionSelector = `~${AutomationIds.powerActionCancel}`;
+
+export async function waitForPauseActionSheet(timeout = 10000): Promise<void> {
+  await (await $(pauseSheetSelector)).waitForExist({ timeout });
+}
+
+export async function tapTurnOff(): Promise<void> {
+  const action = await $(turnOffSelector);
+  await action.waitForExist({ timeout: 5000 });
+  await action.click();
+}
+
+/** Dismiss the pause action sheet if it is open (Cancel does not change state). */
+export async function cancelActionSheetIfPresent(): Promise<void> {
+  const action = await $(cancelActionSelector);
+  if (await action.isExisting()) {
+    await action.click();
+  }
+}

--- a/automation/appium/wdio/src/flows/nav.ts
+++ b/automation/appium/wdio/src/flows/nav.ts
@@ -1,0 +1,88 @@
+import { $, driver } from "@wdio/globals";
+
+import { AutomationIds } from "../support/automationIds.js";
+
+const screenTitleSelector = `~${AutomationIds.screenTitle}`;
+const navBackSelector = `~${AutomationIds.navBack}`;
+const settingsExceptionsSelector = `~${AutomationIds.settingsExceptions}`;
+const settingsRetentionSelector = `~${AutomationIds.settingsRetention}`;
+const exceptionsTabBlockedSelector = `~${AutomationIds.exceptionsTabBlocked}`;
+const retentionToggleSelector = `~${AutomationIds.retentionToggle}`;
+
+interface WaitForScreenOptions {
+  withTitle?: boolean;
+  timeout?: number;
+}
+
+/**
+ * Wait for a screen body marker to render. Every pushed screen also renders the
+ * top-bar title, so assert that too unless `withTitle` is false — Home is at nav
+ * depth 1 with no top bar, so pass `withTitle: false` for it.
+ */
+export async function waitForScreen(
+  screenId: string,
+  { withTitle = true, timeout = 15000 }: WaitForScreenOptions = {}
+): Promise<void> {
+  await (await $(`~${screenId}`)).waitForExist({ timeout });
+  if (withTitle) {
+    await (await $(screenTitleSelector)).waitForExist({ timeout });
+  }
+}
+
+/**
+ * Tap a Home-hub entry control (gear / card button) and wait for its destination
+ * screen to render. The V6 bottom tab bar (`nav_*` ids) is never mounted, so
+ * Home is the only navigation hub — same path as `account.ts::openSettingsScreen`.
+ */
+export async function openHubScreen(
+  buttonId: string,
+  screenId: string,
+  timeout = 15000
+): Promise<void> {
+  const button = await $(`~${buttonId}`);
+  await button.waitForExist({ timeout });
+  await button.click();
+  await waitForScreen(screenId, { timeout });
+}
+
+/**
+ * Pop one pushed route via the top-bar back control — the only pop affordance,
+ * since routes use MaterialWithModalsPageRoute with no iOS edge-swipe. Optionally
+ * assert arrival on an expected screen marker.
+ */
+export async function tapBack(expectScreenId?: string, timeout = 15000): Promise<void> {
+  const back = await $(navBackSelector);
+  await back.waitForExist({ timeout });
+  await back.click();
+  if (expectScreenId) {
+    await (await $(`~${expectScreenId}`)).waitForExist({ timeout });
+  } else {
+    await driver.pause(500);
+  }
+}
+
+export async function goBackToHome(timeout = 15000): Promise<void> {
+  await tapBack(AutomationIds.screenHome, timeout);
+}
+
+/**
+ * From the in-app Settings screen, open the Exceptions sub-page and wait for its
+ * tab segments to render. Call after `openSettingsScreen()`.
+ */
+export async function openExceptionsSubPage(timeout = 15000): Promise<void> {
+  const row = await $(settingsExceptionsSelector);
+  await row.waitForExist({ timeout });
+  await row.click();
+  await (await $(exceptionsTabBlockedSelector)).waitForExist({ timeout });
+}
+
+/**
+ * From the in-app Settings screen, open the Activity/Retention sub-page and wait
+ * for its toggle to render. Call after `openSettingsScreen()`.
+ */
+export async function openRetentionSubPage(timeout = 15000): Promise<void> {
+  const row = await $(settingsRetentionSelector);
+  await row.waitForExist({ timeout });
+  await row.click();
+  await (await $(retentionToggleSelector)).waitForExist({ timeout });
+}

--- a/automation/appium/wdio/src/specs/smoke/power-pause.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/power-pause.spec.ts
@@ -1,0 +1,113 @@
+import { $, driver } from "@wdio/globals";
+import { expect } from "chai";
+
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive } from "../../flows/account.js";
+import {
+  cancelActionSheetIfPresent,
+  getProtectionState,
+  tapPowerButton,
+  tapTurnOff,
+  waitForPauseActionSheet,
+  waitForPowerButton,
+  waitForProtectionInactive
+} from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts, saveScreenshot } from "../../support/artifacts.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+const dnsSheetSelector = `~${AutomationIds.dnsOnboardingSheet}`;
+
+/**
+ * Tap power until protection reports active. The toggle reads "inactive" the
+ * instant status enters `reconfiguring` (still working), and the power button
+ * ignores taps while working — so a single tap can be silently dropped. Retry
+ * until it sticks. The guard checks active before each tap, so we never tap while
+ * active (which would open the pause sheet instead of toggling on); a tap landing
+ * during `reconfiguring` is a harmless no-op.
+ */
+async function activateUntilOn(timeout = 30000): Promise<void> {
+  await driver.waitUntil(
+    async () => {
+      if ((await getProtectionState()) === "active") {
+        return true;
+      }
+      await tapPowerButton();
+      return false;
+    },
+    {
+      timeout,
+      interval: 3000,
+      timeoutMsg: "Protection did not return to active in time"
+    }
+  );
+  // A retry tap can land in the brief window where status just became active,
+  // opening the pause sheet instead of toggling on; dismiss any such stray sheet
+  // so we never leave a modal open (Cancel does not change protection state).
+  await cancelActionSheetIfPresent();
+}
+
+/**
+ * Ensure protection is ON. The DNS profile is installed by dns-onboarding.spec
+ * earlier in the run, so activation is a quick toggle with no onboarding sheet.
+ * If the sheet appears, this spec ran before the DNS profile existed (out of
+ * order) — fail loudly rather than drive the iOS Settings flow here.
+ */
+async function ensureProtectionActive(): Promise<void> {
+  if ((await getProtectionState()) === "active") {
+    return;
+  }
+  await tapPowerButton();
+  const onboardingShown = await (await $(dnsSheetSelector))
+    .waitForExist({ timeout: 4000 })
+    .then(() => true)
+    .catch(() => false);
+  if (onboardingShown) {
+    throw new Error(
+      "DNS onboarding sheet appeared while activating — run power-pause.spec " +
+        "after dns-onboarding.spec so the DNS profile is already installed."
+    );
+  }
+  await activateUntilOn(30000);
+}
+
+// Completes the activation lifecycle: turning protection OFF via the pause action
+// sheet. Requires a paid (non-freemium) active account — a freemium tap toggles
+// off directly with no sheet. Restores protection ON at the end (suite resting
+// state). Registered last in wdio.conf.ts.
+describe("Smoke: power pause / turn-off", () => {
+  before(async () => {
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
+  it("shows the pause sheet, turns protection off, then restores it", async () => {
+    await waitForPowerButton();
+    await ensureProtectionActive();
+
+    // Tapping power while active on a non-freemium account opens the pause sheet.
+    await tapPowerButton();
+    await waitForPauseActionSheet();
+    await saveScreenshot("power-pause-sheet.png");
+
+    // Turn off; the toggle value must flip to inactive.
+    await tapTurnOff();
+    await waitForProtectionInactive(20000);
+    expect(await getProtectionState()).to.equal("inactive");
+
+    // Restore the suite's resting state: protection back ON. Use the retry helper
+    // because the turn-off teardown leaves status in `reconfiguring` briefly,
+    // during which a single re-activation tap would be dropped.
+    await activateUntilOn(30000);
+  });
+});

--- a/automation/appium/wdio/src/specs/smoke/settings-navigation.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/settings-navigation.spec.ts
@@ -1,0 +1,68 @@
+import { $, driver } from "@wdio/globals";
+
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive, openSettingsScreen } from "../../flows/account.js";
+import { waitForPowerButton } from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { goBackToHome, openExceptionsSubPage, openRetentionSubPage, tapBack } from "../../flows/nav.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts } from "../../support/artifacts.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+
+const screenTitleSelector = `~${AutomationIds.screenTitle}`;
+
+// Open the two main Settings sub-pages (Exceptions, Retention) and assert they
+// render. Runs on the active account; returns to Home (no state change).
+describe("Smoke: Settings sub-page navigation", () => {
+  before(async () => {
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
+  it("opens the Exceptions and Retention sub-pages", async () => {
+    await openSettingsScreen();
+
+    // Exceptions: both tab segments + a title render.
+    await openExceptionsSubPage();
+    await (await $(screenTitleSelector)).waitForExist({ timeout: 10000 });
+
+    // Switch to the Allowed tab and verify the selection actually changed — both
+    // segments are always present, so existence alone proves nothing. Each segment
+    // exposes `Semantics(selected:)` (default tab is Blocked), so assert it flips.
+    // If XCUITest doesn't surface `selected` for the merged node, degrade to
+    // confirming the page survives the switch (no crash).
+    const allowedTab = await $(`~${AutomationIds.exceptionsTabAllowed}`);
+    const selectedBefore = await allowedTab.getAttribute("selected").catch(() => null);
+    await allowedTab.click();
+    if (selectedBefore === "true" || selectedBefore === "false") {
+      await driver.waitUntil(
+        async () => (await allowedTab.getAttribute("selected")) === "true",
+        { timeout: 10000, timeoutMsg: "Allowed tab did not become selected after tap" }
+      );
+    } else {
+      console.warn(
+        "Exceptions tab 'selected' attribute not exposed; asserting page survival only."
+      );
+      await (await $(`~${AutomationIds.exceptionsTabBlocked}`)).waitForExist({ timeout: 10000 });
+    }
+    await tapBack(AutomationIds.screenSettings);
+
+    // Retention: toggle + title render. Do NOT flip the toggle — it changes a real
+    // user setting; presence is enough for a smoke.
+    await openRetentionSubPage();
+    await (await $(screenTitleSelector)).waitForExist({ timeout: 10000 });
+    await tapBack(AutomationIds.screenSettings);
+
+    await goBackToHome();
+  });
+});

--- a/automation/appium/wdio/src/specs/smoke/tab-navigation.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/tab-navigation.spec.ts
@@ -1,0 +1,43 @@
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive } from "../../flows/account.js";
+import { waitForPowerButton } from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { goBackToHome, openHubScreen, waitForScreen } from "../../flows/nav.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts } from "../../support/artifacts.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+
+// V6 navigation is hub-and-spoke off Home (the bottom tab bar / `nav_*` ids are
+// dead code — TabWidget is never mounted). Each main screen is opened from Home
+// and popped back via the top-bar back control. Catches route/blank-screen/crash
+// regressions cheaply; runs on the active account and leaves protection unchanged.
+describe("Smoke: Home hub navigation", () => {
+  before(async () => {
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
+  it("opens each main screen from Home and returns", async () => {
+    // Home has no top bar / title.
+    await waitForScreen(AutomationIds.screenHome, { withTitle: false });
+
+    await openHubScreen(AutomationIds.homePrivacyPulse, AutomationIds.screenPrivacyPulse);
+    await goBackToHome();
+
+    await openHubScreen(AutomationIds.homeAdvanced, AutomationIds.screenAdvanced);
+    await goBackToHome();
+
+    await openHubScreen(AutomationIds.homeSettings, AutomationIds.screenSettings);
+    await goBackToHome();
+  });
+});

--- a/automation/appium/wdio/wdio.conf.ts
+++ b/automation/appium/wdio/wdio.conf.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { resolve } from "node:path";
 
 import type { Options } from "@wdio/types";
 
@@ -9,21 +10,33 @@ const logLevel =
   (process.env.WDIO_LOG_LEVEL as Options.WebDriverLogTypes | undefined) ?? "info";
 const server = getAppiumServerConfig(process.env);
 
+// Ordered by account-state lifecycle: inactive-account scenarios first,
+// active-account scenarios last, so the suite ends in the active state (the
+// default most scenarios / manual inspection expect) and mirrors the real user
+// journey (inactive -> paywall -> activate). Each spec self-provisions its
+// account state, so correctness is order-independent; this list just pins the
+// resting state. New specs: insert in account-state order.
+const allSpecs = [
+  "./src/specs/smoke/paywall.spec.ts", // inactive account
+  "./src/specs/smoke/dns-onboarding.spec.ts", // active account; installs DNS profile, leaves protection ON
+  "./src/specs/smoke/tab-navigation.spec.ts", // active account; home-hub navigation (no state change)
+  "./src/specs/smoke/settings-navigation.spec.ts", // active account; settings sub-pages (no state change)
+  "./src/specs/smoke/power-pause.spec.ts" // active account; turns off then re-activates -> resting state
+];
+// CI runs one step per scenario (so each shows separately) by setting WDIO_SPEC
+// to a single spec path; when unset, the whole suite runs in order.
+const specFilter = process.env.WDIO_SPEC?.trim();
+
+// One JUnit file per scenario, consumed by scripts/junit-summary.mjs for the CI
+// run summary and uploaded as an artifact. The filename is namespaced by spec so
+// separate per-scenario wdio processes (each worker cid is 0-0) don't collide.
+const junitDir = resolve(process.cwd(), "..", "output", "junit");
+const junitSpecBase =
+  specFilter?.split("/").pop()?.replace(/\.spec\.ts$/, "") ?? "all";
+
 const rawConfig = {
   runner: "local",
-  // Ordered by account-state lifecycle: inactive-account scenarios first,
-  // active-account scenarios last, so the suite ends in the active state (the
-  // default most scenarios / manual inspection expect) and mirrors the real
-  // user journey (inactive -> paywall -> activate). Each spec self-provisions
-  // its account state, so correctness is order-independent; this list just
-  // pins the resting state. New specs: insert in account-state order.
-  specs: [
-    "./src/specs/smoke/paywall.spec.ts", // inactive account
-    "./src/specs/smoke/dns-onboarding.spec.ts", // active account; installs DNS profile, leaves protection ON
-    "./src/specs/smoke/tab-navigation.spec.ts", // active account; home-hub navigation (no state change)
-    "./src/specs/smoke/settings-navigation.spec.ts", // active account; settings sub-pages (no state change)
-    "./src/specs/smoke/power-pause.spec.ts" // active account; turns off then re-activates -> resting state
-  ],
+  specs: specFilter ? [specFilter] : allSpecs,
   maxInstances: 1,
   hostname: server.host,
   port: server.port,
@@ -40,7 +53,17 @@ const rawConfig = {
       transpileOnly: true
     }
   },
-  reporters: ["spec"],
+  reporters: [
+    "spec",
+    [
+      "junit",
+      {
+        outputDir: junitDir,
+        outputFileFormat: (options: { cid: string }) =>
+          `results-${junitSpecBase}-${options.cid}.xml`
+      }
+    ]
+  ],
   services: [],
   capabilities: [buildCapabilities(process.env)],
   // Wake the device before every worker session. `make appium-test` wakes the

--- a/automation/appium/wdio/wdio.conf.ts
+++ b/automation/appium/wdio/wdio.conf.ts
@@ -10,33 +10,25 @@ const logLevel =
   (process.env.WDIO_LOG_LEVEL as Options.WebDriverLogTypes | undefined) ?? "info";
 const server = getAppiumServerConfig(process.env);
 
-// Ordered by account-state lifecycle: inactive-account scenarios first,
-// active-account scenarios last, so the suite ends in the active state (the
-// default most scenarios / manual inspection expect) and mirrors the real user
-// journey (inactive -> paywall -> activate). Each spec self-provisions its
-// account state, so correctness is order-independent; this list just pins the
-// resting state. New specs: insert in account-state order.
-const allSpecs = [
-  "./src/specs/smoke/paywall.spec.ts", // inactive account
-  "./src/specs/smoke/dns-onboarding.spec.ts", // active account; installs DNS profile, leaves protection ON
-  "./src/specs/smoke/tab-navigation.spec.ts", // active account; home-hub navigation (no state change)
-  "./src/specs/smoke/settings-navigation.spec.ts", // active account; settings sub-pages (no state change)
-  "./src/specs/smoke/power-pause.spec.ts" // active account; turns off then re-activates -> resting state
-];
-// CI runs one step per scenario (so each shows separately) by setting WDIO_SPEC
-// to a single spec path; when unset, the whole suite runs in order.
-const specFilter = process.env.WDIO_SPEC?.trim();
-
-// One JUnit file per scenario, consumed by scripts/junit-summary.mjs for the CI
-// run summary and uploaded as an artifact. The filename is namespaced by spec so
-// separate per-scenario wdio processes (each worker cid is 0-0) don't collide.
+// JUnit output dir (one file per spec, distinct by worker cid) consumed by
+// scripts/junit-summary.mjs for the CI run summary and uploaded as an artifact.
 const junitDir = resolve(process.cwd(), "..", "output", "junit");
-const junitSpecBase =
-  specFilter?.split("/").pop()?.replace(/\.spec\.ts$/, "") ?? "all";
 
 const rawConfig = {
   runner: "local",
-  specs: specFilter ? [specFilter] : allSpecs,
+  // Ordered by account-state lifecycle: inactive-account scenarios first,
+  // active-account scenarios last, so the suite ends in the active state (the
+  // default most scenarios / manual inspection expect) and mirrors the real
+  // user journey (inactive -> paywall -> activate). Each spec self-provisions
+  // its account state, so correctness is order-independent; this list just
+  // pins the resting state. New specs: insert in account-state order.
+  specs: [
+    "./src/specs/smoke/paywall.spec.ts", // inactive account
+    "./src/specs/smoke/dns-onboarding.spec.ts", // active account; installs DNS profile, leaves protection ON
+    "./src/specs/smoke/tab-navigation.spec.ts", // active account; home-hub navigation (no state change)
+    "./src/specs/smoke/settings-navigation.spec.ts", // active account; settings sub-pages (no state change)
+    "./src/specs/smoke/power-pause.spec.ts" // active account; turns off then re-activates -> resting state
+  ],
   maxInstances: 1,
   hostname: server.host,
   port: server.port,
@@ -59,8 +51,7 @@ const rawConfig = {
       "junit",
       {
         outputDir: junitDir,
-        outputFileFormat: (options: { cid: string }) =>
-          `results-${junitSpecBase}-${options.cid}.xml`
+        outputFileFormat: (options: { cid: string }) => `results-${options.cid}.xml`
       }
     ]
   ],

--- a/automation/appium/wdio/wdio.conf.ts
+++ b/automation/appium/wdio/wdio.conf.ts
@@ -19,7 +19,10 @@ const rawConfig = {
   // pins the resting state. New specs: insert in account-state order.
   specs: [
     "./src/specs/smoke/paywall.spec.ts", // inactive account
-    "./src/specs/smoke/dns-onboarding.spec.ts" // active account (leaves device active)
+    "./src/specs/smoke/dns-onboarding.spec.ts", // active account; installs DNS profile, leaves protection ON
+    "./src/specs/smoke/tab-navigation.spec.ts", // active account; home-hub navigation (no state change)
+    "./src/specs/smoke/settings-navigation.spec.ts", // active account; settings sub-pages (no state change)
+    "./src/specs/smoke/power-pause.spec.ts" // active account; turns off then re-activates -> resting state
   ],
   maxInstances: 1,
   hostname: server.host,


### PR DESCRIPTION
## What & why

Two related changes to the iOS Appium smoke suite:

1. **Three new functional-flow smoke specs** covering the previously-untested core (main screens render, Settings sub-pages open, the protection-**off** half of the activation lifecycle).
2. **A per-scenario JUnit run summary** so each scenario's pass/fail + timing is visible at a glance, without adding any CI time (the suite still runs in a single pass on the one physical device).

## New specs (registered in `wdio.conf.ts`, account-state order; device still ends active + ON)

1. **`tab-navigation.spec.ts`** — Home hub-and-spoke navigation to Privacy Pulse / Advanced / Settings, asserting each screen body + top-bar title render, popping back each time.
2. **`settings-navigation.spec.ts`** — opens the Exceptions and Retention sub-pages; asserts the Exceptions tab selection actually flips (graceful fallback if XCUITest doesn't surface `selected`). Does not flip the retention toggle.
3. **`power-pause.spec.ts`** — pause action sheet → turn off → assert toggle `inactive` → re-activate (retry-tolerant of the `reconfiguring` window).

Key finding: the V6 bottom tab bar (`nav_*` ids) is dead code (`TabWidget` is never mounted), so navigation goes through the live Home hub buttons. No `automation/ids.dart` changes — every id already existed.

## JUnit run summary (no added CI time)

- `@wdio/junit-reporter` writes one JUnit file per scenario; `scripts/junit-summary.mjs` renders a per-scenario table (status / scenario / test / duration) into the GitHub **run Summary**, and the XML is uploaded as an artifact.
- The smoke suite still runs as a single `make appium-test` pass (`appium-test` resets the junit dir so the summary is fresh). No per-scenario job steps — an earlier per-scenario-step variant was dropped because it added ~1–2 min of extra Appium/WDA session startup for visibility only.

## Test plan

- [x] `npx tsc --noEmit` — no new type errors (pre-existing `.mjs` baseline only).
- [x] `npm run test:unit` — 91/91 pass (incl. new JUnit-parser tests).
- [x] On-device run on the self-hosted CI iPhone — specs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
