### PR TITLE
test(appium): stabilize Activity Show All tap (settle, coordinate tap, retry)

### DIFF
--- a/automation/appium/wdio/src/specs/smoke/activity.spec.ts
+++ b/automation/appium/wdio/src/specs/smoke/activity.spec.ts
@@ -53,6 +53,29 @@ async function scrollToShowAll(maxSwipes = 10): Promise<boolean> {
   return false;
 }
 
+// Wait until the button's frame is stationary (scroll fully settled), then tap its
+// center via `mobile: tap`. A plain element.click() here can land while the list is
+// still settling; iOS delivers the touch as a scroll-stop, Flutter's onTap never runs,
+// yet WDA reports the click as successful.
+async function tapShowAllSettled(maxProbes = 8): Promise<void> {
+  let prev = await (await $(showAllSelector)).getLocation();
+  for (let i = 0; i < maxProbes; i += 1) {
+    await driver.pause(300);
+    const el = await $(showAllSelector);
+    const loc = await el.getLocation();
+    if (Math.abs(loc.x - prev.x) <= 1 && Math.abs(loc.y - prev.y) <= 1) {
+      const size = await el.getSize();
+      await driver.execute("mobile: tap", {
+        x: Math.round(loc.x + size.width / 2),
+        y: Math.round(loc.y + size.height / 2)
+      });
+      return;
+    }
+    prev = loc;
+  }
+  throw new Error("Recent Activity 'Show All' did not stop moving; cannot tap reliably.");
+}
+
 // Reach the full Activity list via Privacy Pulse -> "Show All" — a route only made
 // reachable-by-test after the V6 nav cleanup — and confirm it renders (top-bar title
 // + screen body, catching route/blank/crash regressions). The search action is gated
@@ -77,7 +100,19 @@ describe("Smoke: Activity screen", () => {
         "Recent Activity 'Show All' did not appear after scrolling the Privacy Pulse list."
       );
     }
-    await (await $(showAllSelector)).click();
+    await tapShowAllSettled();
+
+    // Even a settled coordinate tap can be dropped; re-tap once if the screen has
+    // not appeared — but only if Show All is still on screen (its absence means
+    // navigation is already in flight, just slow).
+    const opened = await (await $(`~${AutomationIds.screenActivity}`))
+      .waitForExist({ timeout: 5000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!opened && (await exists(showAllSelector))) {
+      console.warn("Show All tap produced no navigation within 5s; re-tapping once.");
+      await tapShowAllSettled();
+    }
 
     // The Activity screen body + top-bar title must render.
     await waitForScreen(AutomationIds.screenActivity);


### PR DESCRIPTION
## Problem

Since 2026-07-25 the smoke suite failed ~60% of runs (6 of 10) on a single spec with an identical signature: `Smoke: Activity screen` → `element ("~automation.screen_activity") still not existing after 15000ms`. All other 10 specs stayed green.

## Root cause (harness-side, not an app bug)

Evidence from failed-run artifacts + the CI phone's app log:

- Page source at failure: the `Show All` button visible, enabled, well-positioned (position guard passed).
- Appium server log: the `element.click()` was ACKed by WDA (HTTP 200, 450 ms).
- Failure screenshot 15 s later: app still on Privacy Pulse, unchanged.
- Device app log for the failure window: a positive control (the hub tap's `onNavigated` block) fires a minute earlier, then **zero UI events** for the entire scroll → click → 15 s wait window — no `onNavigated`, no `setRoute`, no exceptions. `Navigation.open()` logs unconditionally, so the silence proves the `onTap` closure never executed.

Conclusion: the tap is dispatched while the just-scrolled list is still settling; iOS delivers the touch as a scroll-stop and Flutter's gesture arena never fires `onTap`, while WDA still reports the click as successful. (Same mechanism the repo's appium skill documents as the `element.click()` / `tapCenter` gotcha.)

## Fix

In `activity.spec.ts`:

- `tapShowAllSettled()`: poll the button's position until stationary (≤1 px across 300 ms probes, max 8), then tap its center via `mobile: tap` (a real touch dispatch) instead of `element.click()`.
- One retry if `screen_activity` hasn't appeared after 5 s, guarded by `Show All` still being on screen (its absence means navigation is already in flight).
- The final `waitForScreen` assertion is unchanged, so the spec still catches genuine route/blank/crash regressions.

## Validation

3 consecutive `workflow_dispatch` runs of the smoke suite on this branch, all green (11/11 specs): 30255142738, 30256735477, 30258256750. Activity spec passed in ~1m04s each time and the retry warning never fired — the settled tap alone eliminates the swallow (~94% confidence at the 60% base failure rate). `tsc --noEmit` clean for the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)