### PR TITLE
fix(deps): make pubspec.lock truthful under the pinned Flutter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,11 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
+      # Must run before `make pub`, which would rewrite a bad lock and hide it.
+      - name: Verify pubspec.lock resolves under the pinned Flutter
+        working-directory: common
+        run: make pub-verify
+
       - name: Analyze Flutter module
         working-directory: common
         run: |

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,16 @@
+{
+  // Point the Dart/Flutter extension at the fvm-pinned SDK (common/.fvmrc), not
+  // whatever Flutter happens to be on PATH. common/pubspec.yaml pins
+  // `flutter: '>=3.35.2 <3.36.0'` as a hard constraint, so an ambient SDK makes
+  // `pub get` fail outright.
+  //
+  // The symlink is created by fvm and is gitignored, so each checkout needs:
+  //   cd common && fvm use
+  "dart.flutterSdkPath": "common/.fvm/flutter_sdk",
+  "search.exclude": {
+    "**/.fvm": true
+  },
+  "files.watcherExclude": {
+    "**/.fvm": true
+  }
+}

--- a/common/Makefile
+++ b/common/Makefile
@@ -7,7 +7,7 @@ OUTPUT_DIR := build/pigeon/
 # Default target
 .DEFAULT_GOAL := build
 
-.PHONY: test test-local analyze clean pub gen-android gen-ios runner \
+.PHONY: test test-local analyze clean pub pub-verify gen-android gen-ios runner \
 	lib lib-debug \
         build-android build-ios build \
 	other-lib-ios-debug other-build-web
@@ -43,6 +43,14 @@ build-ios: pub gen-ios runner
 # Fetch dependencies from pubspec.yaml (flutter pub get)
 pub:
 	$(FLUTTER) pub get
+
+# Fail if the committed pubspec.lock is not a valid resolution under the pinned
+# Flutter. Plain `pub get` silently re-resolves and rewrites the lock instead, so
+# a lock generated on a different SDK (Dependabot's) otherwise lands unnoticed
+# and CI goes green against dependencies nobody committed. Pure check: it never
+# rewrites the lock.
+pub-verify:
+	$(FLUTTER) pub get --enforce-lockfile
 
 # Generate all necessary files for both platforms
 gen: gen-android gen-ios runner

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -142,10 +142,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -310,18 +310,18 @@ packages:
     dependency: "direct main"
     description:
       name: flex_color_scheme
-      sha256: ab854146f201d2d62cc251fd525ef023b84182c4a0bfe4ae4c18ffc505b412d3
+      sha256: "6e713c27a2ebe63393a44d4bf9cdd2ac81e112724a4c69905fc41cbf231af11d"
       url: "https://pub.dev"
     source: hosted
-    version: "8.4.0"
+    version: "8.3.1"
   flex_seed_scheme:
     dependency: transitive
     description:
       name: flex_seed_scheme
-      sha256: a3183753bbcfc3af106224bff3ab3e1844b73f58062136b7499919f49f3667e7
+      sha256: "828291a5a4d4283590541519d8b57821946660ac61d2e07d955f81cfcab22e5d"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "3.6.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -498,10 +498,10 @@ packages:
     dependency: transitive
     description:
       name: idb_shim
-      sha256: "48be1c95f06c4b059d0f5b9888dc5d7384e4a9e4d71824ae2deeb1e1546c6c07"
+      sha256: "071f3b05032fa62e60ca15db9939f8afbaf403b37e67747ac88f858c3e999228"
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.2"
+    version: "2.6.7+1"
   input_code_field:
     dependency: "direct main"
     description:
@@ -602,26 +602,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -1079,10 +1079,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.6"
   time:
     dependency: transitive
     description:
@@ -1196,5 +1196,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0 <3.16.0"
-  flutter: ">=3.35.1"
+  dart: ">=3.9.0 <3.16.0"
+  flutter: ">=3.35.2 <3.36.0"

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -242,14 +242,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
-  dependency_validator:
-    dependency: "direct dev"
-    description:
-      name: dependency_validator
-      sha256: "3a23914cacac37d0cdce067d0576fce18bf5951338616f036a20604c97dba0f7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.3"
   diffutil_dart:
     dependency: transitive
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -17,8 +17,22 @@ description: A new Flutter module project.
 # on any other native host app that you embed your Flutter project into.
 version: 1.0.0+1
 
+# The flutter constraint is what makes Dependabot resolve against the SDK we
+# actually pin (.fvmrc). Without it, dependabot-core's infer_sdk_versions
+# defaults the flutter range to `any` and resolves with the newest stable
+# Flutter, producing a pubspec.lock that is unsatisfiable here (see #1149: it
+# locked meta 1.18.0 / matcher 0.12.19 / flex_color_scheme 8.4.0, none of which
+# resolve on 3.35.2, so every `pub get` silently re-resolved them away).
+#
+# This is a HARD pin, both bounds: since the sdk floor is >=3.9.0, the package's
+# language version is 3.9, which is what makes pub enforce the flutter upper
+# bound too (dart-lang/pub#4310). `flutter pub get` outside [3.35.2, 3.36.0)
+# fails with "requires Flutter SDK version". That is deliberate — an off-SDK
+# resolve is what corrupted the lock in the first place. Use fvm (every make
+# target does). Bump both bounds in lockstep with .fvmrc on a Flutter upgrade.
 environment:
