### PR TITLE
fix(adapty): vendor adapty_flutter 4.0.4 and pin the Android BOM to the bridge's native version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,12 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        # Same trap as pigeon in the pub group: a grouped PR is recreated
+        # whenever one of its members merges, so an ignored dependency can be
+        # dragged back in through the group. Exclude the Adapty BOM here so the
+        # ignore rule below is the only thing that decides when it moves.
+        exclude-patterns:
+          - "io.adapty:adapty-bom"
         update-types:
           - "minor"
           - "patch"
@@ -58,6 +64,16 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
+    ignore:
+      # The Adapty BOM is not an independent dependency: it must equal the BOM
+      # that common/vendor/adapty_flutter/android/build.gradle pins, because the
+      # crossplatform bridge is compiled against that exact native release.
+      # Bumping it alone breaks the release build under R8 — 4.1.0 renamed
+      # AdaptyAttributionSource with no alias and #1222 went green on debug CI
+      # while `:app:minifySixReleaseWithR8` failed on CI Release. It is bumped
+      # together with the vendored adapty_flutter, never alone; remove this when
+      # the plugin upgrade makes the BOM independently bumpable.
+      - dependency-name: "io.adapty:adapty-bom"
 
   - package-ecosystem: "npm"
     directory: "/ios/BlockaWebExtension"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -213,7 +213,10 @@ dependencies {
     // consumer must supply them. We don't author Compose — the BOM only pins
     // the versions for Adapty's prebuilt paywall UI.
     sixImplementation platform('androidx.compose:compose-bom:2026.08.00')
-    sixImplementation platform('io.adapty:adapty-bom:4.1.0')
+    // Must equal the BOM in common/vendor/adapty_flutter/android/build.gradle: the
+    // crossplatform bridge is compiled against that exact native release, so a newer
+    // BOM breaks R8 in release builds (4.1.0 renamed AdaptyAttributionSource — #1222).
+    sixImplementation platform('io.adapty:adapty-bom:4.0.2')
     sixImplementation 'io.adapty:android-sdk'
     sixImplementation 'io.adapty:android-ui'
 

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: "vendor/adapty_flutter"
       relative: true
     source: path
-    version: "4.0.3"
+    version: "4.0.4"
   analyzer:
     dependency: transitive
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -64,7 +64,7 @@ dependencies:
   flutter_chat_core: ^2.6.0
   flutter_chat_ui: ^2.6.0
   logger: ^2.4.0
-  adapty_flutter: 4.0.3
+  adapty_flutter: 4.0.4
   flutter_linkify: ^6.0.0
   cached_network_image: ^3.3.1
   web_socket_channel: ^3.0.3
@@ -79,7 +79,7 @@ dependency_overrides:
   #    (flutter/flutter#184590) — without a podspec `pod install` fails.
   # 2. BlokadaVendorAlias.swift — upstream pluginClass only exists as an
   #    @objc name; the generated Swift registrant needs a Swift name.
-  # 3. ios Package.swift pins AdaptySDK-iOS to the blokadaorg fork (4.0.2 +
+  # 3. ios Package.swift pins AdaptySDK-iOS to the blokadaorg fork (4.0.3 +
   #    restored includeBackground gate) until the translucent-footer
   #    regression is fixed upstream.
   # Keep the vendored version in lockstep with the `adapty_flutter` pin above

--- a/common/vendor/adapty_flutter/CHANGELOG.md
+++ b/common/vendor/adapty_flutter/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 4.0.4
+
+- [Android] `restorePurchases()` no longer fails with `noPurchasesToRestore` when there is nothing to restore. It now completes successfully with the current `AdaptyProfile` — check the access level status in the returned profile instead of catching an error. `AdaptyErrorCode.noPurchasesToRestore` is deprecated on Android.
+- [Android] Restore now uses currently owned purchases only. The native SDK moved to Google Play Billing Library 8, which removed the purchase history API. Purchases made through Adapty are unaffected, but subscriptions that expired before Adapty was integrated can no longer be imported from the device.
+- Fixed text elements in paywalls and flows losing their color and background when the builder sends them under the `text_color` and `text_background` keys. The old `color` and `background` keys are still read, so views built before the change keep rendering as they did. Fixed on both platforms.
+- [iOS] Native iOS SDK dependency pinned to `4.0.3`.
+- [Android] Native Android SDK dependency bumped to `4.0.2`.
+
 # 4.0.3
 
 - `AdaptyUI.createFlowView` and `AdaptyUIFlowPlatformView` now accept a `locale` — the localization the flow view is rendered with. Since 4.0.0 a flow is localized when its view is built, and there was no way to choose that localization from Dart. Requires the native iOS 4.0.2 and Android 4.0.1 releases.

--- a/common/vendor/adapty_flutter/android/build.gradle
+++ b/common/vendor/adapty_flutter/android/build.gradle
@@ -46,9 +46,9 @@ kotlin {
 }
 
 dependencies {
-    implementation platform('io.adapty:adapty-bom:4.0.1')
+    implementation platform('io.adapty:adapty-bom:4.0.2')
     implementation 'io.adapty:android-sdk'
     implementation 'io.adapty:android-ui'
     implementation 'io.adapty:android-ui-video'
-    implementation 'io.adapty.internal:crossplatform:4.0.2'
+    implementation 'io.adapty.internal:crossplatform:4.0.4'
 }

--- a/common/vendor/adapty_flutter/cross_platform.yaml
+++ b/common/vendor/adapty_flutter/cross_platform.yaml
@@ -1,5 +1,5 @@
 $schema: "https://json-schema.org/draft/2020-12/schema"
-$id: "https://adapty.io/crossPlatform/4.0.2/schema"
+$id: "https://adapty.io/crossPlatform/4.0.3/schema"
 title: "Cross Platform Format"
 
 $requests:

--- a/common/vendor/adapty_flutter/ios/adapty_flutter.podspec
+++ b/common/vendor/adapty_flutter/ios/adapty_flutter.podspec
@@ -14,7 +14,7 @@
 # fixed in the pinned Flutter SDK.
 Pod::Spec.new do |s|
   s.name             = 'adapty_flutter'
-  s.version          = '4.0.3'
+  s.version          = '4.0.4'
   s.summary          = 'CocoaPods resolution stub for the SwiftPM-only Adapty Flutter plugin.'
   s.description      = 'Satisfies the generated FlutterPluginRegistrant pod dependency; never shipped.'
   s.homepage         = 'https://adapty.io'

--- a/common/vendor/adapty_flutter/ios/adapty_flutter/Package.swift
+++ b/common/vendor/adapty_flutter/ios/adapty_flutter/Package.swift
@@ -10,15 +10,15 @@ let package = Package(
         .library(name: "adapty-flutter", targets: ["adapty_flutter"]),
     ],
     dependencies: [
-        // BLOKADA VENDOR PATCH: blokadaorg fork of AdaptySDK-iOS at the 4.0.2 tag
-        // plus one commit restoring the includeBackground gate on static decorator
-        // backgrounds (upstream regression darkens translucent paywall footers —
-        // see branch blokada/4.0.2-footer-include-background-gate). Pinned by
-        // revision for reproducibility. Upstream pin was `exact: "4.0.2"`; return
-        // to it when Adapty ships the fix.
+        // BLOKADA VENDOR PATCH: fork of AdaptySDK-iOS at the 4.0.3 tag + restored
+        // includeBackground gate (branch blokada/4.0.3-footer-include-background-gate).
+        // The upstream regression darkens translucent paywall footers; the fork adds
+        // one commit restoring the gate on static decorator backgrounds. Pinned by
+        // revision for reproducibility. Upstream pin was `exact: "4.0.3"`; return to
+        // it when Adapty ships the fix.
         .package(
             url: "https://github.com/blokadaorg/AdaptySDK-iOS.git",
-            revision: "caf82a13d050855fe725a151e29a1e214f9f65cd"
+            revision: "ce0a55a84555019cf6a71e859697c59d827a0ac1"
         ),
     ],
     targets: [

--- a/common/vendor/adapty_flutter/lib/src/adapty_version.dart
+++ b/common/vendor/adapty_flutter/lib/src/adapty_version.dart
@@ -1,1 +1,1 @@
-const String adaptySDKVersion = '4.0.3';
+const String adaptySDKVersion = '4.0.4';

--- a/common/vendor/adapty_flutter/pubspec.yaml
+++ b/common/vendor/adapty_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: adapty_flutter
 description: Adapty SDK is an open-source framework that makes implementing in-app subscriptions in Flutter applications fast and easy. It’s 100% open-source and lightweight.
-version: 4.0.3
+version: 4.0.4
 homepage: https://adapty.io/
 repository: https://github.com/adaptyteam/AdaptySDK-Flutter
 issue_tracker: https://github.com/adaptyteam/AdaptySDK-Flutter/issues

--- a/common/vendor/adapty_flutter/tool/kids/Package.swift
+++ b/common/vendor/adapty_flutter/tool/kids/Package.swift
@@ -12,11 +12,11 @@ let package = Package(
         .library(name: "adapty-flutter-kids", targets: ["adapty_flutter_kids"]),
     ],
     dependencies: [
-        // Pinned exactly to the iOS 4.0.2 stable release; the Flutter bridge (AdaptyPlugin) targets this
+        // Pinned exactly to the iOS 4.0.3 stable release; the Flutter bridge (AdaptyPlugin) targets this
         // exact native version, so we must not resolve to newer 4.x releases it wasn't built against.
         .package(
             url: "https://github.com/adaptyteam/AdaptySDK-iOS.git",
-            exact: "4.0.2",
+            exact: "4.0.3",
             traits: ["KidsMode"]
         ),
     ],


### PR DESCRIPTION
## The break

`CI Release` → `android (six)` has been failing at `:app:minifySixReleaseWithR8` since #1222 bumped `io.adapty:adapty-bom` from 4.0.2 to 4.1.0 in `android/app/build.gradle`.

Adapty Android 4.1 renamed `AdaptyAttributionSource` to `AdaptyExternalAttributionProvider` and shipped no alias. The Flutter bridge we ship (`io.adapty.internal:crossplatform`, pulled in by the vendored `adapty_flutter`) is compiled against 4.0.x and still references the old symbol, so R8 fails to shrink the release build.

PR CI only builds debug variants, which do not run R8 — so #1222 went green and the break only surfaced on `main`'s release job.

## Why not just move to a 4.1-compatible plugin

There isn't one. The newest `adapty_flutter` on pub.dev (and on the upstream `master`) is 4.0.4, and it pins Android BOM 4.0.2 + `crossplatform` 4.0.4 and iOS `AdaptySDK-iOS` exactly 4.0.3. No plugin release targets Adapty Android 4.1 yet. The plugin dictates the native versions; the host app's BOM has to follow it, not lead it.

## What changed

**`chore(adapty): vendor adapty_flutter 4.0.4`**

- Refreshed `common/vendor/adapty_flutter/` from pub.dev 4.0.4. The upstream 4.0.3 → 4.0.4 delta is only `CHANGELOG.md`, `android/build.gradle` (BOM 4.0.1 → 4.0.2, crossplatform 4.0.2 → 4.0.4), `cross_platform.yaml`, `ios/adapty_flutter/Package.swift`, `lib/src/adapty_version.dart`, `pubspec.yaml` and `tool/kids/Package.swift`.
- The three local patches are preserved: the stub `ios/adapty_flutter.podspec` (+ `ios/stub/`) for flutter/flutter#184590, `BlokadaVendorAlias.swift`, and the forked `AdaptySDK-iOS` pin.
- The iOS fork was rebased onto the upstream **4.0.3** tag — branch `blokada/4.0.3-footer-include-background-gate`, revision `ce0a55a8` on `blokadaorg/AdaptySDK-iOS`. It still carries the single commit restoring the `includeBackground` gate on static decorator backgrounds (upstream regression that darkens translucent paywall footers).
- `common/pubspec.yaml` pin → `4.0.4`, `pubspec.lock` follows, stub podspec `s.version` → `4.0.4`.

**`fix(android): pin adapty-bom to the version the Flutter bridge targets`**

- `android/app/build.gradle`: `io.adapty:adapty-bom` 4.1.0 → **4.0.2**, with a comment stating it must equal the BOM in `common/vendor/adapty_flutter/android/build.gradle`.
- `.github/dependabot.yml`: an `ignore` on `io.adapty:adapty-bom` (all update types) plus an `exclude-patterns` entry in the `android-gradle` group. The group exclude matters for the same reason it does for `pigeon`: a grouped PR is recreated whenever one of its members merges, which can drag an otherwise-ignored dependency back in. Remove both when a plugin release makes the BOM independently bumpable.

## Evidence

| Check | Result |
| --- | --- |
| `make -C common test-local` | All tests passed (437) |
| `fvm flutter analyze --no-fatal-warnings --no-fatal-infos` | 442 issues — unchanged from the `main` baseline |
| `node scripts/check-adapty-fallback-version.mjs` | OK, `adapty_flutter 4.0.4` in lockstep across pin / vendored / stub podspec |
| `make build-android-six` (release, **R8**) | `BUILD SUCCESSFUL in 1m 24s` — `:app:minifySixReleaseWithR8` executed and passed, `:app:bundleSixRelease` produced the bundle |
| `make build-android-six-debug` | `BUILD SUCCESSFUL in 10s` |
| `make -C common build-ios` + `xcodebuild -scheme Dev -sdk iphonesimulator` | `** BUILD SUCCEEDED **`; SwiftPM resolved `AdaptySDK-iOS @ ce0a55a` as intended |

The release build is the one that matters: it is the exact task (`:app:minifySixReleaseWithR8`) that has been red on `main`.

## Device sign-off before merge

This is a payment-surface change and CI cannot validate any of it — CI proves it compiles and links, nothing more. Both platforms move their native Adapty SDK, so both need a pass on a real device:

**iOS** (native SDK 4.0.2 → 4.0.3 via the rebased fork)
- [x] Paywall displays, and the translucent footer still renders un-darkened (this is what the fork patch exists for — a regression here means the rebase lost the `includeBackground` commit)
- [ ] Sandbox purchase completes and unlocks the entitlement
- [ ] Restore purchases works

**Android** (BOM 4.1.0 → 4.0.2)
- [x] Paywall displays
- [x] Sandbox purchase completes and unlocks the entitlement
- [ ] Restore purchases works

Note for the Android restore check: plugin 4.0.4 changes `restorePurchases()` on Android so that it no longer throws `noPurchasesToRestore` when there is nothing to restore — it completes with the current profile instead. We do not reference that error code anywhere in the app (`grep` is clean), so no code change was needed, but the empty-restore path is worth a look. The same release also moves the native Android SDK to Google Play Billing 8, which drops the purchase-history API: subscriptions that expired before Adapty was integrated can no longer be imported from the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jZQTfdiZFeRcZEWApW4nd
