### PR TITLE
chore(deps): drop unused dependency_validator dev-dependency

### DIFF
--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -242,14 +242,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  dependency_validator:
-    dependency: "direct dev"
-    description:
-      name: dependency_validator
-      sha256: "3a23914cacac37d0cdce067d0576fce18bf5951338616f036a20604c97dba0f7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.3"
   diffutil_dart:
     dependency: transitive
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -87,7 +87,6 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.2.1
   flutter_lints: ">=2.0.0 <7.0.0"
-  dependency_validator: ">=3.0.0 <6.0.0"
   mobx_codegen: ^2.0.7+3
   pigeon: ">=12.0.0 <27.0.0"
   mockito: ^5.3.2


### PR DESCRIPTION
Closes out #1162 (closed as a no-op).

## What

Removes `dependency_validator` from `common/pubspec.yaml` dev_dependencies, plus its `pubspec.lock` stanza. 9 deletions, nothing else.

## Why

**It is never invoked.** `dependency_validator` is a Workiva pub package that lints a pubspec for unused/missing deps — but nothing in this repo runs it. No CI job, no make target, no script, no git hook. Its only two references in the entire tree were its own pubspec line and the lock entry generated from it. (Despite the name, it is unrelated to Dependabot and unrelated to our `automation/dep-validate/` skill, which is pure Node.)

**And it can't be upgraded anyway.** The deliberate `dependency_overrides: pigeon: 12.0.1` hold pins `analyzer` to 5.x (pigeon 12 requires `analyzer ^5.13.0`), while `dependency_validator` >=5.0.3 requires `analyzer >=7.1.0`:

> Because pigeon >=10.0.1 <13.1.2 depends on analyzer ^5.13.0 and dependency_validator >=5.0.5 depends on analyzer >=7.1.0 <13.0.0, pigeon >=10.0.1 <13.1.2 is incompatible with dependency_validator >=5.0.5.

Version solving fails, so Dependabot's lock update silently re-resolves back to 4.1.3 and commits an **empty tree** — which is exactly what #1162 was: an open, mergeable, CI-green PR with a zero-file diff, regenerating forever. The only way to unblock it for real would be dropping the pigeon override, which pulls pigeon 12.0.1 → 26.3.4 — the native Swift/Kotlin codegen migration we already judged disproportionate for a dev-only tool.

So the choice was: do the pigeon 26 migration to upgrade a linter nobody runs, or delete the linter. This is the delete.

Removing it also frees one `analyzer` constraint from the resolver, and stops the recurring no-op PR at its root (no Dependabot `ignore` rule needed — the dep is simply gone from the manifest).

## Note on the lock diff

The lock delta is the `dependency_validator` stanza **only**. No transitive is orphaned by the removal — `analyzer`, `args`, `glob`, `io`, `yaml`, `pubspec_parse` et al. all remain required by pigeon / build_runner / source_gen / mockito. Verified by regenerating the lock with and without the dep and diffing: the sole difference is that stanza.

Separately, `flutter pub get` on this repo mutates `pubspec.lock` even with **no** source change — it downgrades 8 unrelated packages under the pinned Flutter 3.35.2 (`flex_color_scheme` 8.4.0→8.3.1, `meta` 1.18.0→1.16.0, `matcher`, `leak_tracker`, `material_color_utilities`, `test_api`…). That drift is **pre-existing on `main`** and is deliberately kept out of this diff. It's worth a separate look — the committed lock isn't reproducible under the pinned toolchain — but it is not this PR's business.

## Verification

- `make test` — **379/379 pass** (includes pigeon + build_runner codegen)
- `fvm flutter analyze --no-fatal-warnings --no-fatal-infos` (the CI gate) — **exit 0**; 0 errors, 5 warnings / 410 infos are the pre-existing baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)