### PR TITLE
feat(release): let a promote run reach the public, gated on store state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,11 @@ jobs:
 
   release_scripts:
     name: Release script tests
-    # Covers the two release-pipeline invariants that are unrecoverable once
-    # broken: monotonic store version codes, and the offset applied exactly
-    # once. bash + git + python3 only, so it runs on ubuntu-latest rather than
-    # taking a slot on the self-hosted pool.
+    # Covers the release-pipeline invariants that are expensive once broken:
+    # monotonic store version codes, the offset applied exactly once, and the
+    # App Store state table that decides whether a promote run may start.
+    # bash + git + python3 + ruby only -- all preinstalled on ubuntu-latest, so
+    # this runs there rather than taking a slot on the self-hosted pool.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     if: >-
@@ -79,7 +80,7 @@ jobs:
           git config --global user.email "ci@blokada.org"
           git config --global user.name "blokada-ci"
 
-      - name: Run build-number and version tests
+      - name: Run build-number, version and release-state tests
         run: make test-scripts
 
   flutter_analyze:

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -30,8 +30,13 @@ on:
         required: false
         default: false
         type: boolean
+      public_release:
+        description: "Release to the public: Family publishes once approved, Android goes to production (Six 1%, Family 100%). Six always waits for a manual release."
+        required: false
+        default: false
+        type: boolean
       ios_phased_release:
-        description: "Ramp the iOS update over 7 days (automatic updates only)"
+        description: "iOS only. Ramp Blokada 6 over 7 days for auto-updating users. Untick for a hotfix that must reach everyone at once. Family always releases to all users. App Store Connect locks this once the build is approved, so it cannot be changed later."
         required: false
         default: true
         type: boolean
@@ -88,6 +93,7 @@ jobs:
           FLAVOR_INPUT: ${{ inputs.flavor }}
           PLATFORM_INPUT: ${{ inputs.platform }}
           SUBMIT_IOS_FOR_REVIEW_INPUT: ${{ inputs.submit_ios_for_review }}
