### PR TITLE
fix(appium): fail fast on blocking system alerts + capture hook-failure artifacts

### DIFF
--- a/.agents/skills/dep-validate/SKILL.md
+++ b/.agents/skills/dep-validate/SKILL.md
@@ -21,7 +21,7 @@ node automation/dep-validate/queue.mjs
 
 Prints JSON: `queue` (open Dependabot PRs needing validation) and `advisories` (unscanned ecosystems). Each PR entry carries `reasons`, `majors`, `highRiskPackages`, and `surfaces` (e.g. `payment`, `platform-bridge`, `protection`, `messaging`, `build-system`) precomputed from the bump. Validate one PR per run; take the PR number as input for headless runs.
 
-A queue entry means: the auto-merge workflow would hand it to a human (major bump, non-allowlist file, or github-actions), or it carries a high-risk package (Adapty, Firebase, WireGuard, pigeon, gradle/AGP) at any bump level. Advisories are version-drift notes only — there is no PR to check out, so you surface them, you do not run the loop on them.
+A queue entry means: the auto-merge workflow would hand it to a human (major bump or non-allowlist file), or it carries a high-risk package (Adapty, Firebase, WireGuard, pigeon, gradle/AGP) at any bump level. Advisories are version-drift notes only — there is no PR to check out, so you surface them, you do not run the loop on them.
 
 ## 2. The validation loop
 

--- a/automation/appium/wdio/scripts/tests/blocking-alert-patterns.test.mjs
+++ b/automation/appium/wdio/scripts/tests/blocking-alert-patterns.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// alerts.ts is TypeScript and imports @wdio/globals (needs a live session), so
+// it cannot be imported here. Instead the patterns are read out of the source,
+// which keeps this test honest: it asserts against the committed regexes rather
+// than a copy that can silently drift.
+const alertsSource = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "src",
+  "flows",
+  "alerts.ts"
+);
+
+function loadBlockingPatterns() {
+  const source = readFileSync(alertsSource, "utf8");
+  const block = source.match(/const blockingSystemAlertPatterns = \[([\s\S]*?)\];/);
+  assert.ok(block, "blockingSystemAlertPatterns array not found in alerts.ts");
+  const patterns = [...block[1].matchAll(/\/(.+?)\/([gimsuy]*)/g)].map(
+    (match) => new RegExp(match[1], match[2])
+  );
+  assert.ok(patterns.length > 0, "no regex literals parsed out of the array");
+  return patterns;
+}
+
+const blocks = (text) => loadBlockingPatterns().some((pattern) => pattern.test(text));
+
+// Device-level modals: only a human at the device can clear them, and they
+// swallow every tap while the app stays visible in the accessibility tree.
+test("blocking patterns catch device modals that need a human", () => {
+  // Verbatim from the four consecutive red appium-smoke runs on 2026-07-20,
+  // where this alert made all 11 specs fail on an unrelated selector.
+  assert.equal(
+    blocks(
+      "Apple Account Sign In Requested\n" +
+        "Your Apple Account is being used to sign in on the web."
+    ),
+    true
+  );
+  assert.equal(blocks("Apple ID Sign In Requested"), true);
+  assert.equal(blocks("Software Update Available"), true);
+  assert.equal(blocks("Trust This Computer?"), true);
+  assert.equal(blocks("iPhone Storage is Almost Full"), true);
+});
+
+// The expensive failure mode: tripping on an alert a spec legitimately raises
+// would fail a run that should pass. Guard the known flow alerts explicitly —
+// especially Apple-ID sign-in, which the StoreKit sandbox purchase sheet shows
+// mid-flow (dep-validate Stage D drives purchase/restore).
+test("blocking patterns ignore alerts that flows legitimately raise", () => {
+  assert.equal(blocks('"Blokada" Would Like to Add VPN Configurations'), false);
+  assert.equal(blocks('"Blokada" would like to add DNS configurations'), false);
+  assert.equal(blocks('"Blokada" Would Like to Send You Notifications'), false);
+  assert.equal(blocks("Sign In to iTunes Store"), false);
+  assert.equal(blocks("Enter the password for your Apple ID"), false);
+  assert.equal(blocks("Apple Account"), false);
+  assert.equal(blocks("Confirm Your In-App Purchase"), false);
+});

--- a/automation/appium/wdio/src/flows/alerts.ts
+++ b/automation/appium/wdio/src/flows/alerts.ts
@@ -21,6 +21,52 @@ const notificationButtonSelectors = [
   "-ios class chain:**/XCUIElementTypeButton[`label CONTAINS[c] 'Tillåt'`]"
 ];
 
