### PR TITLE
feat(release): one flag decides whether a release goes live

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -25,18 +25,13 @@ on:
         default: "all"
         type: choice
         options: [all, ios, android]
-      submit_ios_for_review:
-        description: "Submit the App Store version for review (never publishes)"
-        required: false
-        default: false
-        type: boolean
       public_release:
-        description: "Release to the public: Family publishes once approved, Android goes to production (Six 1%, Family 100%). Six always waits for a manual release."
+        description: "Go live once approved. OFF: Android stops at alpha+beta, and both iOS apps wait in App Store Connect for you to press Release. ON: Android also goes to production (Six at 1%, Family at 100%) and Family releases itself the moment Apple approves it. Blokada 6 always waits for you either way. Both apps are always submitted for review."
         required: false
         default: false
         type: boolean
       ios_phased_release:
-        description: "iOS only. Ramp Blokada 6 over 7 days for auto-updating users. Untick for a hotfix that must reach everyone at once. Family always releases to all users. App Store Connect locks this once the build is approved, so it cannot be changed later."
+        description: "iOS only, Blokada 6 only. Roll the update out to auto-updating users over 7 days. Untick for a hotfix that has to reach everyone at once. Family always goes to all users. App Store Connect locks this in once Apple approves the build, so it cannot be changed afterwards."
         required: false
         default: true
         type: boolean
@@ -92,7 +87,6 @@ jobs:
         env:
           FLAVOR_INPUT: ${{ inputs.flavor }}
           PLATFORM_INPUT: ${{ inputs.platform }}
-          SUBMIT_IOS_FOR_REVIEW_INPUT: ${{ inputs.submit_ios_for_review }}
           PUBLIC_RELEASE_INPUT: ${{ inputs.public_release }}
           IOS_PHASED_RELEASE_INPUT: ${{ inputs.ios_phased_release }}
         run: |
@@ -101,8 +95,7 @@ jobs:
             echo "- build: \`${{ steps.r.outputs.build_number }}\`"
             echo "- version: \`${{ steps.r.outputs.version_name }}\`"
             echo "- flavor: \`$FLAVOR_INPUT\` · platform: \`$PLATFORM_INPUT\`"
-            echo "- submit iOS for review: \`$SUBMIT_IOS_FOR_REVIEW_INPUT\`"
-            echo "- release to public: \`$PUBLIC_RELEASE_INPUT\`"
+            echo "- go live once approved: \`$PUBLIC_RELEASE_INPUT\`"
             echo "- iOS phased release (Six): \`$IOS_PHASED_RELEASE_INPUT\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -154,7 +147,6 @@ jobs:
       FLAVOR: ${{ matrix.flavor }}
       BLOKADA_VERSION_CODE: ${{ needs.resolve.outputs.build_number }}
       BLOKADA_VERSION_NAME: ${{ needs.resolve.outputs.version_name }}
-      SUBMIT_FOR_REVIEW: ${{ inputs.submit_ios_for_review }}
       PUBLIC_RELEASE: ${{ inputs.public_release }}
       PHASED_RELEASE: ${{ inputs.ios_phased_release }}
     steps:
@@ -162,7 +154,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Attach build to App Store version
+      - name: Submit the App Store version for review
         env:
           BLOKADA_APPSTORE_KEY_BASE64: ${{ secrets.BLOKADA_APPSTORE_KEY_BASE64 }}
         run: make promote-ios FLAVOR="$FLAVOR"

--- a/Makefile
+++ b/Makefile
@@ -306,16 +306,20 @@ gplay-key-unpack:
 gplay-key-clean:
 	rm -rf blokada-gplay.json
 
-# Attach an already-uploaded build to an App Store version (use FLAVOR,
-# BLOKADA_VERSION_CODE as the raw build number, BLOKADA_VERSION_NAME,
-# SUBMIT_FOR_REVIEW=true|false, PUBLIC_RELEASE=true|false and
+# Attach an already-uploaded build to an App Store version and submit it for
+# review (use FLAVOR, BLOKADA_VERSION_CODE as the raw build number,
+# BLOKADA_VERSION_NAME, PUBLIC_RELEASE=true|false and
 # PHASED_RELEASE=true|false). Never builds or uploads a binary.
 #
