### PR TITLE
fix(ci): stop translations sync failing on locale-only-upstream days

### DIFF
--- a/.github/workflows/translations-sync.yml
+++ b/.github/workflows/translations-sync.yml
@@ -98,13 +98,24 @@ jobs:
 
       - name: Check for changes
         id: changes
+        # The deps/translate gitlink is excluded on purpose: when the new
+        # translate commits only touch locales the app doesn't ship (anything
+        # outside langs.js, e.g. Basque), `make translate` regenerates every
+        # asset byte-identically and the submodule pointer is the only diff.
+        # That is a no-op sync — don't open a PR for it; the pin rides along
+        # with the next run that does carry translation content.
         run: |
           set -euo pipefail
-          if git diff --quiet HEAD && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+          changed=$( { git diff --name-only HEAD; \
+                       git ls-files --others --exclude-standard; } \
+                     | grep -vxF 'deps/translate' | sort -u || true )
+          if [ -z "$changed" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No new translations — exiting cleanly."
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Changed:"
+            printf '%s\n' "$changed"
           fi
 
       - name: Gate
@@ -160,9 +171,14 @@ jobs:
           set -euo pipefail
           today=$(date -u +%Y-%m-%d)
           sha=$(git -C deps/translate rev-parse --short HEAD)
+          # sed, not grep: a `grep` that matches nothing exits 1 and, under
+          # `pipefail`, kills the step before the `${locales:-none}` fallback
+          # below can ever be used. It also has to accept the hyphenated and
+          # mixed-case locale filenames (pt-BR.json, zh-Hant.json), which the
+          # old `[a-z0-9_]+` class silently dropped.
           locales=$( { git diff --name-only HEAD -- common/assets/translations; \
                        git ls-files --others --exclude-standard -- common/assets/translations; } \
-                     | grep -oE '/[a-z0-9_]+\.json$' | tr -d '/' | sed 's/\.json$//' | sort -u | tr '\n' ' ')
+                     | sed -n 's|.*/\([^/]*\)\.json$|\1|p' | sort -u | tr '\n' ' ')
           nfiles=$( { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u | wc -l | tr -d ' ')
           {
             echo "Automated translation sync ($today)."

--- a/.github/workflows/translations-sync.yml
+++ b/.github/workflows/translations-sync.yml
@@ -106,9 +106,12 @@ jobs:
         # with the next run that does carry translation content.
         run: |
           set -euo pipefail
+          # Two steps on purpose: the git calls stay under `pipefail` so a real
+          # failure is loud, and the `|| true` covers only grep's "matched
+          # nothing" exit 1 (i.e. the gitlink was the whole diff).
           changed=$( { git diff --name-only HEAD; \
-                       git ls-files --others --exclude-standard; } \
-                     | grep -vxF 'deps/translate' | sort -u || true )
+                       git ls-files --others --exclude-standard; } | sort -u )
+          changed=$(printf '%s\n' "$changed" | grep -vxF 'deps/translate' || true)
           if [ -z "$changed" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No new translations — exiting cleanly."


### PR DESCRIPTION
The daily Translations sync has been red since 2026-08-02 ([run 30735064783](https://github.com/blokadaorg/blokada/actions/runs/30735064783), [run 30788841964](https://github.com/blokadaorg/blokada/actions/runs/30788841964)), both times dying at `Build PR body` with a bare `exit 1` and no output.

## Root cause

Upstream `translate` moved `79dd861f9 → 6d7a224e4`, and the only commit in that range touches `build/v6/eu.lproj/Ui.strings` (Basque). `eu` is not in `deps/translate/langs.js`, so `make translate` regenerated all 21 shipped locales byte-identically — the `deps/translate` gitlink was the only diff in the tree.

That was enough for `Check for changes` to report `has_changes=true`. `Gate` ran under `set +e` so its own empty `grep` was harmless and the verdict stayed at its default `PASS`. Then `Build PR body`, under `set -euo pipefail`, hit:

```sh
locales=$( { git diff --name-only HEAD -- common/assets/translations; ... } \
           | grep -oE '/[a-z0-9_]+\.json$' | ... )
```

Nothing under `common/assets/translations` had changed → `grep` exited 1 → `pipefail` propagated it → `set -e` aborted the step before the first `echo`, which is why the log is empty. Push / Open PR / Merge were skipped.

## Fixes

1. **`grep` → `sed -n ...p`** for the locale list. `sed` exits 0 on no match, so the `${locales:-none}` fallback that was already written for this case can actually be reached.
2. **Match any basename**, not `[a-z0-9_]+`. The old class silently dropped `pt-BR.json` and `zh-Hant.json` — real filenames the pipeline writes — so those locales never appeared in a PR body.
3. **A lone gitlink bump is no longer a change.** When upstream only touches locales the app doesn't ship, the run now exits cleanly instead of opening a PR that moves the pin and nothing else. The pin rides along with the next run that carries actual translation content.

## Verification

The `run:` bodies of both steps were extracted from the workflow and executed under `bash -euo pipefail` against a stubbed `git` (including `--quiet` exit-status semantics), over five scenarios: gitlink-only bump, real content incl. `pt-BR`/`pt_br`/`zh`, empty tree, changes only outside `common/assets/translations`, and a brand-new locale arriving untracked.

Pre-fix, that harness reproduces all three defects (pin-only PR opened; `pt-BR` missing from the body; step exits 1 when no common JSON changed). Post-fix, all 14 assertions pass.

A `git` that fails is still loud: only grep's no-match exit is tolerated, so a broken `git diff` aborts the step instead of reporting "no changes" (verified with a stub `git` that exits 128).

Live end-to-end dispatch of the final commit on this branch: [run 30792873934](https://github.com/blokadaorg/blokada/actions/runs/30792873934) — green, bumps the submodule to `6d7a224e4` and stops at `Check for changes` with "No new translations — exiting cleanly." On `main`, that exact input is the run that fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