-  sdk: '>=3.1.0 <4.0.0'
+  sdk: '>=3.9.0 <4.0.0'
+  flutter: '>=3.35.2 <3.36.0'
 
 dependencies:
   flutter:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -87,7 +87,6 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.2.1
   flutter_lints: ">=2.0.0 <7.0.0"
-  dependency_validator: ">=3.0.0 <6.0.0"
   mobx_codegen: ^2.0.7+3
   pigeon: ">=12.0.0 <27.0.0"
   mockito: ^5.3.2


### PR DESCRIPTION
**Stacked on #1172** (which removes an unused dev-dep from the same two files). Merge that first; the base retargets to `main` automatically.

## The bug

`common/pubspec.lock` on `main` is **unsatisfiable under the Flutter we pin** (3.35.2, via `.fvmrc`):

```
$ fvm flutter pub get --enforce-lockfile
Would change 8 dependencies.
Unable to satisfy `pubspec.yaml` using `pubspec.lock`.   # exit 65
```

The Flutter SDK pins `meta`/`matcher`/`test_api`/`characters`/`material_color_utilities` **exactly** — 3.35.2 pins `meta 1.16.0`, `matcher 0.12.17`, `test_api 0.7.6`. The committed lock holds `1.18.0` / `0.12.19` / `0.7.11`. Those are unreachable on 3.35.2, so the lock could only have been produced by a **newer Flutter than we pin**.

**Root cause:** dependabot-core's [`infer_sdk_versions.dart`](https://github.com/dependabot/dependabot-core/blob/main/pub/helpers/bin/infer_sdk_versions.dart) reads `environment.sdk` **and** `environment.flutter` from our pubspec, and defaults the flutter range to `any` when the key is absent — then resolves with the *newest stable Flutter*. We never declared `environment.flutter`. So every pub lock Dependabot has committed here was resolved on the wrong SDK.

**Why nobody saw it:** CI runs plain `flutter pub get`, which silently re-resolves and rewrites the lock. `--enforce-lockfile` appears nowhere in the repo. Green CI, corrupt lock.

## The damage was real, not theoretical

Of the **29** lock updates that #1149 merged, **8 never took effect**:

| package | lock *claims* | actually built |
|---|---|---|
| `flex_color_scheme` | 8.4.0 | **8.3.1** |
| `flex_seed_scheme` | 4.0.1 | 3.6.1 |
| `idb_shim` | 2.9.2 | 2.6.7+1 |
| `meta` / `matcher` / `test_api` / `characters` / `material_color_utilities` | all bumped | all unchanged |

We have been shipping `flex_color_scheme` **8.3.1** while the lock said 8.4.0. CI "validated" #1149 against a different dependency set than that PR's own lock declared, and anything read off the lock (audit, SBOM, "what do we ship?") was wrong. Latent risk: on a Flutter upgrade past 3.38, all 8 would have activated at once, untested.

## The fix

1. **`pubspec.yaml`** — declare the real Dart floor (3.9.0) and pin `flutter: '>=3.35.2 <3.36.0'`. This is the field Dependabot resolves against, so it stops the corruption at the source.
2. **`pubspec.lock`** — regenerated on 3.35.2. Corrects the 8 impossible versions **to what we have actually been building**. Not a downgrade; a correction of the record.
3. **`make pub-verify` + a CI step** — `pub get --enforce-lockfile` (a pure check; it never rewrites). Fails loudly on any future lock resolved off the pinned SDK. Runs *before* `make pub`, which would otherwise rewrite and hide it.

## ⚠️ Behavior change: the flutter constraint is a HARD pin

Raising the Dart floor to 3.9.0 sets the package's language version to 3.9, which is what makes pub enforce the flutter **upper** bound too ([dart-lang/pub#4310](https://github.com/dart-lang/pub/issues/4310)). Verified on 3.35.2 against a deliberately violated bound:

| `environment.sdk` floor | `flutter pub get` |
|---|---|
| `>=3.1.0` (old) | exit 0 — upper bound ignored |
| `>=3.9.0` (new) | **exit 1 — `requires Flutter SDK version`** |

So `flutter pub get` outside `[3.35.2, 3.36.0)` now fails outright. **This is deliberate** — an off-SDK resolve is exactly what corrupted the lock, and this makes it impossible for humans too, not just Dependabot. Every make target already uses fvm (`FLUTTER := fvm flutter`), so CI and normal workflows are unaffected. `.vscode/settings.json` points the Dart extension at the fvm SDK so IDE `pub get` keeps working.

**Bump the constraint in lockstep with `.fvmrc` on any Flutter upgrade.**

## Verification

- `make pub-verify` → **exit 0** (and **fails** on the old lock: *"Would change 9 dependencies"*)
- `make test` → **379/379 pass** (incl. pigeon + build_runner codegen)
- `fvm flutter analyze --no-fatal-warnings --no-fatal-infos` → **exit 0**
- `pub get` is now **idempotent** — it no longer mutates the lock
- Lock diff contains **only** the 8 corrected packages + the `sdks:` header; independently reproduced byte-for-byte by a clean `pub get` on 3.35.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)