### PR TITLE
feat(release): publish Android to closed and open testing too

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -281,6 +281,9 @@ jobs:
       LANG: en_US.UTF-8
       LC_ALL: en_US.UTF-8
       FLAVOR: ${{ needs.release_context.outputs.flavor }}
+      # Needed to attach the uploaded build to the closed/open tracks. This is
+      # the same value build_android baked into the AAB via `make version`.
+      BLOKADA_VERSION_CODE: ${{ needs.release_context.outputs.version_code }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -171,9 +171,26 @@ version-clean:
 	git restore $(IOS_PROJECT_FILE)
 
 
-# Publish android app to Google Play internal channel (use FLAVOR param)
+# Tracks that receive the same build after the internal upload. "alpha" is
+# closed testing and "beta" is open testing -- Play's default track ids, which
+# we never renamed. Unlike internal, both require review, and the promote runs
+# below are what submit them.
+GPLAY_PROMOTE_TRACKS ?= alpha beta
+
+# Publish android app to Google Play (use FLAVOR param).
+#
+# Uploads the AAB to internal once, then attaches that same version code to
+# each promote track. A version code can only be *uploaded* once, so the extra
+# tracks must reference it rather than re-upload -- hence --track_promote_to
+# with --skip_upload_aab. Despite the name, promoting does not remove the build
+# from the source track (supply/lib/supply/uploader.rb#promote_track only
+# writes the target track), so the build ends up on internal, alpha and beta.
 publish-android:
 	$(MAKE) gplay-key-unpack
+	@if [ -z "$(BLOKADA_VERSION_CODE)" ]; then \
+	    echo "Error: BLOKADA_VERSION_CODE is not set. It is required to promote the build to: $(GPLAY_PROMOTE_TRACKS)"; \
+	    exit 1; \
+	fi
 	@AAB=$(if $(filter family,$(FLAVOR)),familyRelease/app-family-release.aab,sixRelease/app-six-release.aab); \
 	PKG=$(if $(filter family,$(FLAVOR)),org.blokada.family,org.blokada.sex); \
 	$(FASTLANE) supply --aab android/app/build/outputs/bundle/$$AAB \
@@ -181,6 +198,23 @@ publish-android:
 	--json_key blokada-gplay.json \
 	--metadata_path metadata/android-$(FLAVOR) \
 	--track internal
+	@PKG=$(if $(filter family,$(FLAVOR)),org.blokada.family,org.blokada.sex); \
+	for track in $(GPLAY_PROMOTE_TRACKS); do \
+	    echo "==> Promoting version code $(BLOKADA_VERSION_CODE) to '$$track' and submitting for review"; \
+	    $(FASTLANE) supply \
+	        --package_name "$$PKG" \
+	        --json_key blokada-gplay.json \
+	        --track internal \
+	        --track_promote_to $$track \
+	        --version_code $(BLOKADA_VERSION_CODE) \
+	        --skip_upload_aab true \
+	        --skip_upload_apk true \
+	        --skip_upload_metadata true \
+	        --skip_upload_changelogs true \
+	        --skip_upload_images true \
+	        --skip_upload_screenshots true \
+	        --rescue_changes_not_sent_for_review false || exit 1; \
+	done
 	$(MAKE) gplay-key-clean
 
 # Unpack Google Play api key for publishing (use env var)


### PR DESCRIPTION
Part of the release-automation work in blokadaorg/issue-tracker#324.

Releases currently only reach the **internal** track. Closed (`alpha`) and open (`beta`) testing are promoted by hand — and because both require review unlike internal, that manual step is also the review submission.

## What changes

`make publish-android` uploads the AAB to internal exactly as before, then attaches that same version code to `alpha` and `beta`, submitting each for review.

```
GPLAY_PROMOTE_TRACKS ?= alpha beta
```

`publish_android` in `release-tag.yml` now passes `BLOKADA_VERSION_CODE` — the same value `build_android` baked into the AAB via `make version` (`build.gradle` otherwise hardcodes `versionCode 1`).

## Three non-obvious things, all verified against the installed fastlane 2.232.0

**1. You can't just run supply three times with `--aab`.** A version code can only be *uploaded* once; runs 2 and 3 would fail. The extra tracks must reference the existing code — `--track_promote_to` with `--skip_upload_aab`.

**2. Promoting does not move the build off the source track.** The name suggests otherwise, and the Play Console UI presents it as a move, but `promote_track` in `supply/lib/supply/uploader.rb` reads the release from the source track and then calls only `client.update_track(track_promote_to, ...)`. The source is never written back. So chaining it twice lands one build on internal + alpha + beta, which is the goal. Release notes come along, since the whole release object is copied.

**3. `--rescue_changes_not_sent_for_review false` is the important flag here.** Two options with defaults pulling opposite ways (`supply/lib/supply/options.rb:299-308`):

- `changes_not_sent_for_review` → `false` (good — submit for review)
- `rescue_changes_not_sent_for_review` → **`true`**

With that second default, when Google replies `Please set the query parameter changesNotSentForReview to true`, fastlane catches it, **silently re-commits with `true`**, and exits 0 (`client.rb:197-222`). Green CI, build on the track, *not submitted for review*, needing a manual click. For a step that exists to submit for review, that has to fail loudly instead.

## Why the promote runs skip all metadata

`--skip_upload_metadata/changelogs/images/screenshots true`. Beyond store-listing changes being app-level review items that shouldn't be re-sent per track, there's a trap: `metadata_path` defaults to ``(Dir["./fastlane/metadata/android"] + Dir["./metadata"]).first``. This repo **has** `./metadata`, whose children are `android-six`, `ios-family`, … so simply omitting the flag would make supply treat those directory names as locale codes. All four skips make the guard short-circuit regardless.

## Testing

- `make -n publish-android` for both flavors — correct expansion, package names and metadata paths resolve per flavor
- Missing `BLOKADA_VERSION_CODE` fails before any fastlane call
- Workflow YAML parses; `publish_android.env` carries the new variable and `release_context` exports `version_code`

Not exercised against the live Play API — the service account key only exists as a CI secret, so the first real tag is the actual test.

## Worth a look before merging

Submitting to closed and open at the same time means a rejection hits both together. That interacts with the release strategy in the last checkbox of #324 (family first, then v6 staged), so if you'd rather stage them, `GPLAY_PROMOTE_TRACKS` is overridable per invocation.

Separately: the **internal** upload still runs with the rescue at its default, so if Google ever refuses to auto-submit the *store listing* changes in that edit, it will silently not be submitted. Pre-existing, left alone here because making it strict could turn currently-green releases red — but it's the same class of bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)