+          PUBLIC_RELEASE_INPUT: ${{ inputs.public_release }}
           IOS_PHASED_RELEASE_INPUT: ${{ inputs.ios_phased_release }}
         run: |
           {
@@ -96,7 +102,8 @@ jobs:
             echo "- version: \`${{ steps.r.outputs.version_name }}\`"
             echo "- flavor: \`$FLAVOR_INPUT\` · platform: \`$PLATFORM_INPUT\`"
             echo "- submit iOS for review: \`$SUBMIT_IOS_FOR_REVIEW_INPUT\`"
-            echo "- iOS phased release: \`$IOS_PHASED_RELEASE_INPUT\`"
+            echo "- release to public: \`$PUBLIC_RELEASE_INPUT\`"
+            echo "- iOS phased release (Six): \`$IOS_PHASED_RELEASE_INPUT\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   promote_android:
@@ -115,12 +122,13 @@ jobs:
       LC_ALL: en_US.UTF-8
       FLAVOR: ${{ matrix.flavor }}
       BLOKADA_VERSION_CODE: ${{ needs.resolve.outputs.build_number }}
+      PUBLIC_RELEASE: ${{ inputs.public_release }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
 
-      - name: Release to alpha and beta
+      - name: Release to testing tracks, and production when public
         env:
           BLOKADA_GPLAY_KEY_BASE64: ${{ secrets.BLOKADA_GPLAY_KEY_BASE64 }}
         run: make promote-android FLAVOR="$FLAVOR"
@@ -147,6 +155,7 @@ jobs:
       BLOKADA_VERSION_CODE: ${{ needs.resolve.outputs.build_number }}
       BLOKADA_VERSION_NAME: ${{ needs.resolve.outputs.version_name }}
       SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
+      PUBLIC_RELEASE: ${{ inputs.public_release }}
       PHASED_RELEASE: ${{ inputs.ios_phased_release }}
     steps:
       - uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test-local:
 test-scripts:
 	./scripts/test-build-number.sh
 	./scripts/test-version.sh
+	./scripts/test-release-state.rb
 
 # Build everything from scratch
 build:
@@ -187,8 +188,25 @@ version-clean:
 
 # Tracks that a release promotes an existing build to. "alpha" is closed
 # testing and "beta" is open testing -- Play's default track ids, which we
-# never renamed. Unlike internal, both require review.
+# never renamed. Unlike internal, both require review. "production" is appended
+# only when PUBLIC_RELEASE=true.
 GPLAY_PROMOTE_TRACKS ?= alpha beta
+
+# The tracks a given run actually writes. Assigned once so the error message
+# and the loop below can never disagree about what the run would touch.
+GPLAY_TRACKS = $(GPLAY_PROMOTE_TRACKS) $(if $(filter true,$(PUBLIC_RELEASE)),production)
+
+# Fraction of users a Blokada 6 production release starts at. Raising it is a
+# manual Play Console action -- Play has no time-based ramp, so there is no
+# Android equivalent of the iOS 7-day phased release and a staged rollout
+# percentage is the closest thing.
+#
+# Family does not use this: it is the smaller app, and releasing it is exactly
+# how we take a whole live step, so it goes out at 100%. supply only forces a
+# staged rollout when the value is strictly between 0 and 1
+# (supply/lib/supply/uploader.rb#update_track); passing no --rollout at all
+# leaves release_status at its "completed" default, which is that full release.
+GPLAY_SIX_PRODUCTION_ROLLOUT ?= 0.01
 
 # Upload the AAB to the Google Play internal track (use FLAVOR param).
 #
@@ -235,10 +253,17 @@ publish-android:
 # Metadata and changelogs are NOT skipped here: the internal release
 # deliberately carries no notes, so release notes have to be attached at this
 # point.
+#
+# production is written only when PUBLIC_RELEASE=true, and only six starts at a
+# fraction of users -- see GPLAY_SIX_PRODUCTION_ROLLOUT above.
+#
+# Replacing a release that is already in review needs nothing extra: update_track
+# assigns track.releases = [track_release] and Play drops releases omitted from
+# edits.tracks.update, so writing a track supersedes whatever sat on it.
 promote-android:
 	$(MAKE) gplay-key-unpack
 	@if [ -z "$(BLOKADA_VERSION_CODE)" ]; then \
-	    echo "Error: BLOKADA_VERSION_CODE is not set. It is required to release to: $(GPLAY_PROMOTE_TRACKS)"; \
+	    echo "Error: BLOKADA_VERSION_CODE is not set. It is required to release to: $(GPLAY_TRACKS)"; \
 	    exit 1; \
 	fi
 	@PKG=$(if $(filter family,$(FLAVOR)),org.blokada.family,org.blokada.sex); \
@@ -246,13 +271,19 @@ promote-android:
 	./scripts/verify-play-version-code.rb \
 	    --json-key blokada-gplay.json \
 	    --package-name "$$PKG" \
-	    --version-code $$STORE_CODE || exit 1; \
-	for track in $(GPLAY_PROMOTE_TRACKS); do \
-	    echo "==> Releasing store code $$STORE_CODE to '$$track' and submitting for review"; \
+	    --version-code $$STORE_CODE \
+	    $(if $(filter true,$(PUBLIC_RELEASE)),--check-production-rollout) || exit 1; \
+	for track in $(GPLAY_TRACKS); do \
+	    ROLLOUT=""; \
+	    if [ "$$track" = "production" ] && [ "$(FLAVOR)" != "family" ]; then \
+	        ROLLOUT="--rollout $(GPLAY_SIX_PRODUCTION_ROLLOUT)"; \
+	    fi; \
+	    echo "==> Releasing store code $$STORE_CODE to '$$track' $${ROLLOUT:+at $(GPLAY_SIX_PRODUCTION_ROLLOUT) rollout }and submitting for review"; \
 	    $(FASTLANE) supply \
 	        --package_name "$$PKG" \
 	        --json_key blokada-gplay.json \
 	        --track $$track \
+	        $$ROLLOUT \
 	        --version_codes_to_retain $$STORE_CODE \
 	        --metadata_path metadata/android-$(FLAVOR) \
 	        --skip_upload_aab true \
@@ -277,12 +308,18 @@ gplay-key-clean:
 
 # Attach an already-uploaded build to an App Store version (use FLAVOR,
 # BLOKADA_VERSION_CODE as the raw build number, BLOKADA_VERSION_NAME,
-# SUBMIT_FOR_REVIEW=true|false and PHASED_RELEASE=true|false). Never builds or
-# uploads a binary.
+# SUBMIT_FOR_REVIEW=true|false, PUBLIC_RELEASE=true|false and
+# PHASED_RELEASE=true|false). Never builds or uploads a binary.
 #
-# The two flags default opposite ways on purpose, so an unset variable is the
-# safe answer for each: submitting for review needs an explicit "true", while
-# the phased 7-day rollout needs an explicit "false" to turn off.
+# The flags default in opposite directions on purpose, so that an unset
+# variable is the cautious answer for each. SUBMIT_FOR_REVIEW and
+# PUBLIC_RELEASE need an explicit "true": nothing is submitted, and family does
+# not publish itself. PHASED_RELEASE needs an explicit "false": six's 7-day
+# ramp is the safe default and turning it off is the deliberate hotfix choice.
+#
+# PHASED_RELEASE governs six only -- family always releases to all users at
+# once. It has to be decided here rather than in App Store Connect because the
+# console greys the setting out once Apple approves the build.
 promote-ios:
 	$(MAKE) appstore-key-unpack
 	@if [ -z "$(BLOKADA_VERSION_CODE)" ] || [ -z "$(BLOKADA_VERSION_NAME)" ]; then \
@@ -295,6 +332,7 @@ promote-ios:
 	    build_number:$$STORE_CODE \
 	    version_name:$(BLOKADA_VERSION_NAME) \
 	    submit_for_review:$(if $(filter true,$(SUBMIT_FOR_REVIEW)),true,false) \
+	    public_release:$(if $(filter true,$(PUBLIC_RELEASE)),true,false) \
 	    phased_release:$(if $(filter false,$(PHASED_RELEASE)),false,true)
 	$(MAKE) appstore-key-clean
 

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -11,12 +11,14 @@ promote-only release step:
   published and nothing is submitted for review.
 - **Releasing** never builds. It takes a build number that is already uploaded
   and releases it: to Play `alpha` + `beta`, and to an App Store version that is
-  optionally submitted for review. Publishing is always a manual click.
+  optionally submitted for review.
 
-The pipeline stops at Play `alpha`/`beta` and at an App Store version in
-Pending Developer Release. **Neither reaches production.** Promoting an
-alpha/beta release to Play `production`, and releasing an approved App Store
-version, are console actions with no automation here at all — see
+By default the pipeline stops at Play `alpha`/`beta` and at an App Store version
+in Pending Developer Release, and **neither reaches production**. The
+`public_release` input is what takes the live step: it sends both Android
+flavors to Play `production` and lets the Family App Store version publish
+itself once approved. Blokada 6 on the App Store is never published
+automatically — that click is always ours. See
 [Reaching production](#reaching-production).
 
 The point is that the binary you ship is the exact binary that has been sitting
@@ -227,29 +229,110 @@ Trigger: `workflow_dispatch` only.
 | `flavor` | `all` | `all`, `six`, `family` |
 | `platform` | `all` | `all`, `ios`, `android` |
 | `submit_ios_for_review` | **false** | Whether to submit the App Store version |
-| `ios_phased_release` | **true** | Ramp the iOS update over 7 days |
+| `public_release` | **false** | Take the live step — see below |
+| `ios_phased_release` | **true** | Ramp Blokada 6 over 7 days; untick for a hotfix |
 
 Defaults give the standard sequence with no input at all. The flavor/platform
 narrowing is the manual-override path.
 
-The two iOS flags default opposite ways so that an unset value is the cautious
-answer for each: submitting for review takes an explicit opt-in, while the
-phased ramp takes an explicit opt-out.
+The flags default in opposite directions so that an unset value is the cautious
+answer for each. `submit_ios_for_review` and `public_release` need an explicit
+`true`: nothing is submitted, and nothing reaches the public. `ios_phased_release`
+needs an explicit `false`: the ramp is the safe default, and turning it off is
+the deliberate hotfix choice.
 
-### iOS phased release
+### `public_release`
 
-`deliver` only touches the setting when the option is non-nil
-(`deliver/upload_metadata.rb:314`), so passing nothing leaves whatever App Store
-Connect happens to have on that version. This workflow always passes a real
-boolean instead, so the input decides rather than a per-version setting somebody
-clicked months ago. The consequence worth knowing: `false` does not mean "leave
-alone", it **deletes** an existing phased release.
+| | `false` | `true` |
+|---|---|---|
+| **iOS six** | ramp per `ios_phased_release` · manual release | *identical* |
+| **iOS family** | all users · manual release | all users · **auto-release once approved** |
+| **Android six** | `alpha` + `beta` | `alpha` + `beta` + **`production` @ 1%** |
+| **Android family** | `alpha` + `beta` | `alpha` + `beta` + **`production` @ 100%** |
+
+The flag is about **family**: it is how we take the smaller live step. Family is
+the lower-traffic app, so it goes out first and goes out whole — full rollout,
+publishing itself once approved. Six never changes behaviour with the flag on
+iOS at all; on Play it gains a production release that starts at 1%.
+
+Default `false` matters because the flag decides whether Play production is
+written. An input nobody thought about must not publish.
+
+### iOS phased release and automatic release
+
+Six ramps over 7 days unless `ios_phased_release` is unticked, and always waits
+for a manual release click. Family never ramps — that is fixed in the lane, not
+an input — and `public_release` decides whether it publishes itself once
+approved.
+
+**Why the ramp is a dispatch-time input and not something to fix later.** App
+Store Connect greys the phased-release checkboxes out once Apple approves the
+build — verified on a real Pending Developer Release version on 2026-08-03,
+which contradicts Apple's own help page listing Pending Developer Release among
+the statuses where the option is available; read that list as "at submission
+time". The API refuses too: `PATCH /v1/appStoreVersionPhasedReleases` returns
+409 *"You cannot change the state of a phased release in the current version
+state"*. Releasing and then clicking *Release to all users* does work, but only
+once the version has Ready for Distribution status — so a hotfix that must not
+trickle out over a week has to say so when the release is dispatched, or accept
+going live at 1% first and being accelerated by hand.
+
+`upload_metadata.rb:314` skips the phased setting only when the option is
+`nil` — but `deliver`'s ConfigItem for `phased_release` carries
+`default_value: false` (`deliver/options.rb:221-226`), so it is **never nil in
+practice**. Omitting it is the same as passing `false`, and `false` does not
+mean "leave alone", it **deletes** an existing phased release. Dropping the
+explicit `phased_release: true` from `publish_ios_six` would therefore silently
+remove six's ramp, not inherit whatever App Store Connect has.
+
+`automatic_release` is the one that genuinely honours nil: it has no
+`default_value`. Both are written out explicitly anyway, so the lane decides
+rather than a per-version setting somebody clicked months ago.
 
 The ramp governs **automatic updates for existing users only** — anyone who
 updates by hand or installs fresh gets the build immediately regardless. It runs
 7 days, and it can be paused or pushed to everyone from App Store Connect once
-the release is out, so this input sets the starting position rather than an
-irreversible choice.
+the release is out, so it sets the starting position rather than an irreversible
+choice.
+
+### The App Store state gate
+
+`ensure_promotable` runs before `deliver` in both promote lanes and decides
+whether the release may start at all, from the newest version record's
+`appVersionState`:
+
+| State | Action |
+|---|---|
+| *(none)*, `READY_FOR_DISTRIBUTION`, `REPLACED_WITH_NEW_VERSION` | proceed — nothing pending |
+| `PREPARE_FOR_SUBMISSION`, `DEVELOPER_REJECTED`, `REJECTED`, `METADATA_REJECTED`, `INVALID_BINARY` | proceed — editable |
+| `WAITING_FOR_REVIEW`, `IN_REVIEW` | cancel the submission, then proceed |
+| everything else | fail, naming the state |
+
+The table (`ios/fastlane/release_state.rb`) is **fail-closed**: an unlisted state
+blocks the release, so a new or renamed Apple state produces a legible refusal
+rather than an unpredictable mutation. Refusals are emitted as GitHub
+`::error` annotations so the run page names the state instead of showing
+`Process completed with exit code 2`.
+
+**Why this exists.** `get_edit_app_store_version` counts `WAITING_FOR_REVIEW` as
+editable, so `ensure_version!` will happily rename a submission that is already
+in review to the version name of the build being promoted, upload metadata over
+it, and only fail later when `select_build` refuses to swap the binary. Run
+`30808857877` did exactly that to 26.8.1007.
+
+**Why not `reject_if_possible`.** deliver's own flag cancels an in-progress
+submission, but `Runner#run` calls it *after* `verify_version`, so the rename
+has already happened, and its wait loop has no timeout. The lane does the same
+cancellation earlier and bounded to 5 minutes, and leaves the flag off.
+
+The cancellation only runs when `submit_ios_for_review` is on. A run that pulled
+a submitted version out of review and put nothing back in its place would be
+worse than a refusal.
+
+An **approved** version cannot be cancelled at all: its review submission is
+`COMPLETE`, so `get_in_progress_review_submission` no longer returns it and
+there is no API to un-approve. `PENDING_DEVELOPER_RELEASE` therefore fails with
+a message telling the operator to release or reject it by hand.
 
 **`latest` resolves the newest *tag*, not the newest successful build.** The
 number is allocated before anything is built, so if that `ci-release` run
@@ -276,23 +359,50 @@ in Play Console (confirmed 2026-07-28).
 
 ### Reaching production
 
-**The pipeline never touches production on either store.** `promote.yml` ends
-with:
+Without `public_release`, the pipeline never touches production on either store.
+`promote.yml` ends with:
 
 - Play: a release on `alpha` and `beta`, submitted for review.
 - App Store: a version with the build attached, either still editable or — with
   `submit_ios_for_review: true` and once approved — in Pending Developer
   Release.
 
-Getting from there to users is entirely manual, in the two consoles:
+With `public_release: true` it goes further:
 
-- **Play production** — Play Console → *Production* → *Create new release* →
-  add the reviewed version code → *Start rollout*. There is no make target, no
-  lane and no workflow input for this, by design.
-- **App Store** — App Store Connect → *Release this version*, because
-  `automatic_release: false`.
+- **Play production** is written directly by `promote-android`, for both
+  flavors, in the same run as `alpha`/`beta`. Six starts at a 1% staged rollout;
+  family goes out at 100%.
+- **The Family App Store version** is created with `automatic_release: true`, so
+  Apple publishes it as soon as review passes.
 
-"Publishing is always a manual click" refers to exactly these two actions.
+What stays manual, always:
+
+- **Blokada 6 on the App Store** — App Store Connect → *Release this version*,
+  because six keeps `automatic_release: false`. This is the one click the
+  pipeline will never make.
+- **Raising six's Play rollout** — Play Console → *Production* → the staged
+  release → increase the percentage. Play has no time-based ramp, so nothing
+  raises it on a schedule. `GPLAY_SIX_PRODUCTION_ROLLOUT` sets only the starting
+  fraction.
+
+  **This is not optional maintenance — it gates the next public release of
+  six.** A track cannot hold two in-progress staged rollouts: Play's own
+  guidance is that you cannot create a new release while an earlier one is
+  still rolling out, and it has to be completed, halted or discarded first.
+
+  `scripts/verify-play-version-code.rb --check-production-rollout` refuses the
+  run up front when production still holds one, naming the version code and the
+  percentage it is stuck at. The flag is passed only when the run would write
+  production. Without it the rejection would land at the production write —
+  *after* `alpha` and `beta` had been written, leaving the release
+  half-applied. A rollout of the code being promoted does not block its own
+  re-run.
+
+Leaving an approved App Store version un-released has a cost worth knowing: it
+sits in `PENDING_DEVELOPER_RELEASE`, and no new version can be created for that
+app until it is released or rejected — so the next promote run for that flavor
+fails the state gate. Family avoids this by publishing itself; six does not, and
+that is the trade for keeping the click.
 
 ### Why Android writes the track instead of promoting
 
@@ -369,19 +479,30 @@ old patches are <= 75, new ones start at 1000.
 |---|---|---|
 | `version` | both | unchanged |
 | `publish-android` | merge | internal only; **remove** the promote loop added on this branch, and add the metadata skip flags |
-| `promote-android` | release | **new** — preflight the code, then write `alpha`/`beta` directly with `--version_codes_to_retain`, plus metadata/changelogs |
+| `promote-android` | release | **new** — preflight the code, then write `alpha`/`beta` (and `production` when `PUBLIC_RELEASE=true`) directly with `--version_codes_to_retain`, plus metadata/changelogs |
 | `publish-ios-testflight` | merge | **new** — `upload_to_testflight` lane |
-| `promote-ios` | release | **renamed from `publish-ios`** — `deliver` with `build_number`, `skip_binary_upload`, optional `submit_for_review`, then an explicit build attach |
-| `test-scripts` | neither | **new** — runs `test-build-number.sh` and `test-version.sh`; wired into PR CI on `ubuntu-latest` |
+| `promote-ios` | release | **renamed from `publish-ios`** — state gate, then `deliver` with `build_number`, `skip_binary_upload`, optional `submit_for_review`, then an explicit build attach |
+| `test-scripts` | neither | **new** — runs `test-build-number.sh`, `test-version.sh` and `test-release-state.rb`; wired into PR CI on `ubuntu-latest` |
 
 ### iOS submission settings
+
+Six:
 
 ```ruby
 submit_for_review: <input>,        # default false
 automatic_release: false,          # → "Pending Developer Release", manual click
+phased_release: <input>,           # default true, unticked only for a hotfix
+reject_if_possible: false,         # the state gate already did it, earlier
 submission_information: {
   content_rights_contains_third_party_content: false
 }
+```
+
+Family differs in exactly two places:
+
+```ruby
+automatic_release: <public_release>,  # publishes itself once approved
+phased_release: false,                # always all users at once
 ```
 
 Export compliance needs **nothing**: `ITSAppUsesNonExemptEncryption` is already
@@ -435,6 +556,22 @@ Verified against fastlane 2.232.0 as installed, not from documentation.
   codes; the explicit skip flags avoid this regardless.
 - **`deliver` refuses concurrent submissions** — `submit_for_review.rb` errors
   with *"A review submission is already in progress"*. Clean, legible failure.
+- **spaceship treats `WAITING_FOR_REVIEW` as an editable state.**
+  `App#get_edit_app_store_version` filters on `PREPARE_FOR_SUBMISSION`,
+  `DEVELOPER_REJECTED`, `REJECTED`, `METADATA_REJECTED`, `WAITING_FOR_REVIEW`
+  and `INVALID_BINARY`, so `ensure_version!` will rename a version that is
+  already in review instead of refusing. This is why the state gate runs first.
+- **`reject_if_possible` runs too late to help.** `Runner#run` calls
+  `reject_version_if_possible` *after* `verify_version`, and the poll loop
+  inside it has no timeout.
+- **An approved version has no cancellable submission.**
+  `App#get_in_progress_review_submission` filters on `WAITING_FOR_REVIEW`,
+  `IN_REVIEW` and `UNRESOLVED_ISSUES`; a `COMPLETE` submission is invisible to
+  it, and nothing in the API un-approves a version.
+- **`--rollout` strictly between 0 and 1 forces a staged release.**
+  `Uploader#update_track` sets `status: inProgress` and `user_fraction` only in
+  that range; omitting the flag leaves `release_status` at its `completed`
+  default, which is a 100% release. Play has no time-based ramp at all.
 - **`workflow_dispatch` requires the workflow file on the default branch**;
   `push` does not. This shaped the pre-merge validation below.
 - **TestFlight builds expire after 90 days.** This is an **iOS-only** limit: a

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -13,6 +13,15 @@
 # Uncomment the line if you want fastlane to automatically update itself
 # update_fastlane
 
+# Required here rather than inside the lane that uses them. fastlane evaluates
+# this file with `eval(data, binding, "Fastfile")` -- a *relative* filename --
+# so require_relative resolves against the current directory instead of a real
+# file path. That is fine at parse time, which FastFile#parse wraps in a chdir
+# to the fastlane folder, but a require_relative left in a lane body resolves
+# at call time and raises LoadError from any other working directory.
+require_relative "release_state"
+require_relative "ci_annotation"
+
 default_platform(:ios)
 
 platform :ios do
@@ -35,6 +44,173 @@ platform :ios do
   desc "Family: build release"
   lane :build_ios_family do
     build_app(workspace: "IOS.xcworkspace", scheme: "FamilyProd")
+  end
+
+  # Refuses to start a release App Store Connect is not in a state to accept,
+  # and clears the one state that can be cleared.
+  #
+  # This exists because deliver mishandles a version that is already in review.
+  # get_edit_app_store_version (spaceship connect_api/models/app.rb) counts
+  # WAITING_FOR_REVIEW as editable, so ensure_version! renames the submission
+  # sitting in review to the version name of the build being promoted, uploads
+  # metadata over it, and only fails much later when select_build refuses to
+  # swap the binary. Run 30808857877 did precisely that to 26.8.1007.
+  #
+  # deliver has reject_if_possible, which cancels an in-progress submission --
+  # but Runner#run calls it *after* verify_version, so the rename has already
+  # landed by then, and its wait loop has no timeout at all. This does the same
+  # cancellation earlier and bounded, which is why reject_if_possible stays off
+  # in both lanes below.
+  #
+  # An approved version cannot be handled here: once the review submission is
+  # COMPLETE, get_in_progress_review_submission no longer returns it and there
+  # is no API to un-approve. Those states fail with an explicit message instead.
+  #
+  # Returns :already_submitted when the version in review is the one this run
+  # was asked to promote, so the caller can skip deliver entirely -- see the
+  # idempotence note in the cancel branch.
+  #
+  # api_key_path is relative to the *fastlane folder*, not the project folder --
+  # see attach_build for why.
+  private_lane :ensure_promotable do |options|
+    require "spaceship"
+
+    bundle_id = options[:bundle_id]
+    version_name = options[:version_name]
+
+    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from_json_file(options[:api_key_path])
+    platform = Spaceship::ConnectAPI::Platform::IOS
+
+    app = Spaceship::ConnectAPI::App.find(bundle_id)
+    UI.user_error!("Could not find app '#{bundle_id}' on App Store Connect") if app.nil?
+
+    # Every refusal goes through here so the run page always names the state,
+    # rather than leaving "Process completed with exit code 2" as the only
+    # visible output.
+    refuse = lambda do |message|
+      CiAnnotation.error(title: "Cannot promote #{bundle_id}", message: message)
+      UI.user_error!(message)
+    end
+
+    # The replacement build is validated FIRST, before anything is mutated.
+    # Cancelling a review submission is irreversible -- Apple has no un-cancel
+    # -- so a run that cancelled and only then discovered its build was missing
+    # or still processing would leave the app with nothing in review at all.
+    # deliver never checks this on the submit path either: attach_build, which
+    # does, is skipped there.
+    build = Spaceship::ConnectAPI::Build.all(
+      app_id: app.id,
+      version: version_name,
+      build_number: options[:build_number],
+      platform: platform
+    ).first
+
+    if build.nil?
+      refuse.call("#{bundle_id}: build #{version_name} (#{options[:build_number]}) does not exist. " \
+                  "It has to be uploaded to TestFlight by a ci-release run before it can be released.")
+    end
+
+    unless build.processing_state == Spaceship::ConnectAPI::Build::ProcessingState::VALID
+      refuse.call("#{bundle_id}: build #{version_name} (#{options[:build_number]}) is " \
+                  "'#{build.processing_state}', not " \
+                  "'#{Spaceship::ConnectAPI::Build::ProcessingState::VALID}'. Wait for App Store " \
+                  "Connect to finish processing it and re-run.")
+    end
+
+    # Asks App Store Connect for pending versions by state instead of sorting
+    # client-side. get_latest_app_store_version sorts by
+    # Date.parse(created_date) -- calendar-day granularity, and sort_by is not
+    # stable -- so a live version created the same day as a pending one can win
+    # the sort and hide it, which would let the gate wave through the exact
+    # rename it exists to prevent.
+    pending = lambda do
+      classified = app
+                   .get_app_store_versions(filter: {
+                                             platform: platform,
+                                             appVersionState: ReleaseState::PENDING.join(",")
+                                           })
+                   .map { |v| [v, *ReleaseState.classify(v.app_version_state)] }
+
+      strictest = ReleaseState.strictest(classified.map { |(_, act, _)| act })
+      classified.find { |(_, act, _)| act == strictest }
+    end
+
+    current = pending.call
+    version, action, reason = current || [nil, :proceed, nil]
+
+    if action == :blocked
+      refuse.call("#{bundle_id}: version #{version.version_string} is " \
+                  "#{version.app_version_state} -- #{reason}")
+    end
+
+    if action == :cancel
+      # Idempotence. Re-dispatching the same build after an unrelated leg of the
+      # release failed is routine, and the version in review is then the one
+      # this run would submit. Cancelling it would restart the Apple review
+      # queue for no reason, so the run stops here instead. A version string
+      # identifies a build in this pipeline -- 26.8.1009 is always 669001009 --
+      # so matching names mean matching binaries.
+      if version.version_string == version_name
+        UI.success("#{bundle_id}: #{version_name} is already in review -- nothing to do")
+        next :already_submitted
+      end
+
+      # Cancelling without resubmitting would pull a finished submission out of
+      # review and put nothing back, which is worse than refusing to run.
+      unless options[:submit].to_s == "true"
+        refuse.call("#{bundle_id}: version #{version.version_string} is " \
+                    "#{version.app_version_state}. Promoting #{version_name} would have to cancel " \
+                    "that submission and would put nothing back in its place, so re-run with " \
+                    "'Submit the App Store version for review' enabled to replace it.")
+      end
+
+      UI.important("#{bundle_id}: cancelling the review submission for #{version.version_string} " \
+                   "so #{version_name} can replace it")
+
+      submission = app.get_in_progress_review_submission(platform: platform)
+      if submission.nil?
+        refuse.call("#{bundle_id}: version #{version.version_string} is " \
+                    "#{version.app_version_state} but App Store Connect reports no cancellable " \
+                    "review submission. Cancel it by hand and re-run.")
+      end
+      submission.cancel_submission
+
+      # Cancellation is not instant, and the submission leaves the in-progress
+      # filter (CANCELING is not one of its states) before the version leaves
+      # review -- so poll the version state itself, not the submission.
+      cleared = false
+      attempts = 20 # 20 x 15s = 5 minutes
+      attempts.times do |attempt|
+        fresh_version, fresh_action, fresh_reason = pending.call || []
+
+        if fresh_action == :blocked
+          refuse.call("#{bundle_id}: cancelling #{version.version_string} left it in " \
+                      "#{fresh_version.app_version_state} -- #{fresh_reason}")
+        end
+
+        # Only an editable version record proves the cancellation landed. An
+        # empty response is not evidence of anything -- treating "no pending
+        # version" as success here would hand a still-in-review version to
+        # deliver, which is the failure this lane exists to prevent.
+        if fresh_version && fresh_action == :proceed
+          cleared = true
+          break
+        end
+
+        UI.message("Waiting for the cancellation to take effect...")
+        sleep(15) unless attempt == attempts - 1
+      end
+
+      unless cleared
+        refuse.call("#{bundle_id}: cancellation of #{version.version_string} did not take effect " \
+                    "within 5 minutes. Check App Store Connect and re-run.")
+      end
+
+      UI.success("Cancelled the previous submission")
+    end
+
+    UI.success("#{bundle_id}: ready to promote #{version_name}")
+    :proceed
   end
 
   # Attaches an already-uploaded build to the App Store version deliver just
@@ -108,17 +284,33 @@ platform :ios do
   # ship the exact binary that has been on TestFlight. app_version must be the
   # name baked in at build time -- deliver looks a build up by the pair.
   #
-  # automatic_release: false leaves an approved build in Pending Developer
-  # Release. Publishing is always a manual click.
+  # Six always waits for a manual release click, and ramps over 7 days unless
+  # the run says otherwise: it is the larger app, so the ramp is the safety net
+  # and the click is ours. Family never ramps -- it is the smaller app, and
+  # releasing it is precisely how we take a whole live step -- and
+  # public_release decides whether it publishes itself once approved. That
+  # makes family the only thing in this pipeline that can reach users without a
+  # human clicking anything.
   #
-  # phased_release is passed as a real boolean on every run, never left nil.
-  # deliver only touches the setting when the option is non-nil
-  # (deliver/upload_metadata.rb:314), so nil means "leave whatever App Store
-  # Connect has" -- true creates the 7-day ramp, and false DELETES an existing
-  # one. Being explicit means the workflow input decides, rather than a stale
-  # per-version setting somebody clicked months ago. Note the ramp only governs
-  # automatic updates for existing users; manual updates and fresh installs get
-  # the build immediately either way.
+  # The ramp is a lane option rather than something to fix afterwards in App
+  # Store Connect: the console greys the phased-release checkboxes out once
+  # Apple approves the build (verified on a real Pending Developer Release
+  # version, 2026-08-03), and the API refuses to change the state too --
+  # PATCH /v1/appStoreVersionPhasedReleases returns 409 "You cannot change the
+  # state of a phased release in the current version state". Releasing and then
+  # clicking "Release to all users" works, but only once the version is live,
+  # so a hotfix that must not trickle out has to say so at dispatch time.
+  #
+  # Both are stated explicitly on every run. upload_metadata.rb:314 skips the
+  # phased setting only when the option is nil, but deliver's ConfigItem for
+  # phased_release carries default_value: false (deliver/options.rb:221-226),
+  # so it is never nil in practice -- omitting it does not mean "leave whatever
+  # App Store Connect has", it means false, which DELETES an existing ramp.
+  # (automatic_release has no default_value and genuinely is nil when omitted.)
+  # Writing both out means the lane decides, rather than a stale per-version
+  # setting somebody clicked months ago or a default nobody read. Note the ramp
+  # only governs automatic updates for existing users; manual updates and fresh
+  # installs get the build immediately either way.
   #
   # Export compliance needs no entry here: ITSAppUsesNonExemptEncryption is
   # already <false/> in Info-six.plist and Info-family.plist, so App Store
@@ -128,6 +320,19 @@ platform :ios do
     # the CLI's `submit_for_review:true` into the Ruby boolean true before the
     # lane ever sees it, so comparing against the string is always false.
     submit = options[:submit_for_review].to_s == "true"
+
+    # next, not return: a lane body is a block. :already_submitted means this
+    # exact version is in review, so there is nothing left for deliver to do.
+    if ensure_promotable(
+      api_key_path: "../blokada-appstore.json", # lane body, not an action -- see attach_build
+      bundle_id: "net.blocka.app",
+      version_name: options[:version_name],
+      build_number: options[:build_number],
+      submit: submit
+    ) == :already_submitted
+      next
+    end
+
     deliver(
       app_identifier: "net.blocka.app",
       metadata_path: "../metadata/ios-six/",
@@ -140,8 +345,9 @@ platform :ios do
       force: true, # skips verification of HTML preview file
       run_precheck_before_submit: false, # not supported through ASC API yet
       submit_for_review: submit,
-      automatic_release: false,
-      phased_release: options[:phased_release].to_s == "true",
+      automatic_release: false, # six is always released by hand
+      phased_release: options[:phased_release].to_s != "false", # 7-day ramp unless a hotfix says no
+      reject_if_possible: false, # ensure_promotable already did it, earlier and bounded
       submission_information: {
         content_rights_contains_third_party_content: false
       }
@@ -163,6 +369,20 @@ platform :ios do
     # the CLI's `submit_for_review:true` into the Ruby boolean true before the
     # lane ever sees it, so comparing against the string is always false.
     submit = options[:submit_for_review].to_s == "true"
+    public_release = options[:public_release].to_s == "true"
+
+    # next, not return: a lane body is a block. :already_submitted means this
+    # exact version is in review, so there is nothing left for deliver to do.
+    if ensure_promotable(
+      api_key_path: "../blokada-appstore.json", # lane body, not an action -- see attach_build
+      bundle_id: "net.blocka.app.family",
+      version_name: options[:version_name],
+      build_number: options[:build_number],
+      submit: submit
+    ) == :already_submitted
+      next
+    end
+
     deliver(
       app_identifier: "net.blocka.app.family",
       metadata_path: "../metadata/ios-family/",
@@ -175,8 +395,9 @@ platform :ios do
       force: true,
       run_precheck_before_submit: false,
       submit_for_review: submit,
-      automatic_release: false,
-      phased_release: options[:phased_release].to_s == "true",
+      automatic_release: public_release, # the live step: publish once approved
+      phased_release: false, # family always goes to all users at once
+      reject_if_possible: false, # ensure_promotable already did it, earlier and bounded
       submission_information: {
         content_rights_contains_third_party_content: false
       }

--- a/ios/fastlane/ci_annotation.rb
+++ b/ios/fastlane/ci_annotation.rb
@@ -1,0 +1,27 @@
+# Surfaces a release refusal on the GitHub Actions run page.
+#
+# UI.user_error! only reaches the job log. The annotation GitHub puts next to a
+# failed job is "Process completed with exit code 2", which says nothing about
+# which App Store Connect state stopped the release -- exactly the problem with
+# the 2026-08-03 promote failures, where the reason was buried in a spaceship
+# backtrace. A workflow command puts it at the top of the run instead.
+module CiAnnotation
+  # Workflow commands are single-line: an unescaped newline silently truncates
+  # everything after it.
+  # https://docs.github.com/actions/reference/workflow-commands-for-github-actions
+  def self.escape(text)
+    text.to_s.gsub("%", "%25").gsub("\r", "%0D").gsub("\n", "%0A")
+  end
+
+  # No-ops outside GitHub Actions so local `make promote-ios` runs stay clean.
+  def self.error(title:, message:)
+    return unless ENV["GITHUB_ACTIONS"]
+
+    puts("::error title=#{escape(title)}::#{escape(message)}")
+
+    summary = ENV["GITHUB_STEP_SUMMARY"]
+    File.open(summary, "a") { |f| f.puts("- **#{title}** — #{message}") } if summary
+
+    nil
+  end
+end

--- a/ios/fastlane/release_state.rb
+++ b/ios/fastlane/release_state.rb
@@ -1,0 +1,84 @@
+# Maps an App Store Connect version state onto what a promote run is allowed to
+# do with it. Kept out of the Fastfile, and free of any network call, so PR CI
+# can cover every state without store credentials.
+#
+# Fail closed. Apple has already replaced one of these enums once
+# (appStoreState superseded by appVersionState), and a release that stalls with
+# a legible message beats one that mutates a submission nobody was looking at.
+module ReleaseState
+  # No pending version at all: the live one, a superseded one, or a brand new
+  # app. deliver creates the version it needs.
+  IDLE = [nil, "READY_FOR_DISTRIBUTION", "REPLACED_WITH_NEW_VERSION"].freeze
+
+  # A pending version App Store Connect still lets us edit.
+  EDITABLE = %w[
+    PREPARE_FOR_SUBMISSION
+    DEVELOPER_REJECTED
+    REJECTED
+    METADATA_REJECTED
+    INVALID_BINARY
+  ].freeze
+
+  # Submitted, undecided, and cancellable -- so a newer build can take its
+  # place. Anything Apple has already approved is deliberately not here: once
+  # the review submission is COMPLETE there is no API to undo it.
+  CANCELLABLE = %w[
+    WAITING_FOR_REVIEW
+    IN_REVIEW
+  ].freeze
+
+  # What the operator has to do, per blocking state. Written as the tail of
+  # "version X is STATE -- ...".
+  BLOCKED = {
+    "PENDING_DEVELOPER_RELEASE" =>
+      "it is approved and waiting to be released by hand. Release it in App Store Connect " \
+      "(or reject it there), then re-run this workflow.",
+    "PENDING_APPLE_RELEASE" =>
+      "it is approved and scheduled for release by Apple. Wait for it to go live in App Store " \
+      "Connect, then re-run this workflow.",
+    "PROCESSING_FOR_DISTRIBUTION" =>
+      "it has been released and Apple is still processing it. Wait for it to go live in App " \
+      "Store Connect, then re-run this workflow.",
+    "ACCEPTED" =>
+      "it is approved and on its way out. Wait for it to go live in App Store Connect, then " \
+      "re-run this workflow.",
+    "READY_FOR_REVIEW" =>
+      "a review submission has been prepared for it in App Store Connect but never sent. Submit " \
+      "or delete that submission, then re-run this workflow.",
+    "WAITING_FOR_EXPORT_COMPLIANCE" =>
+      "it is waiting on an export compliance answer in App Store Connect. Answer it, then " \
+      "re-run this workflow."
+  }.freeze
+
+  UNKNOWN = "the release pipeline does not know this state. Check the version in App Store " \
+            "Connect, then teach ios/fastlane/release_state.rb what to do with it."
+
+  # Every state that means "a version is pending", for use as an
+  # appVersionState filter. Asking App Store Connect for exactly these is the
+  # only deterministic way to find the pending version: spaceship's
+  # get_latest_app_store_version sorts client-side by Date.parse(created_date),
+  # which has calendar-day granularity and is not a stable sort, so a live
+  # version created on the same day as a pending one can win the sort and hide
+  # it. Derived from the tables above, so a state added there is queried here.
+  PENDING = (EDITABLE + CANCELLABLE + BLOCKED.keys).freeze
+
+  # Most restrictive first. Used when App Store Connect reports more than one
+  # pending version, so a blocked one is never masked by an editable one.
+  SEVERITY = %i[blocked cancel proceed].freeze
+
+  def self.strictest(actions)
+    SEVERITY.find { |action| actions.include?(action) } || :proceed
+  end
+
+  # Returns [action, reason]:
+  #   :proceed - deliver can create or edit the version; reason is nil
+  #   :cancel  - a review submission has to be cancelled before deliver runs
+  #   :blocked - the release cannot continue; reason says what a human must do
+  def self.classify(state)
+    return [:proceed, nil] if IDLE.include?(state)
+    return [:proceed, nil] if EDITABLE.include?(state)
+    return [:cancel, "it is in review and this build would replace it"] if CANCELLABLE.include?(state)
+
+    [:blocked, BLOCKED.fetch(state, UNKNOWN)]
+  end
+end

--- a/scripts/test-release-state.rb
+++ b/scripts/test-release-state.rb
@@ -1,0 +1,147 @@
+#!/usr/bin/env ruby
+# Verifies the promote state table: every App Store Connect version state maps
+# to exactly one action, and anything unrecognised blocks the release.
+#
+# Deliberately free of credentials and of the fastlane runtime -- the table is
+# a pure function so PR CI can cover every state without touching a store.
+require_relative "../ios/fastlane/release_state"
+require_relative "../ios/fastlane/ci_annotation"
+require "stringio"
+require "tmpdir"
+
+FAILURES = []
+
+def check(name)
+  ok = yield
+  puts(ok ? "ok   #{name}" : "FAIL #{name}")
+  FAILURES << name unless ok
+end
+
+# CiAnnotation writes to stdout, which is also where this script reports, so
+# every annotation check has to run with stdout swapped out.
+def capture_stdout
+  original = $stdout
+  $stdout = StringIO.new
+  yield
+  $stdout.string
+ensure
+  $stdout = original
+end
+
+# Mirrors Spaceship::ConnectAPI::AppStoreVersion::AppVersionState
+# (spaceship/lib/spaceship/connect_api/models/app_store_version.rb).
+ALL_STATES = %w[
+  ACCEPTED
+  DEVELOPER_REJECTED
+  IN_REVIEW
+  INVALID_BINARY
+  METADATA_REJECTED
+  PENDING_APPLE_RELEASE
+  PENDING_DEVELOPER_RELEASE
+  PREPARE_FOR_SUBMISSION
+  PROCESSING_FOR_DISTRIBUTION
+  READY_FOR_DISTRIBUTION
+  READY_FOR_REVIEW
+  REJECTED
+  REPLACED_WITH_NEW_VERSION
+  WAITING_FOR_EXPORT_COMPLIANCE
+  WAITING_FOR_REVIEW
+].freeze
+
+check("every Apple state classifies") do
+  ALL_STATES.all? { |s| %i[proceed cancel blocked].include?(ReleaseState.classify(s).first) }
+end
+
+check("no version means nothing is pending") { ReleaseState.classify(nil).first == :proceed }
+check("live version does not block") { ReleaseState.classify("READY_FOR_DISTRIBUTION").first == :proceed }
+check("superseded version does not block") { ReleaseState.classify("REPLACED_WITH_NEW_VERSION").first == :proceed }
+check("editable version proceeds") { ReleaseState.classify("PREPARE_FOR_SUBMISSION").first == :proceed }
+check("developer rejected proceeds") { ReleaseState.classify("DEVELOPER_REJECTED").first == :proceed }
+check("apple rejected proceeds") { ReleaseState.classify("REJECTED").first == :proceed }
+check("invalid binary proceeds") { ReleaseState.classify("INVALID_BINARY").first == :proceed }
+check("waiting for review cancels") { ReleaseState.classify("WAITING_FOR_REVIEW").first == :cancel }
+check("in review cancels") { ReleaseState.classify("IN_REVIEW").first == :cancel }
+check("pending developer release blocks") { ReleaseState.classify("PENDING_DEVELOPER_RELEASE").first == :blocked }
+check("pending apple release blocks") { ReleaseState.classify("PENDING_APPLE_RELEASE").first == :blocked }
+check("processing for distribution blocks") { ReleaseState.classify("PROCESSING_FOR_DISTRIBUTION").first == :blocked }
+check("unknown state fails closed") { ReleaseState.classify("BRAND_NEW_APPLE_STATE").first == :blocked }
+
+check("blocked states explain themselves") do
+  (ALL_STATES + ["BRAND_NEW_APPLE_STATE"]).all? do |s|
+    action, reason = ReleaseState.classify(s)
+    action != :blocked || (reason.is_a?(String) && !reason.empty?)
+  end
+end
+
+check("pending developer release names the manual step") do
+  ReleaseState.classify("PENDING_DEVELOPER_RELEASE").last.include?("App Store Connect")
+end
+
+check("PENDING covers every non-idle state the table knows") do
+  ReleaseState::PENDING.sort ==
+    (ReleaseState::EDITABLE + ReleaseState::CANCELLABLE + ReleaseState::BLOCKED.keys).sort
+end
+
+check("PENDING excludes the idle states") do
+  (ReleaseState::PENDING & ReleaseState::IDLE.compact).empty?
+end
+
+check("PENDING is what a promote run must ask App Store Connect for") do
+  ALL_STATES.all? { |s| ReleaseState.classify(s).first == :proceed || ReleaseState::PENDING.include?(s) }
+end
+
+check("strictest prefers blocked over everything") do
+  ReleaseState.strictest(%i[proceed cancel blocked]) == :blocked
+end
+
+check("strictest prefers cancel over proceed") { ReleaseState.strictest(%i[proceed cancel]) == :cancel }
+check("strictest of nothing is proceed") { ReleaseState.strictest([]) == :proceed }
+check("strictest of proceed alone is proceed") { ReleaseState.strictest([:proceed]) == :proceed }
+
+# Every annotation check runs with GITHUB_STEP_SUMMARY pointed at a scratch
+# file. Under CI both GITHUB_ACTIONS and GITHUB_STEP_SUMMARY are already set to
+# the real job summary, and CiAnnotation appends to whatever that variable
+# names -- so without this, the test suite would write fabricated release
+# refusals into every PR's run page, which is exactly the misleading output
+# CiAnnotation exists to prevent.
+was_actions = ENV["GITHUB_ACTIONS"]
+was_summary = ENV["GITHUB_STEP_SUMMARY"]
+
+Dir.mktmpdir do |dir|
+  summary = File.join(dir, "summary.md")
+  ENV["GITHUB_STEP_SUMMARY"] = summary
+
+  check("annotation is silent off CI") do
+    ENV.delete("GITHUB_ACTIONS")
+    capture_stdout { CiAnnotation.error(title: "T", message: "M") }.empty? && !File.exist?(summary)
+  end
+
+  check("annotation is a workflow command on CI") do
+    ENV["GITHUB_ACTIONS"] = "true"
+    capture_stdout { CiAnnotation.error(title: "Cannot promote", message: "boom") }.strip ==
+      "::error title=Cannot promote::boom"
+  end
+
+  check("annotation escapes newlines") do
+    ENV["GITHUB_ACTIONS"] = "true"
+    capture_stdout { CiAnnotation.error(title: "T", message: "a\nb") }.strip == "::error title=T::a%0Ab"
+  end
+
+  check("annotation appends to the step summary") do
+    ENV["GITHUB_ACTIONS"] = "true"
+    capture_stdout { CiAnnotation.error(title: "T", message: "boom") }
+    File.exist?(summary) && File.read(summary).include?("boom")
+  end
+end
+
+ENV["GITHUB_ACTIONS"] = was_actions
+ENV.delete("GITHUB_ACTIONS") if was_actions.nil?
+ENV["GITHUB_STEP_SUMMARY"] = was_summary
+ENV.delete("GITHUB_STEP_SUMMARY") if was_summary.nil?
+
+check("the suite leaves the real step summary untouched") do
+  ENV["GITHUB_STEP_SUMMARY"] == was_summary && ENV["GITHUB_ACTIONS"] == was_actions
+end
+
+abort("\nFAIL: #{FAILURES.size} check(s) failed: #{FAILURES.join(', ')}") unless FAILURES.empty?
+puts "\nPASS: release state table classifies every state, annotations are legible"

--- a/scripts/verify-play-version-code.rb
+++ b/scripts/verify-play-version-code.rb
@@ -44,6 +44,10 @@ parser = OptionParser.new do |opts|
   opts.on("--package-name PKG", "Play package name") { |v| options[:package_name] = v }
   opts.on("--version-code CODE", Integer,
           "Store version code (VERSION_CODE_OFFSET + raw build number)") { |v| options[:version_code] = v }
+  opts.on("--check-production-rollout",
+          "Also refuse if production still holds an unfinished staged rollout") do
+    options[:check_production_rollout] = true
+  end
 end
 
 begin
@@ -90,10 +94,29 @@ rescue StandardError => e
 end
 
 codes = nil
+stalled_rollout = nil
 begin
   codes = (client.aab_version_codes + client.apks_version_codes).map(&:to_i)
+
+  # A track cannot hold two staged rollouts. Play refuses a new release while an
+  # earlier one is still rolling out -- it has to be completed, halted or
+  # discarded first -- and `make promote-android` writes alpha and beta before
+  # production, so discovering that at the production write leaves the run
+  # half-applied. Nothing in this pipeline finishes a rollout (raising it is a
+  # deliberate human decision), so the previous release's 1% ramp is a standing
+  # precondition of the next public release. Check it before any track is
+  # written.
+  if options[:check_production_rollout]
+    releases = client.tracks("production").first&.releases || []
+    stalled_rollout = releases.find do |release|
+      # A re-run that writes the same code again is not blocked by its own
+      # rollout -- same idempotence rule the iOS gate applies.
+      release.status == "inProgress" &&
+        !(release.version_codes || []).map(&:to_i).include?(version_code)
+    end
+  end
 rescue StandardError => e
-  fail_with("could not list uploaded artifacts for #{package_name}: #{e.message}")
+  fail_with("could not read the release state of #{package_name}: #{e.message}")
 ensure
   # Read-only check: never leave the throwaway edit hanging around. A failure to
   # clean it up must not mask the result of the check itself. This still runs
@@ -115,6 +138,20 @@ unless codes.include?(version_code)
     "       Check that the ci-release run for this build number finished " \
     "successfully.\n" \
     "       Highest uploaded code for this package: #{newest}."
+  )
+end
+
+if stalled_rollout
+  rolling = (stalled_rollout.version_codes || []).join(", ")
+  percent = ((stalled_rollout.user_fraction || 0) * 100).round(2)
+  fail_with(
+    "#{package_name} still has an unfinished staged rollout on production, so Play will " \
+    "not accept a new release there.\n" \
+    "       Rolling out: version code #{rolling} at #{percent}% of users.\n" \
+    "       Finish it (Play Console -> Production -> the staged release -> raise to 100%) " \
+    "or halt it, then re-run this release.\n" \
+    "       Refusing now rather than after alpha and beta have been written, which would " \
+    "leave this release half-applied."
   )
 end
 


### PR DESCRIPTION
Two changes that surfaced together when the first real `Promote to Stores` runs failed on 2026-08-03 ([run 30792264713](https://github.com/blokadaorg/blokada/actions/runs/30792264713), [run 30808857877](https://github.com/blokadaorg/blokada/actions/runs/30808857877)): the pipeline could not reach production, and its App Store failures were unreadable.

## Inputs

`ios_phased_release` is replaced by two inputs that say what they do.

**`public_release`** (default **false**) takes the live step:

| | `false` | `true` |
|---|---|---|
| **iOS six** | ramp per `ios_phased_release` · manual release | *identical* |
| **iOS family** | all users · manual release | all users · **auto-release once approved** |
| **Android six** | `alpha` + `beta` | + **`production` @ 1%** |
| **Android family** | `alpha` + `beta` | + **`production` @ 100%** |

The flag is about Family: it is the smaller app, so releasing it whole is how we take the smaller live step. Default `false` because it decides whether Play production is written at all.

**`ios_phased_release`** (default **true**) governs Six's 7-day ramp. It has to be decided at dispatch — App Store Connect greys the checkboxes out once Apple approves the build, and the API returns 409 on a state change, so it cannot be undone later. Untick for a hotfix.

**Blokada 6 keeps `automatic_release: false`.** That click stays ours.

## The App Store state gate

`ensure_promotable` runs before `deliver` and decides from the pending version's `appVersionState` whether the release may start: proceed, cancel a submission still in review so a newer build replaces it, or refuse naming the state. Refusals become GitHub `::error` annotations, so the run page says *"version 26.8.1006 is PENDING_DEVELOPER_RELEASE — release it in App Store Connect…"* instead of `Process completed with exit code 2`.

This exists because spaceship counts `WAITING_FOR_REVIEW` as editable, so `ensure_version!` renames a submission that is already in review and uploads metadata over it — which is what happened to 26.8.1007. The table is fail-closed: an unlisted state blocks the release.

`deliver`'s own `reject_if_possible` stays off — it runs *after* `verify_version`, by which point the rename has landed, and its wait loop has no timeout.

## Play rollout precondition

A track cannot hold two staged rollouts, and nothing here ever finishes one, so the previous 1% ramp gates the next public release of Six. `verify-play-version-code.rb --check-production-rollout` refuses up front rather than letting the rejection land after `alpha` and `beta` are written.

## Verification

- `make test-scripts` — 20 new checks covering every `appVersionState`, fail-closed behaviour, and the annotation format. Wired into the existing *Release script tests* CI job (adds a `ruby` dependency; preinstalled on `ubuntu-latest`).
- Fastfile parses with all lanes registered; Makefile track/rollout expansion exercised across every flavor × flag combination.
- **Not exercised locally:** the App Store Connect queries and the Play rollout check need store credentials, and the local ruby toolchain cannot load `supply`. The first real promote run is their first execution.
- Reviewed with `/code-review high`; ten findings, nine fixed here, one (a GitHub Environment approval gate on production) deliberately declined.

## Operator notes

- `workflow_dispatch` reads inputs from the default branch, so the new inputs only appear in the Actions UI after this merges.
- `net.blocka.app` currently has an in-review version labelled 26.8.1009 carrying build 669001007, and `net.blocka.app.family` has one stuck in Pending Developer Release. Both need clearing in App Store Connect before the next promote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)