-# The flags default in opposite directions on purpose, so that an unset
-# variable is the cautious answer for each. SUBMIT_FOR_REVIEW and
-# PUBLIC_RELEASE need an explicit "true": nothing is submitted, and family does
-# not publish itself. PHASED_RELEASE needs an explicit "false": six's 7-day
-# ramp is the safe default and turning it off is the deliberate hotfix choice.
+# Every run submits: promoting is submitting. What PUBLIC_RELEASE decides is
+# what happens after Apple approves -- family releases itself, or waits for a
+# human like six always does.
+#
+# The two flags default in opposite directions on purpose, so that an unset
+# variable is the cautious answer for each. PUBLIC_RELEASE needs an explicit
+# "true": family does not publish itself. PHASED_RELEASE needs an explicit
+# "false": six's 7-day ramp is the safe default and turning it off is the
+# deliberate hotfix choice.
 #
 # PHASED_RELEASE governs six only -- family always releases to all users at
 # once. It has to be decided here rather than in App Store Connect because the
@@ -331,7 +335,6 @@ promote-ios:
 	cd ios/ && $(FASTLANE) $$LANE \
 	    build_number:$$STORE_CODE \
 	    version_name:$(BLOKADA_VERSION_NAME) \
-	    submit_for_review:$(if $(filter true,$(SUBMIT_FOR_REVIEW)),true,false) \
 	    public_release:$(if $(filter true,$(PUBLIC_RELEASE)),true,false) \
 	    phased_release:$(if $(filter false,$(PHASED_RELEASE)),false,true)
 	$(MAKE) appstore-key-clean

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -10,8 +10,8 @@ promote-only release step:
   Android) and uploads them to Play **internal** and **TestFlight**. Nothing is
   published and nothing is submitted for review.
 - **Releasing** never builds. It takes a build number that is already uploaded
-  and releases it: to Play `alpha` + `beta`, and to an App Store version that is
-  optionally submitted for review.
+  and releases it: to Play `alpha` + `beta`, and to an App Store version that
+  is submitted for review.
 
 By default the pipeline stops at Play `alpha`/`beta` and at an App Store version
 in Pending Developer Release, and **neither reaches production**. The
@@ -228,27 +228,33 @@ Trigger: `workflow_dispatch` only.
 | `build_number` | latest | Which already-uploaded build to release |
 | `flavor` | `all` | `all`, `six`, `family` |
 | `platform` | `all` | `all`, `ios`, `android` |
-| `submit_ios_for_review` | **false** | Whether to submit the App Store version |
-| `public_release` | **false** | Take the live step — see below |
+| `public_release` | **false** | Go live once approved — see below |
 | `ios_phased_release` | **true** | Ramp Blokada 6 over 7 days; untick for a hotfix |
 
 Defaults give the standard sequence with no input at all. The flavor/platform
 narrowing is the manual-override path.
 
-The flags default in opposite directions so that an unset value is the cautious
-answer for each. `submit_ios_for_review` and `public_release` need an explicit
-`true`: nothing is submitted, and nothing reaches the public. `ios_phased_release`
-needs an explicit `false`: the ramp is the safe default, and turning it off is
-the deliberate hotfix choice.
+Both flags default in the cautious direction. `public_release` needs an explicit
+`true`: nothing goes live on its own. `ios_phased_release` needs an explicit
+`false`: the ramp is the safe default, and turning it off is the deliberate
+hotfix choice.
+
+**Submitting for review is not an input.** Every promote run submits both iOS
+apps. What `public_release` decides is what happens *after* Apple approves.
 
 ### `public_release`
 
+Both iOS apps are submitted for review either way. The flag decides what
+happens once Apple approves, and whether Play production is written.
+
 | | `false` | `true` |
 |---|---|---|
-| **iOS six** | ramp per `ios_phased_release` · manual release | *identical* |
-| **iOS family** | all users · manual release | all users · **auto-release once approved** |
+| **iOS six** | submitted · waits for your Release click | *identical* |
+| **iOS family** | submitted · waits for your Release click | submitted · **releases itself on approval** |
 | **Android six** | `alpha` + `beta` | `alpha` + `beta` + **`production` @ 1%** |
 | **Android family** | `alpha` + `beta` | `alpha` + `beta` + **`production` @ 100%** |
+
+Six's ramp is orthogonal — `ios_phased_release` governs it in both columns.
 
 The flag is about **family**: it is how we take the smaller live step. Family is
 the lower-traffic app, so it goes out first and goes out whole — full rollout,