+// Device-level modals that can never be part of a legitimate smoke flow. They
+// are SpringBoard alerts, so they swallow every tap while the Flutter view
+// stays in the accessibility tree underneath: elements are still *found* and
+// *clicked* successfully, the taps just never reach the app. The suite then
+// fails on whatever selector the blocked navigation was waiting for, which
+// points at the app instead of the device.
+//
+// This is not hypothetical: an "Apple Account Sign In Requested" 2FA prompt sat
+// on the CI iPhone for four consecutive runs, and all 11 specs failed with
+// `element ("~automation.screen_settings") still not existing after 15000ms`.
+// Fail fast with the alert text instead.
+//
+// Deliberately narrow, and biased that way on purpose: a missed pattern just
+// falls back to today's behavior (a selector timeout), whereas a false positive
+// fails a run that would have passed. So match only alerts that unambiguously
+// need a human at the device, and never anything a flow can raise.
+//
+// In particular this must NOT match on "Apple ID"/"Apple Account" alone: the
+// StoreKit sandbox purchase sheet legitimately prompts for Apple ID sign-in
+// mid-flow (dep-validate Stage D drives purchase/restore). Only the 2FA
+// approval phrasing — "<Apple Account|Apple ID> Sign In Requested" — is matched.
+const blockingSystemAlertPatterns = [
+  /sign[- ]in requested/i,
+  /software update/i,
+  /storage is (almost )?full/i,
+  /trust this computer/i
+];
+
+export class BlockingSystemAlertError extends Error {
+  constructor(public readonly alertText: string) {
+    super(
+      `Unexpected system alert is blocking the device: "${alertText}". ` +
+        "It swallows every tap, so the app cannot be driven. Dismiss it on " +
+        "the device and re-run."
+    );
+    this.name = "BlockingSystemAlertError";
+  }
+}
+
+/** Throws when `text` is a device-level modal only a human at the device can clear. */
+function assertNotBlockingSystemAlert(text: string): void {
+  if (blockingSystemAlertPatterns.some((pattern) => pattern.test(text))) {
+    throw new BlockingSystemAlertError(text);
+  }
+}
+
 function looksLikeNotification(text: string | undefined): boolean {
   if (!text) {
     return false;
@@ -56,7 +102,10 @@ export async function acceptNotificationAlert(timeout = 8000): Promise<void> {
     }
 
     if (alertText && !looksLikeNotification(alertText)) {
-      // A non-notification alert is up; leave it for the caller to handle.
+      // A device-level modal blocks the whole suite — fail now, with the text.
+      assertNotBlockingSystemAlert(alertText);
+      // Any other non-notification alert is a flow alert (VPN/DNS profile,
+      // StoreKit); leave it for the caller to handle.
       return;
     }
 

--- a/automation/appium/wdio/wdio.conf.ts
+++ b/automation/appium/wdio/wdio.conf.ts
@@ -6,6 +6,7 @@ import type { Options } from "@wdio/types";
 import { buildCapabilities } from "./scripts/lib/capabilities.mjs";
 import { getAppiumServerConfig } from "./scripts/lib/paths.mjs";
 import { resetAccountState } from "./src/support/account-state.js";
+import { savePageSource, saveScreenshot } from "./src/support/artifacts.js";
 
 const logLevel =
   (process.env.WDIO_LOG_LEVEL as Options.WebDriverLogTypes | undefined) ?? "info";
@@ -103,6 +104,33 @@ const rawConfig = {
       console.warn(
         `Pre-session device wake failed (continuing; WDA will activate): ${String(error)}`
       );
+    }
+  },
+  // Capture a screenshot + page source when a HOOK fails. Specs screenshot
+  // their own failures, but a `before all` failure aborts the spec before any
+  // test body runs, so it previously produced NO visual evidence at all — the
+  // CI job even reported "No files were found with the provided path:
+  // output/*.png". The Apple-Account 2FA modal that blocked the device for four
+  // runs had to be reconstructed from Appium server logs for want of one frame.
+  // Best-effort: an artifact failure must never mask the hook's real error.
+  afterHook: async function (
+    test: { title?: string; parent?: string },
+    _context: unknown,
+    result: { error?: unknown }
+  ) {
+    if (!result?.error) return;
+    const slug =
+      `${test?.parent ?? ""}-${test?.title ?? "hook"}`
+        .replace(/[^a-z0-9]+/gi, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, 80)
+        .toLowerCase() || "hook";
+    try {
+      const shot = await saveScreenshot(`hook-failure-${slug}.png`);
+      const source = await savePageSource(`hook-failure-${slug}.xml`);
+      console.warn(`Hook failed; captured ${shot} and ${source}`);
+    } catch (error) {
+      console.warn(`Hook-failure artifact capture failed: ${String(error)}`);
     }
   },
   // Sleep the device screen when each spec finishes so the CI iPhone is not

--- a/automation/dep-validate/lib/queue.mjs
+++ b/automation/dep-validate/lib/queue.mjs
@@ -107,17 +107,14 @@ function highRiskHits(bumps) {
 }
 
 // Classifies one open Dependabot PR. Returns null when the PR would auto-merge
-// (no major, only allowlisted files, not github-actions, no high-risk package) —
-// i.e. nothing for the human/agent to validate.
+// (no major, only allowlisted files, no high-risk package) — i.e. nothing for
+// the human/agent to validate.
 function classifyPr(pr, detail) {
   const bumps = extractBumps(detail.title ?? "", detail.body ?? "");
   const majors = bumps.filter((b) => b.major);
   const risk = highRiskHits(bumps);
   const files = (detail.files ?? []).map((f) => f.path);
   const offlist = files.filter((f) => !ALLOWED_FILES_REGEX.test(f));
-  const isGithubActions = pr.headRefName.startsWith(
-    "dependabot/github_actions/"
-  );
 
   const reasons = [];
   if (majors.length) {
@@ -135,9 +132,13 @@ function classifyPr(pr, detail) {
   if (offlist.length) {
     reasons.push(`touches non-dependency file(s): ${offlist.join(", ")}`);
   }
-  if (isGithubActions) {
-    reasons.push("github-actions ecosystem bump (supply-chain risk)");
-  }
+  // No github-actions carve-out: dependabot-auto-merge.yml dropped its
+  // "human review required (supply-chain risk)" branch-prefix case in #1115,
+  // so action bumps flow through the same path as every other ecosystem and
+  // the major-bump gate above is the one real guard. Dependabot only bumps an
+  // action already in the repo, so a bump cannot introduce a new publisher.
+  // Re-adding a reason here would queue every patch/minor action bump that the
+  // workflow auto-merges anyway.
 
   if (!reasons.length) return null;
 


### PR DESCRIPTION
Two independent automation fixes, one commit each — splittable if you would rather land them separately.

## 1. Appium: diagnose blocked-device runs (`4680804`)

An **"Apple Account Sign In Requested"** 2FA modal sat on the CI iPhone for four consecutive `appium-smoke` runs (2026-07-20, runs `29714640386` → `29720164508`). It is a SpringBoard alert, so it swallows every tap while the Flutter view stays in the accessibility tree — the gear was *found* and *clicked* successfully, the taps just never reached the app. All 11 specs then failed in `before all` on an unrelated selector:

```
element ("~automation.screen_settings") still not existing after 15000ms
  at openSettingsScreen (src/flows/account.ts:64)
```

Confirmed present 20–22× in every red run and **absent from the last green run**.

- **Fail fast.** `acceptNotificationAlert` already detected the alert and had its text, but returned silently to "leave it for the caller to handle" — and no caller anywhere does. It now throws `BlockingSystemAlertError` with the text for device-level modals, and still returns silently for flow alerts.
- **Narrow on purpose.** A missed pattern falls back to today’s timeout; a false positive fails a run that would have passed. It must **not** match `Apple ID`/`Apple Account` alone — the StoreKit sandbox purchase sheet prompts for Apple ID sign-in mid-flow (dep-validate Stage D drives purchase/restore) — so only the 2FA phrasing matches.
- **Artifacts on hook failure.** This needed server-log forensics because the run produced no visual evidence: spec screenshots are per-test, and a `before all` failure aborts before any test body runs (the job reported *"No files were found with the provided path: output/*.png"*). `afterHook` now captures a screenshot + page source, best-effort so it cannot mask the hook’s real error. Both globs are already uploaded by the workflow.

## 2. dep-validate: drop the retired github-actions carve-out (`426dfd4`)

`dependabot-auto-merge.yml` removed its github-actions branch-prefix case in #1115, but `queue.mjs` / `SKILL.md` still ported the old rule — so every action bump was queued as needing human validation at any bump level, while the workflow auto-merged the non-major ones.

## Verification

- `tsc --noEmit` diffed against a stashed baseline: **zero new errors** (the 5 reported pre-exist).
- `npm run test:unit`: **93/93** (was 91).
- New test parses the regexes out of `alerts.ts` rather than copying them, so it cannot drift. Confirmed it **goes red** when the over-broad `/apple id/i` pattern is reintroduced.
- Queue: #1177/#1179 still queue via major + high-risk; a non-major action bump now yields zero reasons.

**Not verified on-device.** `afterHook` firing and the error surfacing through the reporter are only provable on a real run. Smoke dispatched against this branch to check exactly that — the device still has the modal, so the expected result is a **fast, clearly-labelled failure with a screenshot**, not a green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)