### PR TITLE
Pin Appium xcuitest driver to 10.28.1

### DIFF
--- a/automation/appium/wdio/scripts/lib/appium-runtime.mjs
+++ b/automation/appium/wdio/scripts/lib/appium-runtime.mjs
@@ -10,6 +10,9 @@ const WDA_KEYBOARD_PATCH_MARKER =
   "Blokada: preserve current iOS keyboard preferences during Appium sessions.";
 const WDA_KEYBOARD_PREFERENCES_TARGET =
   "  [FBConfiguration configureDefaultKeyboardPreferences];";
+// Pinned: driver 12.x bundles WebDriverAgent 16.x, whose UITestingUITests.m
+// no longer contains the keyboard-preferences line the patch above anchors on.
+const XCUITEST_DRIVER_VERSION = "10.28.1";
 
 export function parseBooleanFlag(value, fallback = false) {
   if (value == null || value === "") {
@@ -316,7 +319,10 @@ export async function ensureAppiumRuntime(options = {}) {
   }
 
   log("Installing Appium xcuitest driver into the repo-local Appium home...");
-  const installResult = runAppiumCli(["driver", "install", "xcuitest"], env);
+  const installResult = runAppiumCli(
+    ["driver", "install", `xcuitest@${XCUITEST_DRIVER_VERSION}`],
+    env
+  );
   if (installResult.status !== 0) {
     throw new Error(
       installResult.stderr || installResult.stdout || "Failed to install Appium xcuitest driver."


### PR DESCRIPTION
## Problem

The Appium smoke workflow has failed on every run since 2026-08-17 (e.g. [run 32007002098](https://github.com/blokadaorg/blokada/actions/runs/32007002098)), dying in setup before any spec starts:

```
Error: WebDriverAgent keyboard preferences hook not found.
    at patchWdaKeyboardPreferencesSource (.../lib/appium-runtime.mjs:97:11)
```

The runner checkout wipes the repo-local Appium home, so every CI run does a fresh `appium driver install xcuitest` with no version pin. On 2026-08-14 `appium-xcuitest-driver` 12.3.4 became `latest` on npm, bundling WebDriverAgent 16.x — where `UITestingUITests.m` changed `[FBConfiguration configureDefaultKeyboardPreferences]` to `[FBConfiguration.sharedInstance configureDefaultKeyboardPreferences]`, so the exact-string anchor our keyboard-preferences patch searches for no longer matches. The workflow was green through Aug 11 with driver 10.28.1 / WDA 11.4.0.

## Fix

Pin the install to the known-good `xcuitest@10.28.1`. The 10 → 12 driver upgrade is two majors and should be validated as its own change (it also requires reworking the WDA patch anchor and asset for the new `FBConfiguration.sharedInstance` API).

## Verification

- `npm run test:unit` — 93/93 pass
- Reproduced the CI path in a scratch `APPIUM_HOME`: pinned install succeeds, fresh WDA source contains the patch anchor, and `ensurePatchedWebDriverAgent()` patches it cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)