@@ -325,9 +331,8 @@ submission, but `Runner#run` calls it *after* `verify_version`, so the rename
 has already happened, and its wait loop has no timeout. The lane does the same
 cancellation earlier and bounded to 5 minutes, and leaves the flag off.
 
-The cancellation only runs when `submit_ios_for_review` is on. A run that pulled
-a submitted version out of review and put nothing back in its place would be
-worse than a refusal.
+Cancelling is unconditional because every run resubmits: something always goes
+back into review in place of what was taken out.
 
 An **approved** version cannot be cancelled at all: its review submission is
 `COMPLETE`, so `get_in_progress_review_submission` no longer returns it and
@@ -363,9 +368,8 @@ Without `public_release`, the pipeline never touches production on either store.
 `promote.yml` ends with:
 
 - Play: a release on `alpha` and `beta`, submitted for review.
-- App Store: a version with the build attached, either still editable or — with
-  `submit_ios_for_review: true` and once approved — in Pending Developer
-  Release.
+- App Store: a version submitted for review, and once approved sitting in
+  Pending Developer Release.
 
 With `public_release: true` it goes further:
 
@@ -439,25 +443,24 @@ to finish before supply opens the edit it will commit. Every error path —
 auth, network, unexpected response — exits non-zero, so a broken check blocks
 the release rather than waving it through.
 
-### Why iOS attaches the build explicitly
+### Why every promote run submits for review
 
 `deliver` selects a build **only** inside its submit-for-review step:
 `Runner#run` calls `submit_for_review` under
 `if options[:submit_for_review] && precheck_success` (runner.rb:71), and
-`options[:build_number]` is read nowhere else in deliver. With
-`submit_for_review: false` — the default — deliver would create the App Store
-version, upload the metadata, report success, and leave the version with **no
-binary attached**.
+`options[:build_number]` is read nowhere else in deliver. So a "stage it but do
+not submit" mode would create the App Store version, upload the metadata,
+report success, and leave the version with **no binary attached** — and it
+needed a hand-written build attach afterwards to make up for it.
 
-So each promote lane attaches the build itself after `deliver`, using the same
-`Spaceship::ConnectAPI` calls deliver's own `select_build` uses: find the app by
-bundle id, take the editable App Store version for iOS, look the build up by
-`app_version` + `build_number`, select it on the version. Re-selecting an
-already-selected build is the same PATCH with the same value, so re-runs are
-safe. A build that has not finished processing fails with a message saying so.
-The step is skipped when `submit_for_review` is on, because deliver's own
-submit flow selects the build and then moves the version out of an editable
-state.
+Making submission unconditional deletes that whole path. Promoting is
+submitting; the only decision left is what happens after Apple approves, which
+is what `public_release` answers.
+
+The build is still checked before anything is touched — `ensure_promotable`
+looks it up by `app_version` + `build_number` and requires
+`processingState == VALID` — because deliver would otherwise discover a missing
+or still-processing build only after cancelling whatever was in review.
 
 ### Why the tag trigger is removed
 
@@ -481,7 +484,7 @@ old patches are <= 75, new ones start at 1000.
 | `publish-android` | merge | internal only; **remove** the promote loop added on this branch, and add the metadata skip flags |
 | `promote-android` | release | **new** — preflight the code, then write `alpha`/`beta` (and `production` when `PUBLIC_RELEASE=true`) directly with `--version_codes_to_retain`, plus metadata/changelogs |
 | `publish-ios-testflight` | merge | **new** — `upload_to_testflight` lane |
-| `promote-ios` | release | **renamed from `publish-ios`** — state gate, then `deliver` with `build_number`, `skip_binary_upload`, optional `submit_for_review`, then an explicit build attach |
+| `promote-ios` | release | **renamed from `publish-ios`** — state gate, then `deliver` with `build_number`, `skip_binary_upload` and `submit_for_review` |
 | `test-scripts` | neither | **new** — runs `test-build-number.sh`, `test-version.sh` and `test-release-state.rb`; wired into PR CI on `ubuntu-latest` |
 
 ### iOS submission settings
