### PR TITLE
Fix invisible chat links in the sent bubble

### DIFF
--- a/common/lib/src/features/support/ui/link_message.dart
+++ b/common/lib/src/features/support/ui/link_message.dart
@@ -87,28 +87,28 @@ class LinkMessage extends StatelessWidget {
           )
         : null;
 
+    // In the sent bubble the accent IS the bubble background, so links use
+    // the bubble's text color (underline marks them); accent stays readable
+    // on the received bubble's gray. Underline must match the text color
+    // explicitly, or the engine paints it black.
+    final linkColor = isSentByMe
+        ? (paragraphStyle?.color ?? theme.colors.onPrimary)
+        : context.theme.accent;
+
     final textContent = Linkify(
       onOpen: onOpenLink,
       text: message.text,
-      linkStyle: TextStyle(color: context.theme.accent),
-      style: _isOnlyEmoji
-          ? paragraphStyle?.copyWith(fontSize: onlyEmojiFontSize)
-          : paragraphStyle,
+      linkStyle: TextStyle(color: linkColor, decorationColor: linkColor),
+      style: _isOnlyEmoji ? paragraphStyle?.copyWith(fontSize: onlyEmojiFontSize) : paragraphStyle,
     );
 
     return Container(
       padding: _isOnlyEmoji
-          ? EdgeInsets.symmetric(
-              horizontal: (padding?.horizontal ?? 0) / 2,
-              vertical: 0,
-            )
+          ? EdgeInsets.symmetric(horizontal: (padding?.horizontal ?? 0) / 2, vertical: 0)
           : padding,
       decoration: _isOnlyEmoji
           ? null
-          : BoxDecoration(
-              color: backgroundColor,
-              borderRadius: borderRadius ?? theme.shape,
-            ),
+          : BoxDecoration(color: backgroundColor, borderRadius: borderRadius ?? theme.shape),
       child: _buildContentBasedOnPosition(
         context: context,
         textContent: textContent,
@@ -175,23 +175,19 @@ class LinkMessage extends StatelessWidget {
 
   TextStyle? _resolveParagraphStyle(bool isSentByMe, ChatTheme theme) {
     if (isSentByMe) {
-      return sentTextStyle ??
-          theme.typography.bodyMedium.copyWith(color: theme.colors.onPrimary);
+      return sentTextStyle ?? theme.typography.bodyMedium.copyWith(color: theme.colors.onPrimary);
     }
-    return receivedTextStyle ??
-        theme.typography.bodyMedium.copyWith(color: theme.colors.onSurface);
+    return receivedTextStyle ?? theme.typography.bodyMedium.copyWith(color: theme.colors.onSurface);
   }
 
   TextStyle? _resolveTimeStyle(bool isSentByMe, ChatTheme theme) {
     if (isSentByMe) {
       return timeStyle ??
           theme.typography.labelSmall.copyWith(
-            color:
-                _isOnlyEmoji ? theme.colors.onSurface : theme.colors.onPrimary,
+            color: _isOnlyEmoji ? theme.colors.onSurface : theme.colors.onPrimary,
           );
     }
-    return timeStyle ??
-        theme.typography.labelSmall.copyWith(color: theme.colors.onSurface);
+    return timeStyle ?? theme.typography.labelSmall.copyWith(color: theme.colors.onSurface);
   }
 }
 
@@ -236,17 +232,13 @@ class TimeAndStatus extends StatelessWidget {
       spacing: 2,
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (showTime && time != null)
-          Text(timeFormat.format(time!.toLocal()), style: textStyle),
+        if (showTime && time != null) Text(timeFormat.format(time!.toLocal()), style: textStyle),
         if (showStatus && status != null)
           if (status == MessageStatus.sending)
             SizedBox(
               width: 6,
               height: 6,
-              child: CircularProgressIndicator(
-                color: textStyle?.color,
-                strokeWidth: 2,
-              ),
+              child: CircularProgressIndicator(color: textStyle?.color, strokeWidth: 2),
             )
           else
             Icon(getIconForStatus(status!), color: textStyle?.color, size: 12),

--- a/common/test/features/support/ui/link_message_test.dart
+++ b/common/test/features/support/ui/link_message_test.dart
@@ -1,0 +1,95 @@
+import 'package:common/src/features/support/ui/link_message.dart';
+import 'package:common/src/shared/ui/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_chat_core/flutter_chat_core.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+// Accent doubles as the sent-bubble background (ColorScheme.primary in
+// app.dart), which is exactly the collision these tests guard against.
+const _accent = Color(0xffe450ba);
+const _onPrimary = Colors.white;
+
+const _blokadaTheme = BlokadaTheme(
+  bgColor: Color(0xFFF2F1F6),
+  bgColorHome1: Colors.white,
+  bgColorHome2: Colors.white,
+  bgColorHome3: Colors.white,
+  bgColorCard: Colors.white,
+  panelBackground: Colors.white,
+  cloud: Color(0xFF007AFF),
+  accent: _accent,
+  freemium: Color(0xFF48A9A6),
+  shadow: Color(0xffe8e8e8),
+  bgMiniCard: Colors.white,
+  textPrimary: Colors.black,
+  textSecondary: Colors.black54,
+  divider: Colors.black26,
+);
+
+Widget _host({required bool sentByMe, TextStyle? sentTextStyle}) {
+  final themeData = ThemeData(
+    colorScheme: const ColorScheme.light().copyWith(primary: _accent, onPrimary: _onPrimary),
+    extensions: const [_blokadaTheme],
+  );
+  return MaterialApp(
+    theme: themeData,
+    home: MultiProvider(
+      providers: [
+        Provider<ChatTheme>.value(value: ChatTheme.fromThemeData(themeData)),
+        Provider<UserID>.value(value: 'me'),
+      ],
+      child: Scaffold(
+        body: LinkMessage(
+          message: TextMessage(
+            id: '1',
+            authorId: sentByMe ? 'me' : 'support',
+            text: 'write to support@blokada.org please',
+          ),
+          index: 0,
+          onOpenLink: (_) {},
+          sentTextStyle: sentTextStyle,
+          showTime: false,
+          showStatus: false,
+        ),
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('sent-bubble link uses onPrimary, not the bubble color', (tester) async {
+    await tester.pumpWidget(_host(sentByMe: true));
+    final linkify = tester.widget<Linkify>(find.byType(Linkify));
+    expect(linkify.linkStyle?.color, _onPrimary);
+    expect(linkify.linkStyle?.color, isNot(_accent));
+  });
+
+  testWidgets('sent-bubble link underline matches the link color', (tester) async {
+    await tester.pumpWidget(_host(sentByMe: true));
+    final linkify = tester.widget<Linkify>(find.byType(Linkify));
+    expect(linkify.linkStyle?.decorationColor, linkify.linkStyle?.color);
+  });
+
+  testWidgets('sent-bubble link falls back to onPrimary for colorless sentTextStyle', (
+    tester,
+  ) async {
+    await tester.pumpWidget(_host(sentByMe: true, sentTextStyle: const TextStyle(fontSize: 16)));
+    final linkify = tester.widget<Linkify>(find.byType(Linkify));
+    expect(linkify.linkStyle?.color, _onPrimary);
+    expect(linkify.linkStyle?.color, isNot(_accent));
+  });
+
+  testWidgets('received-bubble link uses accent', (tester) async {
+    await tester.pumpWidget(_host(sentByMe: false));
+    final linkify = tester.widget<Linkify>(find.byType(Linkify));
+    expect(linkify.linkStyle?.color, _accent);
+  });
+
+  testWidgets('received-bubble link underline matches the link color', (tester) async {
+    await tester.pumpWidget(_host(sentByMe: false));
+    final linkify = tester.widget<Linkify>(find.byType(Linkify));
+    expect(linkify.linkStyle?.decorationColor, _accent);
+  });
+}


### PR DESCRIPTION
## Problem

Links (emails, URLs) in the user's own chat bubble were invisible: they were styled with the accent color, which is also the sent-bubble background (`ColorScheme.primary` is set to the same constant in `app.dart`) — pink-on-pink in Family, orange-on-orange in v6, in both light and dark modes. The underline also rendered black, because `flutter_linkify` adds `decoration: underline` while `decorationColor` was left unset, which the engine paints black.

## Fix

Per-bubble link color in `LinkMessage`, with `decorationColor` always matching the text:

- **Sent bubble**: link uses the bubble's text color (`paragraphStyle.color`, falling back to `onPrimary`), distinguished by the underline — the iMessage convention. `onPrimary` is contrast-guaranteed against `primary` per flavor and mode, so this can't collide with any current or future accent.
- **Received bubble**: link keeps the accent, which contrasts with the gray bubble in both modes and flavors.

## Testing

- 5 new widget tests pin link color and underline color per bubble, plus the colorless-`sentTextStyle` fallback.
- Full `common` suite green (419 tests), errors-only analyze gate clean.
- Not yet verified on device — worth a quick glance at the chat screen in the Family build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)