### PR TITLE
feat(release): rename the promote workflow and control iOS phased release

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Promote to Stores
 
 # Promotes a build that ci-release.yml already uploaded. Never builds, so the
 # binary that ships is the exact one that has been sitting on internal.

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -30,6 +30,11 @@ on:
         required: false
         default: false
         type: boolean
+      ios_phased_release:
+        description: "Ramp the iOS update over 7 days (automatic updates only)"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write # pushes the record tag
@@ -83,6 +88,7 @@ jobs:
           FLAVOR_INPUT: ${{ inputs.flavor }}
           PLATFORM_INPUT: ${{ inputs.platform }}
           SUBMIT_IOS_FOR_REVIEW_INPUT: ${{ inputs.submit_ios_for_review }}
+          IOS_PHASED_RELEASE_INPUT: ${{ inputs.ios_phased_release }}
         run: |
           {
             echo "### Release"
@@ -90,6 +96,7 @@ jobs:
             echo "- version: \`${{ steps.r.outputs.version_name }}\`"
             echo "- flavor: \`$FLAVOR_INPUT\` · platform: \`$PLATFORM_INPUT\`"
             echo "- submit iOS for review: \`$SUBMIT_IOS_FOR_REVIEW_INPUT\`"
+            echo "- iOS phased release: \`$IOS_PHASED_RELEASE_INPUT\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   promote_android:
@@ -140,6 +147,7 @@ jobs:
       BLOKADA_VERSION_CODE: ${{ needs.resolve.outputs.build_number }}
       BLOKADA_VERSION_NAME: ${{ needs.resolve.outputs.version_name }}
       SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
+      PHASED_RELEASE: ${{ inputs.ios_phased_release }}
     steps:
       - uses: actions/checkout@v7
         with:

--- a/Makefile
+++ b/Makefile
@@ -276,8 +276,13 @@ gplay-key-clean:
 	rm -rf blokada-gplay.json
 
 # Attach an already-uploaded build to an App Store version (use FLAVOR,
-# BLOKADA_VERSION_CODE as the raw build number, BLOKADA_VERSION_NAME, and
-# SUBMIT_FOR_REVIEW=true|false). Never builds or uploads a binary.
+# BLOKADA_VERSION_CODE as the raw build number, BLOKADA_VERSION_NAME,
+# SUBMIT_FOR_REVIEW=true|false and PHASED_RELEASE=true|false). Never builds or
+# uploads a binary.
+#
+# The two flags default opposite ways on purpose, so an unset variable is the
+# safe answer for each: submitting for review needs an explicit "true", while
+# the phased 7-day rollout needs an explicit "false" to turn off.
 promote-ios:
 	$(MAKE) appstore-key-unpack
 	@if [ -z "$(BLOKADA_VERSION_CODE)" ] || [ -z "$(BLOKADA_VERSION_NAME)" ]; then \
@@ -289,7 +294,8 @@ promote-ios:
 	cd ios/ && $(FASTLANE) $$LANE \
 	    build_number:$$STORE_CODE \
 	    version_name:$(BLOKADA_VERSION_NAME) \
-	    submit_for_review:$(if $(filter true,$(SUBMIT_FOR_REVIEW)),true,false)
+	    submit_for_review:$(if $(filter true,$(SUBMIT_FOR_REVIEW)),true,false) \
+	    phased_release:$(if $(filter false,$(PHASED_RELEASE)),false,true)
 	$(MAKE) appstore-key-clean
 
 # Upload an already-built IPA to TestFlight (use FLAVOR param). Continuous

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -111,7 +111,7 @@ Properties that matter:
   succeeded, re-run *all* jobs.
 - **Atomic** — the tag push either wins or fails, so it doubles as the lock.
 - **Auditable** — `build/1042` points at the exact commit that produced it, and
-  `release.yml` puts the human-facing `26.7.1042` tag on that same commit
+  `promote.yml` puts the human-facing `26.7.1042` tag on that same commit
   rather than on whatever `main` happens to be at release time.
 
 Failed runs leave an orphan `build/N` with no matching release tag. That is
@@ -149,7 +149,7 @@ concurrency:
 Cancelling mid-flight would strand a consumed build number and a half-finished
 upload, so runs queue instead.
 
-The group is **shared with `release.yml`**, deliberately. Both workflows write
+The group is **shared with `promote.yml`**, deliberately. Both workflows write
 the same Play packages, and Play invalidates an open edit whose underlying app
 state changed, so a merge landing mid-release would break one side or the other
 with a confusing error. The consequence to accept: a merge to `main` that lands
@@ -217,7 +217,7 @@ forever after. If tags are ever pruned anyway, the `--start` floor in
 `ci-release.yml` must be raised above the highest build number ever published,
 in the same commit.
 
-## Workflow B — `release.yml`
+## Workflow B — `promote.yml`
 
 Trigger: `workflow_dispatch` only.
 
@@ -256,7 +256,7 @@ in Play Console (confirmed 2026-07-28).
 
 ### Reaching production
 
-**The pipeline never touches production on either store.** `release.yml` ends
+**The pipeline never touches production on either store.** `promote.yml` ends
 with:
 
 - Play: a release on `alpha` and `beta`, submitted for review.
@@ -440,7 +440,7 @@ and allocated `build/1000`, annotated `26.7.1000`, with all four artifacts
 branch trigger was then removed in `958d8f98`, and `ci-release.yml` fires on
 `main` only.
 
-`release.yml` could not be dispatched before merge — `workflow_dispatch`
+`promote.yml` could not be dispatched before merge — `workflow_dispatch`
 requires the workflow file on the default branch. It is inert on `main` (it
 cannot fire by itself), so it lands unexercised by design; its first real run
 is the first release.
@@ -455,7 +455,7 @@ numbers were consumed (they are free).
 | 1 | Restructure the Play work: move promote out of `publish-android` into `promote-android` | Already written; wrong location under the new design |
 | 2 | Versioning: allocator + `YY.M.BUILD` | Foundational and irreversible — codes only ever go up |
 | 3 | `ci-release.yml` | Proves the upload path continuously |
-| 4 | `release.yml`, submit off by default | Safest last; needs real builds from step 3 to promote |
+| 4 | `promote.yml`, submit off by default | Safest last; needs real builds from step 3 to promote |
 
 ## Failure semantics
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -227,9 +227,29 @@ Trigger: `workflow_dispatch` only.
 | `flavor` | `all` | `all`, `six`, `family` |
 | `platform` | `all` | `all`, `ios`, `android` |
 | `submit_ios_for_review` | **false** | Whether to submit the App Store version |
+| `ios_phased_release` | **true** | Ramp the iOS update over 7 days |
 
 Defaults give the standard sequence with no input at all. The flavor/platform
 narrowing is the manual-override path.
+
+The two iOS flags default opposite ways so that an unset value is the cautious
+answer for each: submitting for review takes an explicit opt-in, while the
+phased ramp takes an explicit opt-out.
+
+### iOS phased release
+
+`deliver` only touches the setting when the option is non-nil
+(`deliver/upload_metadata.rb:314`), so passing nothing leaves whatever App Store
+Connect happens to have on that version. This workflow always passes a real
+boolean instead, so the input decides rather than a per-version setting somebody
+clicked months ago. The consequence worth knowing: `false` does not mean "leave
+alone", it **deletes** an existing phased release.
+
+The ramp governs **automatic updates for existing users only** — anyone who
+updates by hand or installs fresh gets the build immediately regardless. It runs
+7 days, and it can be paused or pushed to everyone from App Store Connect once
+the release is out, so this input sets the starting position rather than an
+irreversible choice.
 
 **`latest` resolves the newest *tag*, not the newest successful build.** The
 number is allocated before anything is built, so if that `ci-release` run

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -111,6 +111,15 @@ platform :ios do
   # automatic_release: false leaves an approved build in Pending Developer
   # Release. Publishing is always a manual click.
   #
+  # phased_release is passed as a real boolean on every run, never left nil.
+  # deliver only touches the setting when the option is non-nil
+  # (deliver/upload_metadata.rb:314), so nil means "leave whatever App Store
+  # Connect has" -- true creates the 7-day ramp, and false DELETES an existing
+  # one. Being explicit means the workflow input decides, rather than a stale
+  # per-version setting somebody clicked months ago. Note the ramp only governs
+  # automatic updates for existing users; manual updates and fresh installs get
+  # the build immediately either way.
+  #
   # Export compliance needs no entry here: ITSAppUsesNonExemptEncryption is
   # already <false/> in Info-six.plist and Info-family.plist, so App Store
   # Connect never asks.
@@ -132,6 +141,7 @@ platform :ios do
       run_precheck_before_submit: false, # not supported through ASC API yet
       submit_for_review: submit,
       automatic_release: false,
+      phased_release: options[:phased_release].to_s == "true",
       submission_information: {
         content_rights_contains_third_party_content: false
       }
@@ -166,6 +176,7 @@ platform :ios do
       run_precheck_before_submit: false,
       submit_for_review: submit,
       automatic_release: false,
+      phased_release: options[:phased_release].to_s == "true",
       submission_information: {
         content_rights_contains_third_party_content: false
       }


### PR DESCRIPTION
Two follow-ups to #1196, raised after watching the pipeline run for real.

## 1. `Release` → `Promote to Stores`

`Release` and `CI Release` sat next to each other in the Actions list and read as variants of one thing, when they're opposites — `CI Release` builds every merge and uploads to internal channels, this one never builds and promotes an existing build to alpha/beta and the App Store.

Also renamed the file to `promote.yml`, so `gh workflow run promote.yml` says what it does. Free to do now: nothing depends on the filename, because the build counter lives in `build/N` tags rather than `GITHUB_RUN_NUMBER`. Git tracked it as a rename (99% similarity), so history is preserved.

## 2. iOS phased release is now an input

Observed on the first real promote: the App Store version had *"Release update to all users immediately"*. That wasn't a choice this pipeline made — `deliver` only touches the setting when the option is non-nil (`deliver/upload_metadata.rb:314`), and the lanes never passed it, so whatever App Store Connect had on the version won.

New `ios_phased_release` input, **default true**, passed as a real boolean on every run so the dispatch decides rather than a per-version setting someone clicked months ago.

The sharp edge worth knowing: **`false` does not mean "leave alone" — it deletes an existing phased release.** That's precisely why passing it explicitly is better than passing nothing.

The two iOS flags now default opposite ways, so an unset value is the cautious answer for each:

| Input | Default | Rationale |
|---|---|---|
| `submit_ios_for_review` | `false` | Submitting needs an explicit opt-in |
| `ios_phased_release` | `true` | The 7-day ramp needs an explicit opt-out |

Scope of the ramp, documented in the design doc: it governs **automatic updates for existing users only** — manual updaters and fresh installs get the build immediately either way. It runs 7 days and can be paused or pushed to everyone from App Store Connect, so the input sets the starting position rather than an irreversible choice.

## Verification

- `ruby -c ios/fastlane/Fastfile` — Syntax OK
- `promote.yml` asserts: dispatch-only, `name: Promote to Stores`, `ios_phased_release` default `true`, `submit_ios_for_review` default `false`, `PHASED_RELEASE` wired into `promote_ios` env, and no raw `${{ inputs.* }}` in any `run:` body (the injection guard from #1196 still holds)
- `make -n promote-ios` — unset → `phased_release:true`, `PHASED_RELEASE=false` → `phased_release:false`
- `make test-scripts` — 2/2 pass

Behaviour on the continuous path is untouched; this only affects a dispatched promote.

## Context

#1196 is merged and live. The merge triggered `ci-release` on `main`, which ran green across all six jobs and allocated `build/1001` → `26.7.1001`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)