### PR TITLE
test(appium): smoke specs for protection persistence, blocklist toggle, Privacy Pulse range

### DIFF
--- a/automation/appium/wdio/src/specs/smoke/blocklist-toggle.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/blocklist-toggle.spec.ts
@@ -1,0 +1,91 @@
+import { $, driver } from "@wdio/globals";
+import { expect } from "chai";
+
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive } from "../../flows/account.js";
+import { waitForPowerButton } from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { goBackToHome, openHubScreen } from "../../flows/nav.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts } from "../../support/artifacts.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+
+// Filter option switches expose ids like `automation.filter_option.<filter>.<option>`
+// (filter.dart `_filterOptionAutomationId`) with the CupertinoSwitch state on the
+// element `value` ("1"/"0"). Match any of them by id prefix so the spec isn't pinned
+// to one pack name (which varies by account/flavor); the first match is then pinned
+// by its exact id so a list rebuild on toggle can't retarget a different option.
+const filterOptionPrefixSelector =
+  "-ios predicate string: name BEGINSWITH 'automation.filter_option.'";
+
+// The filter actor debounces the backend write ~1s then syncs; give margin before
+// asserting the new state and before toggling back so each write commits.
+const SYNC_WAIT_MS = 2000;
+
+async function valueOf(selector: string): Promise<string | undefined> {
+  const value = await (await $(selector)).getAttribute("value");
+  return typeof value === "string" ? value : undefined;
+}
+
+// Exercises the core blocking config: enable/disable a filter option, confirm the
+// switch state flips, then restore it so the account's config is left unchanged.
+// Requires the paid/active account — freemium wraps the filter list in IgnorePointer
+// so toggles are inert. Runs on the active account; returns Home (protection
+// untouched).
+describe("Smoke: blocklist pack toggle", () => {
+  before(async () => {
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
+  it("toggles a filter option and restores it", async () => {
+    await openHubScreen(AutomationIds.homeAdvanced, AutomationIds.screenAdvanced);
+
+    // First available filter option. Fail loudly if none render (wrong account type
+    // or the Advanced list failed to populate).
+    const firstOption = await $(filterOptionPrefixSelector);
+    await firstOption.waitForExist({ timeout: 15000 });
+    const optionId = await firstOption.getAttribute("name");
+    expect(optionId, "filter option should expose its automation id")
+      .to.be.a("string")
+      .and.match(/^automation\.filter_option\./);
+    const optionSelector = `~${optionId}`;
+
+    const initial = await valueOf(optionSelector);
+    expect(initial, "filter option should expose a switch value").to.be.a("string");
+
+    // Flip it and confirm the switch state changed (optimistic UI update).
+    await (await $(optionSelector)).click();
+    await driver.pause(SYNC_WAIT_MS);
+    await driver.waitUntil(async () => (await valueOf(optionSelector)) !== initial, {
+      timeout: 10000,
+      interval: 500,
+      timeoutMsg: `Filter option '${String(optionId)}' value did not change from '${String(
+        initial
+      )}' after toggling.`
+    });
+
+    // Restore the original state so the spec leaves the account's config unchanged.
+    await (await $(optionSelector)).click();
+    await driver.pause(SYNC_WAIT_MS);
+    await driver.waitUntil(async () => (await valueOf(optionSelector)) === initial, {
+      timeout: 10000,
+      interval: 500,
+      timeoutMsg: `Filter option '${String(optionId)}' did not return to its original state '${String(
+        initial
+      )}'.`
+    });
+
+    await goBackToHome();
+  });
+});

--- a/automation/appium/wdio/src/specs/smoke/cold-restart-persistence.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/cold-restart-persistence.spec.ts
@@ -1,0 +1,104 @@
+import { $, driver } from "@wdio/globals";
+import { expect } from "chai";
+
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive } from "../../flows/account.js";
+import {
+  cancelActionSheetIfPresent,
+  getProtectionState,
+  tapPowerButton,
+  waitForPowerButton
+} from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts } from "../../support/artifacts.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+const dnsSheetSelector = `~${AutomationIds.dnsOnboardingSheet}`;
+
+async function exists(selector: string): Promise<boolean> {
+  try {
+    return await (await $(selector)).isExisting();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Drive protection to active and keep it there. Mirrors power-pause's helper: the
+ * toggle reads "inactive" while status is reconfiguring and ignores taps while
+ * working, so a single tap can be silently dropped — retry until it sticks. A retry
+ * tap landing just as status turns active opens the pause sheet; cancel it.
+ *
+ * If activating raises the DNS onboarding sheet the DNS profile isn't installed —
+ * fail loudly (this spec must run after dns-onboarding.spec).
+ */
+async function ensureProtectionActive(timeout = 30000): Promise<void> {
+  await driver.waitUntil(
+    async () => {
+      if ((await getProtectionState()) === "active") {
+        return true;
+      }
+      await tapPowerButton();
+      if (await exists(dnsSheetSelector)) {
+        throw new Error(
+          "DNS onboarding sheet appeared while activating — run " +
+            "cold-restart-persistence.spec after dns-onboarding.spec so the DNS " +
+            "profile is already installed."
+        );
+      }
+      return false;
+    },
+    { timeout, interval: 3000, timeoutMsg: "Protection did not reach active in time" }
+  );
+  await cancelActionSheetIfPresent();
+}
+
+// Protection must survive a cold app restart. Every other active spec re-activates
+// if needed and so would mask a state-restoration regression; this one asserts the
+// toggle is STILL active after a kill + relaunch, without tapping. Runs on the
+// active account and leaves protection ON (suite resting state preserved).
+describe("Smoke: protection persists across cold restart", () => {
+  before(async () => {
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
+  it("stays active after a kill and relaunch", async () => {
+    await waitForPowerButton();
+    await ensureProtectionActive();
+    expect(await getProtectionState()).to.equal("active");
+
+    // Cold restart: fully terminate, then relaunch from scratch.
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+
+    // Assert WITHOUT tapping: the app should restore the active tunnel on launch.
+    // Allow a short settle while status resolves out of any transient reconfiguring
+    // state; staying inactive is the regression this guards against.
+    await driver.waitUntil(
+      async () => (await getProtectionState()) === "active",
+      {
+        timeout: 20000,
+        interval: 1000,
+        timeoutMsg:
+          "Protection did not report active after a cold restart — possible " +
+          "state-restoration regression (it was active before the relaunch)."
+      }
+    );
+    expect(await getProtectionState()).to.equal("active");
+  });
+});

--- a/automation/appium/wdio/src/specs/smoke/privacy-pulse-range.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/privacy-pulse-range.spec.ts
@@ -1,0 +1,78 @@
+import { $, driver } from "@wdio/globals";
+
+import { activateApp, terminateApp } from "../../flows/app.js";
+import { acceptNotificationAlert } from "../../flows/alerts.js";
+import { ensureAccountActive } from "../../flows/account.js";
+import { waitForPowerButton } from "../../flows/home.js";
+import { dismissIntroOverlayIfPresent } from "../../flows/onboarding.js";
+import { dismissRatePromptIfPresent } from "../../flows/modals.js";
+import { goBackToHome, openHubScreen } from "../../flows/nav.js";
+import { AutomationIds } from "../../support/automationIds.js";
+import { registerFailureArtifacts } from "../../support/artifacts.js";
+
+registerFailureArtifacts();
+
+const APP_BUNDLE_ID = process.env.APP_BUNDLE_ID ?? "net.blocka.app";
+const dailySelector = `~${AutomationIds.privacyPulseRangeDaily}`;
+const weeklySelector = `~${AutomationIds.privacyPulseRangeWeekly}`;
+
+// Opens Privacy Pulse and flips the 24h <-> 7d toplist range — the one interactive
+// stats control, which tab-navigation only ever opens. The segments expose
+// Semantics(selected:), so assert the selection moves (default is 24h); degrade to
+// page-survival if XCUITest doesn't surface `selected` on the merged node (same
+// pattern as the Exceptions tab switch). The range toggle renders unconditionally
+// (it is the charts' trailing control). Active account; restores 24h and returns
+// Home.
+describe("Smoke: Privacy Pulse range toggle", () => {
+  before(async () => {
+    await terminateApp(APP_BUNDLE_ID);
+    await activateApp(APP_BUNDLE_ID);
+    await dismissRatePromptIfPresent(5000);
+    await acceptNotificationAlert();
+    await dismissIntroOverlayIfPresent();
+    await waitForPowerButton();
+    await ensureAccountActive();
+  });
+
+  it("switches between the 24h and 7d ranges", async () => {
+    await openHubScreen(AutomationIds.homePrivacyPulse, AutomationIds.screenPrivacyPulse);
+
+    const weekly = await $(weeklySelector);
+    await weekly.waitForExist({ timeout: 15000 });
+
+    // Default range is 24h, so the 7d segment should not be selected yet. Both
+    // segments are always present, so existence proves nothing — assert the
+    // selection flips. If the merged node doesn't expose `selected`, fall back to
+    // confirming the page survives the switch.
+    const exposesSelected = await weekly
+      .getAttribute("selected")
+      .then((v) => v === "true" || v === "false")
+      .catch(() => false);
+
+    await weekly.click();
+    if (exposesSelected) {
+      await driver.waitUntil(async () => (await weekly.getAttribute("selected")) === "true", {
+        timeout: 10000,
+        timeoutMsg: "7d range did not become selected after tapping it"
+      });
+    } else {
+      console.warn(
+        "Privacy Pulse range 'selected' attribute not exposed; asserting page survival only."
+      );
+      await (await $(dailySelector)).waitForExist({ timeout: 10000 });
+    }
+
+    // Restore the default 24h range.
+    const daily = await $(dailySelector);
+    await daily.waitForExist({ timeout: 10000 });
+    await daily.click();
+    if (exposesSelected) {
+      await driver.waitUntil(async () => (await daily.getAttribute("selected")) === "true", {
+        timeout: 10000,
+        timeoutMsg: "24h range did not become selected after the restore tap"
+      });
+    }
+
+    await goBackToHome();
+  });
+});

--- a/automation/appium/wdio/wdio.conf.ts
+++ b/automation/appium/wdio/wdio.conf.ts
@@ -35,8 +35,11 @@ const rawConfig = {
     "./src/specs/smoke/paywall.spec.ts", // restores inactive (first spec of the run)
     // --- active account (boundary: dns-onboarding pays the one active restore) ---
     "./src/specs/smoke/dns-onboarding.spec.ts", // restores active; installs DNS profile, leaves protection ON
+    "./src/specs/smoke/cold-restart-persistence.spec.ts", // protection survives kill+relaunch (restore skipped)
     "./src/specs/smoke/tab-navigation.spec.ts", // home-hub navigation (restore skipped)
     "./src/specs/smoke/settings-navigation.spec.ts", // settings sub-pages (restore skipped)
+    "./src/specs/smoke/blocklist-toggle.spec.ts", // toggle a filter option + restore (restore skipped)
+    "./src/specs/smoke/privacy-pulse-range.spec.ts", // 24h<->7d toplist range toggle (restore skipped)
     "./src/specs/smoke/power-pause.spec.ts" // turns off then re-activates -> resting state (restore skipped)
   ],
   maxInstances: 1,


### PR DESCRIPTION
## What

Adds three functional iOS smoke specs to the Appium suite. Until now the suite
covered navigation/paywall/power chrome but never the app's actual function. Each
new spec rides the existing active-account group (no extra `cc restore`),
self-restores state, and leaves protection ON.

| Spec | Guards against | New app IDs |
|---|---|---|
| `cold-restart-persistence` | Protection failing to restore after a kill+relaunch — asserts `power_toggle` stays `active` without re-tapping (the other active specs re-activate and so mask this) | none |
| `blocklist-toggle` | Core blocking config breaking — flips a real filter option, waits the ~1s backend debounce, asserts the switch state flipped, then restores it | none (existing `automation.filter_option.*`) |
| `privacy-pulse-range` | The 24h↔7d toplist range — the one interactive stats control, today only opened | none (existing `privacy_pulse_range_*`) |

Registered in the active group of `wdio.conf.ts` (cold-restart right after
dns-onboarding so the DNS profile exists; power-pause still last as resting state).

## Not yet run on-device

Authored + statically reviewed + type-checked, but **not** executed against a
device (the CI/dev iPhone is wireless-only + locked, so WebDriverAgent couldn't
attach from the authoring environment). **Please run `make appium-test` on a
USB-connected, unlocked, passcode-free device before merging.** `blocklist-toggle`
is the one most worth eyeballing — it depends on the filter switch `value` being
`"1"`/`"0"` on your device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