@@ -489,7 +492,7 @@ old patches are <= 75, new ones start at 1000.
 Six:
 
 ```ruby
-submit_for_review: <input>,        # default false
+submit_for_review: true,           # promoting is submitting
 automatic_release: false,          # → "Pending Developer Release", manual click
 phased_release: <input>,           # default true, unticked only for a hotfix
 reject_if_possible: false,         # the state gate already did it, earlier

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -70,8 +70,15 @@ platform :ios do
   # was asked to promote, so the caller can skip deliver entirely -- see the
   # idempotence note in the cancel branch.
   #
-  # api_key_path is relative to the *fastlane folder*, not the project folder --
-  # see attach_build for why.
+  # api_key_path is relative to the *fastlane folder*, not the project folder:
+  # Runner#execute wraps the whole lane in `Dir.chdir(FastlaneFolder.path)`
+  # (runner.rb:45), which is "./fastlane/" (fastlane_folder.rb:8-16), and
+  # try_switch_to_lane (runner.rb:185) does not chdir back. Only *actions* are
+  # moved up, by execute_action's `custom_dir ||= ".."` (runner.rb:218-229). So
+  # lane-body code like the call below runs in ios/fastlane/ while deliver runs
+  # in ios/ -- hence "../blokada-appstore.json" at the call sites but
+  # "./blokada-appstore.json" in the deliver calls. Both land on
+  # ios/blokada-appstore.json, where `make appstore-key-unpack` writes it.
   private_lane :ensure_promotable do |options|
     require "spaceship"
 
@@ -96,8 +103,8 @@ platform :ios do
     # Cancelling a review submission is irreversible -- Apple has no un-cancel
     # -- so a run that cancelled and only then discovered its build was missing
     # or still processing would leave the app with nothing in review at all.
-    # deliver never checks this on the submit path either: attach_build, which
-    # does, is skipped there.
+    # deliver does not check it either: its select_build fails on a build that
+    # is missing or still processing, but only after the cancellation.
     build = Spaceship::ConnectAPI::Build.all(
       app_id: app.id,
       version: version_name,
@@ -155,15 +162,8 @@ platform :ios do
         next :already_submitted
       end
 
-      # Cancelling without resubmitting would pull a finished submission out of
-      # review and put nothing back, which is worse than refusing to run.
-      unless options[:submit].to_s == "true"
-        refuse.call("#{bundle_id}: version #{version.version_string} is " \
-                    "#{version.app_version_state}. Promoting #{version_name} would have to cancel " \
-                    "that submission and would put nothing back in its place, so re-run with " \
-                    "'Submit the App Store version for review' enabled to replace it.")
-      end
-
+      # Safe to cancel unconditionally: every promote run submits, so something
+      # always goes back into review in place of what is taken out.
       UI.important("#{bundle_id}: cancelling the review submission for #{version.version_string} " \
                    "so #{version_name} can replace it")
 
@@ -213,76 +213,19 @@ platform :ios do
     :proceed
   end
 
-  # Attaches an already-uploaded build to the App Store version deliver just
-  # created or updated.
-  #
-  # deliver only ever selects a build inside its submit-for-review step:
-  # runner.rb:71 runs submit_for_review only when options[:submit_for_review]
-  # is set, and options[:build_number] is read nowhere else in deliver. So on
-  # the default (submit off) path deliver creates the version, uploads the
-  # metadata, reports success -- and leaves the version with no binary. This
-  # closes that gap; submitting for review stays opt-in.
-  #
-  # The API shape follows deliver's own select_build
-  # (deliver/lib/deliver/submit_for_review.rb): find the app by bundle id, take
-  # the editable App Store version for the platform, look the build up by
-  # app_version + build_number, and select it on the version. Selecting a build
-  # that is already selected is the same PATCH with the same value, so re-runs
-  # are safe.
-  #
-  # api_key_path is relative to the *fastlane folder*, not the project folder:
-  # Runner#execute wraps the whole lane in `Dir.chdir(FastlaneFolder.path)`
-  # (runner.rb:45), which is "./fastlane/" (fastlane_folder.rb:8-16), and
-  # try_switch_to_lane (runner.rb:185) does not chdir back. Only *actions* are
-  # moved up, by execute_action's `custom_dir ||= ".."` (runner.rb:218-229).
-  # So lane-body code like the line below runs in ios/fastlane/ while deliver
-  # runs in ios/ -- hence "../blokada-appstore.json" here but
-  # "./blokada-appstore.json" in the deliver calls. Both land on
-  # ios/blokada-appstore.json, where `make appstore-key-unpack` writes it.
-  private_lane :attach_build do |options|
-    require "spaceship"
-
-    api_key_path = options[:api_key_path]
-    bundle_id = options[:bundle_id]
-    version_name = options[:version_name]
-    build_number = options[:build_number]
-
-    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.from_json_file(api_key_path)
-    platform = Spaceship::ConnectAPI::Platform::IOS
-
-    app = Spaceship::ConnectAPI::App.find(bundle_id)
-    UI.user_error!("Could not find app '#{bundle_id}' on App Store Connect") if app.nil?
-
-    version = app.get_edit_app_store_version(platform: platform)
-    UI.user_error!("No editable App Store version for '#{bundle_id}' -- deliver should have created one") if version.nil?
-
-    build = Spaceship::ConnectAPI::Build.all(
-      app_id: app.id,
-      version: version_name,
-      build_number: build_number,
-      platform: platform
-    ).first
-
-    if build.nil?
-      UI.user_error!("Build #{version_name} (#{build_number}) does not exist for '#{bundle_id}'. " \
-                     "It has to be uploaded to TestFlight by a ci-release run before it can be released.")
-    end
-
-    unless build.processing_state == Spaceship::ConnectAPI::Build::ProcessingState::VALID
-      UI.user_error!("Build #{version_name} (#{build_number}) is '#{build.processing_state}', not " \
-                     "'#{Spaceship::ConnectAPI::Build::ProcessingState::VALID}', so it cannot be attached yet. " \
-                     "Wait for App Store Connect to finish processing it and re-run the release.")
-    end
-
-    version.select_build(build_id: build.id)
-    UI.success("Attached build #{version_name} (#{build_number}) to App Store version #{version.version_string}")
-  end
-
-  # Release path: attach an already-uploaded build to an App Store version.
+  # Release path: attach an already-uploaded build to an App Store version and
+  # send it to Apple.
   #
   # skip_binary_upload with build_number promotes rather than re-uploads, so we
   # ship the exact binary that has been on TestFlight. app_version must be the
   # name baked in at build time -- deliver looks a build up by the pair.
+  #
+  # submit_for_review is not an input: promoting *is* submitting. That also
+  # keeps the lane simple, because deliver only ever selects a build inside its
+  # submit step (runner.rb:71 gates submit_for_review, and build_number is read
+  # nowhere else). A "stage without submitting" mode would leave the version
+  # with no binary attached and needed a hand-written build attach to make up
+  # for it; always submitting deletes that whole path.
   #
   # Six always waits for a manual release click, and ramps over 7 days unless
   # the run says otherwise: it is the larger app, so the ramp is the safety net
@@ -316,19 +259,13 @@ platform :ios do
   # already <false/> in Info-six.plist and Info-family.plist, so App Store
   # Connect never asks.
   lane :publish_ios_six do |options|
-    # .to_s, not == "true": fastlane's CommandLineHandler.convert_value turns
-    # the CLI's `submit_for_review:true` into the Ruby boolean true before the
-    # lane ever sees it, so comparing against the string is always false.
-    submit = options[:submit_for_review].to_s == "true"
-
     # next, not return: a lane body is a block. :already_submitted means this
     # exact version is in review, so there is nothing left for deliver to do.
     if ensure_promotable(
-      api_key_path: "../blokada-appstore.json", # lane body, not an action -- see attach_build
+      api_key_path: "../blokada-appstore.json", # lane body, not an action -- see ensure_promotable
       bundle_id: "net.blocka.app",
       version_name: options[:version_name],
-      build_number: options[:build_number],
-      submit: submit
+      build_number: options[:build_number]
     ) == :already_submitted
       next
     end
@@ -344,7 +281,7 @@ platform :ios do
       skip_app_version_update: false,
       force: true, # skips verification of HTML preview file
       run_precheck_before_submit: false, # not supported through ASC API yet
-      submit_for_review: submit,
+      submit_for_review: true, # promoting is submitting -- see the lane comment
       automatic_release: false, # six is always released by hand
       phased_release: options[:phased_release].to_s != "false", # 7-day ramp unless a hotfix says no
       reject_if_possible: false, # ensure_promotable already did it, earlier and bounded
@@ -352,33 +289,21 @@ platform :ios do
         content_rights_contains_third_party_content: false
       }
     )
-    # deliver's submit flow selects the build itself and then moves the version
-    # out of an editable state, so only do this on the non-submitting path.
-    unless submit
-      attach_build(
-        api_key_path: "../blokada-appstore.json", # lane body, not an action -- see attach_build
-        bundle_id: "net.blocka.app",
-        version_name: options[:version_name],
-        build_number: options[:build_number]
-      )
-    end
   end
 
   lane :publish_ios_family do |options|
     # .to_s, not == "true": fastlane's CommandLineHandler.convert_value turns
-    # the CLI's `submit_for_review:true` into the Ruby boolean true before the
+    # the CLI's `public_release:true` into the Ruby boolean true before the
     # lane ever sees it, so comparing against the string is always false.
-    submit = options[:submit_for_review].to_s == "true"
     public_release = options[:public_release].to_s == "true"
 
     # next, not return: a lane body is a block. :already_submitted means this
     # exact version is in review, so there is nothing left for deliver to do.
     if ensure_promotable(
-      api_key_path: "../blokada-appstore.json", # lane body, not an action -- see attach_build
+      api_key_path: "../blokada-appstore.json", # lane body, not an action -- see ensure_promotable
       bundle_id: "net.blocka.app.family",
       version_name: options[:version_name],
-      build_number: options[:build_number],
-      submit: submit
+      build_number: options[:build_number]
     ) == :already_submitted
       next
     end
@@ -394,7 +319,7 @@ platform :ios do
       skip_app_version_update: false,
       force: true,
       run_precheck_before_submit: false,
-      submit_for_review: submit,
+      submit_for_review: true, # promoting is submitting -- see the lane comment
       automatic_release: public_release, # the live step: publish once approved
       phased_release: false, # family always goes to all users at once
       reject_if_possible: false, # ensure_promotable already did it, earlier and bounded
@@ -402,14 +327,6 @@ platform :ios do
         content_rights_contains_third_party_content: false
       }
     )
-    unless submit
-      attach_build(
-        api_key_path: "../blokada-appstore.json", # lane body, not an action -- see attach_build
-        bundle_id: "net.blocka.app.family",
-        version_name: options[:version_name],
-        build_number: options[:build_number]
-      )
-    end
   end
 
   # Continuous path: upload to TestFlight only, run on every merge to main.


### PR DESCRIPTION
Follow-up to #1205. That PR left two overlapping checkboxes — `submit_ios_for_review` and `public_release` — and whether a release actually reached anyone depended on reading both. Worse, for Blokada 6 the second one did nothing on iOS at all, so the two flags were only orthogonal on paper.

## Now

**Promoting is submitting.** Every promote run sends both iOS apps for review. `submit_ios_for_review` is gone.

One flag decides what happens once Apple approves:

| | `public_release` OFF | `public_release` ON |
|---|---|---|
| **iOS six** | submitted · waits for your Release click | *identical* |
| **iOS family** | submitted · waits for your Release click | submitted · **releases itself on approval** |
| **Android six** | `alpha` + `beta` | + **`production` @ 1%** |
| **Android family** | `alpha` + `beta` | + **`production` @ 100%** |

Blokada 6 always waits for that click. `ios_phased_release` stays an independent iOS-only flag for the 7-day ramp, unchanged.

## What this deletes

`deliver` only selects a build inside its submit-for-review step, so the old "stage but don't submit" mode created a version with **no binary attached** — which is why a hand-written `attach_build` lane existed to compensate. Making submission unconditional removes that whole path: **65 lines gone**, and two follow-on simplifications:

- `ensure_promotable` cancels an in-review submission unconditionally now, because something always goes back in place of what it takes out. The `submit`-gated refusal branch is gone.
- The build is still validated before anything is mutated — that check moved into `ensure_promotable` in #1205 and is the only copy now.

Net: **+82 / −167**.

## Descriptions

Both inputs now say what they do in plain terms instead of naming the fastlane option behind them. The old `submit_ios_for_review` label promised "(never publishes)", which #1205 had quietly made untrue for Family.

> **Go live once approved.** OFF: Android stops at alpha+beta, and both iOS apps wait in App Store Connect for you to press Release. ON: Android also goes to production (Six at 1%, Family at 100%) and Family releases itself the moment Apple approves it. Blokada 6 always waits for you either way. Both apps are always submitted for review.

## Verification

- `make test-scripts` green; the state-table and annotation suites are untouched by this change.
- Fastfile parses, lanes register, `attach_build` confirmed gone.
- `make -n promote-ios` checked across flag combinations: `public_release` and `phased_release` resolve correctly and `submit_for_review` no longer appears on the CLI.
- Store-side behaviour still needs a real run — unchanged from #1205.

## Operator note

`workflow_dispatch` reads inputs from the default branch, so the checkbox only disappears from the Actions UI once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)