### PR TITLE
fix(android): target Android 16 (API 36), migrate back handling

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,7 +45,7 @@ android {
     defaultConfig {
         applicationId "org.blokada" // Not a real name, see flavors below
         minSdkVersion 28
-        targetSdkVersion 35
+        targetSdkVersion 36
         versionCode 1
         versionName "dev"
 

--- a/android/app/src/main/java/ui/MainActivity.kt
+++ b/android/app/src/main/java/ui/MainActivity.kt
@@ -21,6 +21,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View
 import android.view.WindowManager
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.lifecycleScope
@@ -83,6 +84,18 @@ class MainActivity : AppCompatActivity() {
         supportFragmentManager.beginTransaction()
             .replace(R.id.container_fragment, FlutterHomeFragment())
             .commit()
+
+        // Always-enabled callback: back is fully resolved by the Flutter side,
+        // never by the system (required since targetSdk 36 no longer delivers
+        // back events to the deprecated onBackPressed override).
+        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
+            override fun handleOnBackPressed() {
+                if (stage.goBack()) return
+                lifecycleScope.launch {
+                    commands.execute(CommandName.BACK)
+                }
+            }
+        })
     }
 
     private var splashFallbackRunnable: Runnable? = null
@@ -172,16 +185,6 @@ class MainActivity : AppCompatActivity() {
         }
         context.unsetActivityContext()
         super.onDestroy()
-    }
-
-    @Deprecated("This method has been deprecated in favor of using the\n      {@link OnBackPressedDispatcher} via {@link #getOnBackPressedDispatcher()}.\n      The OnBackPressedDispatcher controls how back button events are dispatched\n      to one or more {@link OnBackPressedCallback} objects.")
-    override fun onBackPressed() {
-        if (stage.goBack()) return
-        lifecycleScope.launch {
-            commands.execute(CommandName.BACK)
-        }
-        return
-        super.onBackPressed()
     }
 
     @Deprecated("This method has been deprecated in favor of using the Activity Result API\n      which brings increased type safety via an {@link ActivityResultContract} and the prebuilt\n      contracts for common intents available in\n      {@link androidx.activity.result.contract.ActivityResultContracts}, provides hooks for\n      testing, and allow receiving results in separate, testable classes independent from your\n      activity. Use\n      {@link #registerForActivityResult(ActivityResultContract, ActivityResultCallback)}\n      with the appropriate {@link ActivityResultContract} and handling the result in the\n      {@link ActivityResultCallback#onActivityResult(Object) callback}.")


### PR DESCRIPTION
## Why

Google Play requires apps to target Android 16 (API level 36) or higher.

## What

- `targetSdkVersion` 35 → 36 (`compileSdk` is already 37, no toolchain change).
- Migrated `MainActivity` back handling from the deprecated `onBackPressed()` override to an always-enabled `OnBackPressedCallback` on the `OnBackPressedDispatcher`, with identical logic (`stage.goBack()`, else `CommandName.BACK` to Flutter). This is required, not cosmetic: at target 36, `enableOnBackInvokedCallback` defaults to true and the system stops calling `onBackPressed()` overrides — without the migration, back would background the app instead of navigating. The dispatcher path behaves the same on all API levels down to minSdk 28.

## Other target-36 gated changes, checked

- **16 KB pages**: all 64-bit `.so` files in `deps/wireguard-android.aar` (arm64-v8a, x86_64) have 16 KB ELF LOAD alignment; the 4 KB-aligned 32-bit libs never load on 16 KB-page devices. Flutter engine libs are aligned upstream. No compat dialog expected.
- **Edge-to-edge**: the removed opt-out attribute was never used; the app already draws edge-to-edge.
- **Large screens (follow-up decision)**: Android 16 ignores `android:screenOrientation="portrait"` on ≥600dp screens for target-36 apps, so tablets/foldables will rotate and resize freely. Left as-is given the adaptive layout work; the temporary opt-out (`PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY`, removed in API 37) is available if we want to defer.

## Verification

- `apk-six-debug` assembles green on current main; `compileFamilyDebugKotlin` passes (the callback uses the base `androidx.activity` class, available to both flavors — `activity-ktx` is six-only).
- Merged manifest of the built APK reads `targetSdkVersion="36"`.
- Before release: manual back-navigation smoke on a device (nested screens, sheets, back at root), ideally on an API 36 device/emulator where the new default actually applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)