### PR TITLE
feat(family): confirm before an incoming link re-homes a device

### DIFF
--- a/common/lib/src/app_variants/family/module/auth/actor.dart
+++ b/common/lib/src/app_variants/family/module/auth/actor.dart
@@ -28,7 +28,7 @@ class AuthActor with Logging, Actor {
   _recheckToken(Marker m) async {
     final token = await _currentToken.fetch(m);
     if (token != null) {
-      log(Markers.auth).i("current token is $token");
+      log(Markers.auth).i("found a current token");
       try {
         useToken(token, m);
         startHeartbeat();

--- a/common/lib/src/app_variants/family/module/device_v3/actor.dart
+++ b/common/lib/src/app_variants/family/module/device_v3/actor.dart
@@ -30,6 +30,7 @@ class AlreadyLinkedException implements Exception {
 class DeviceActor with Logging, Actor {
   late final _devices = Core.get<DeviceApi>();
   late final _thisDevice = Core.get<ThisDevice>();
+  late final _wasSetUp = Core.get<WasSetUp>();
   late final _nextAlias = Core.get<NameGenerator>();
   late final _profiles = Core.get<ProfileActor>();
 
@@ -79,7 +80,12 @@ class DeviceActor with Logging, Actor {
           m);
 
       await _thisDevice.change(m, newDevice);
+      await _wasSetUp.change(m, true);
       devices = await _devices.fetch(m);
+    } else {
+      // Backfill for installs predating WasSetUp: a device that is already in
+      // the account is set up, whatever the flag currently says.
+      await _wasSetUp.change(m, true);
     }
   }
 
@@ -130,21 +136,19 @@ class DeviceActor with Logging, Actor {
     return d;
   }
 
-  setThisDeviceForLinked(DeviceTag tag, String token, Marker m) async {
+  setThisDeviceForLinked(DeviceTag tag, String token, Marker m,
+      {bool confirmed = false}) async {
     final devices = await _devices.fetchByToken(tag, token, m);
     final d = devices.firstWhereOrNull((it) => it.deviceTag == tag);
     if (d == null) throw Exception("Device $tag not found");
 
-    final thisDevice = await _thisDevice.now();
+    final thisDevice = await _thisDevice.fetch(m);
     if (thisDevice?.deviceTag == tag) return;
 
-    // If we were linked to another device, we cant change it now
-    if (thisDevice != null) {
-      // If the linked device got deleted, allow to re-link
-      final confirmedThisDevice = devices
-          .firstWhereOrNull((it) => it.deviceTag == thisDevice.deviceTag);
-      if (confirmedThisDevice != null) throw AlreadyLinkedException();
-    }
+    // Re-homing onto another account needs the user's answer. Compared against
+    // locally persisted state, not the incoming token's device list.
+    if (thisDevice != null && !confirmed) throw AlreadyLinkedException();
+
     await _thisDevice.change(m, d);
   }
 

--- a/common/lib/src/app_variants/family/module/device_v3/device.dart
+++ b/common/lib/src/app_variants/family/module/device_v3/device.dart
@@ -20,6 +20,7 @@ class DeviceModule with Module {
   @override
   onCreateModule() async {
     await register(CurrentToken());
+    await register(WasSetUp());
     await register(SelectedDeviceTag());
     await register(SlidableOnboarding());
     await register(NameGenerator());

--- a/common/lib/src/app_variants/family/module/device_v3/value.dart
+++ b/common/lib/src/app_variants/family/module/device_v3/value.dart
@@ -10,6 +10,13 @@ class SelectedDeviceTag extends NullableAsyncValue<DeviceTag> {
   }
 }
 
+/// True once this device has been set up, as a linked child or as a parent
+/// with its own controller device. Never cleared on token expiry, so a wiped
+/// token cannot make a set up device look fresh to the link confirmation.
+class WasSetUp extends BoolPersistedValue {
+  WasSetUp() : super("was_set_up");
+}
+
 class SlidableOnboarding extends BoolPersistedValue {
   SlidableOnboarding() : super("slidable_onboarding");
 }

--- a/common/lib/src/app_variants/family/module/family/command.dart
+++ b/common/lib/src/app_variants/family/module/family/command.dart
@@ -13,10 +13,8 @@ class FamilyCommand with Command {
   Future<void> cmdLink(Marker m, dynamic args) async {
     final url = args[0] as String;
 
-    // When entering from a camera app qr code scan, this will be called
-    // by the OS very early, and since onStartApp is executed async to not
-    // block the UI thread, we need to wait for the app to be ready.
-    await sleepAsync(const Duration(seconds: 3));
-    return await _actor.link(url, m);
+    // A camera-app QR scan calls this before the app is ready, so the link is
+    // parked. The family UI resolves it once mounted, a real readiness signal.
+    return await _actor.requestLink(url, m);
   }
 }

--- a/common/lib/src/app_variants/family/module/family/family.dart
+++ b/common/lib/src/app_variants/family/module/family/family.dart
@@ -33,6 +33,7 @@ class FamilyModule with Module {
     await register(ParentDeviceProtectionOwnerValue());
     await register(FamilyActor());
     await register(FamilyLinkedMode());
+    await register(PendingLinkValue());
     await register(LinkActor());
     await register(FamilyCommand());
     await register(FamilySheetActor());

--- a/common/lib/src/app_variants/family/module/family/link_actor.dart
+++ b/common/lib/src/app_variants/family/module/family/link_actor.dart
@@ -3,17 +3,54 @@ part of 'family.dart';
 const familyLinkBase = "https://go.blokada.org/family/link_device";
 const linkTemplate = "$familyLinkBase?token=TOKEN";
 
+// AsyncValue.fetch can stall behind a racing in-flight fetch. Bound it so the
+// confirmation decision always completes.
+const _predicateTimeout = Duration(seconds: 5);
+
+// Three base64url segments. The token is only structurally validated here;
+// the API is the authority on whether it is genuine.
+final _jwtFormat = RegExp(r'^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$');
+
+/// Extracts the enrolment token from an incoming link.
+///
+/// Accepts the canonical `familyLinkBase?token=...` URL and the bare token that
+/// the Android CommandActivity delivers. Returns null for anything else.
+String? parseFamilyLinkToken(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return null;
+
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+    if (!trimmed.startsWith(familyLinkBase)) return null;
+    final uri = Uri.tryParse(trimmed);
+    if (uri == null) return null;
+    final token = uri.queryParameters["token"];
+    if (token == null) return null;
+    return _jwtFormat.hasMatch(token) ? token : null;
+  }
+
+  return _jwtFormat.hasMatch(trimmed) ? trimmed : null;
+}
+
 class LinkActor with Logging, Actor {
   late final _stage = Core.get<StageStore>();
 
   late final _device = Core.get<DeviceActor>();
   late final _auth = Core.get<AuthActor>();
   late final _thisDevice = Core.get<ThisDevice>();
+  late final _currentToken = Core.get<CurrentToken>();
+  late final _account = Core.get<AccountStore>();
+  late final _wasSetUp = Core.get<WasSetUp>();
 
   late final linkedMode = Core.get<FamilyLinkedMode>();
+  late final pendingLink = Core.get<PendingLinkValue>();
 
   bool linkedTokenOk = false;
   String onboardLinkTemplate = linkTemplate;
+
+  // Claimed synchronously so check-and-claim cannot interleave. PendingLinkValue
+  // reports present == null until its first change resolves, so it cannot be
+  // the authority for "is a link already awaiting an answer".
+  String? _claimedLink;
 
   LinkingDevice? _linkingDevice;
   var linkDeviceHeartbeatReceived = () {};
@@ -21,11 +58,18 @@ class LinkActor with Logging, Actor {
 
   @override
   onCreate(Marker m) async {
-    _auth.onTokenExpired = (m) {
+    _auth.onTokenExpired = (m) async {
       log(m).i("token expired");
       linkedTokenOk = false;
       linkedMode.now = false;
-      _thisDevice.change(m, null);
+      // Only a device that already held state was set up. useToken validates a
+      // candidate token before persisting it, so a rejected first link reaches
+      // here with nothing stored. Recorded before the wipe clears the evidence.
+      if (await _currentToken.fetch(m) != null ||
+          await _thisDevice.fetch(m) != null) {
+        await _wasSetUp.change(m, true);
+      }
+      await _thisDevice.change(m, null);
     };
     _auth.onTokenRefreshed = (m) {
       log(m).i("token refreshed");
@@ -43,7 +87,7 @@ class LinkActor with Logging, Actor {
           ? await _device.addDevice(deviceName, profile, m)
           : LinkingDevice(device: device, relink: true);
       d.token = await _auth.createToken(d.device.deviceTag, m);
-      log(m).i("Linking device ${d.device.deviceTag} token: ${d.token}");
+      log(m).i("Linking device ${d.device.deviceTag}");
       _linkingDevice = d;
       _device.onHeartbeat = (tag) => _finishLinkDevice(m, tag);
       _device.startHeartbeatMonitoring(d.device.deviceTag, m);
@@ -135,13 +179,90 @@ class LinkActor with Logging, Actor {
     return onboardLinkTemplate.replaceAll("TOKEN", token.urlEncode);
   }
 
-  link(String qrUrl, Marker m) async {
+  /// True when this device has state worth protecting. WasSetUp survives a
+  /// token wipe; ThisDevice and CurrentToken do not, and a refresh failure
+  /// clears both. Do not gate on FamilyPhase or linkedMode, which default to
+  /// the "not set up" value early in boot and would fail open.
+  Future<bool> needsConfirmation(Marker m) async {
+    try {
+      // Read the stored account, not the loaded one: a link can arrive before
+      // startup resolves it, and type reports libre while unresolved. On iOS
+      // the account survives a reinstall that wipes the device state below.
+      if (_account.type.isActive()) return true;
+      if (await _account
+          .hasActivePersistedAccount(m)
+          .timeout(_predicateTimeout)) {
+        return true;
+      }
+
+      if (await _wasSetUp.fetch(m).timeout(_predicateTimeout)) return true;
+
+      final device = await _thisDevice.fetch(m).timeout(_predicateTimeout);
+      if (device != null) return true;
+      final token = await _currentToken.fetch(m).timeout(_predicateTimeout);
+      return token != null;
+    } catch (e) {
+      // A racing in-flight fetch can stall. Fail closed: an extra confirmation
+      // is a nuisance, a silent re-home is not.
+      log(m).e(msg: "needsConfirmation failed, assuming set up: $e");
+      return true;
+    }
+  }
+
+  /// Parks an incoming link. Nothing is persisted until the user answers.
+  ///
+  /// One at a time: a second link arriving while the first still awaits an
+  /// answer is dropped, rather than replacing it under an open prompt. The
+  /// user re-scans if they meant the newer one.
+  Future<void> requestLink(String rawInput, Marker m) async {
+    return await log(m).trace("requestLink", (m) async {
+      final token = parseFamilyLinkToken(rawInput);
+      if (token == null) {
+        // The Android scanner and CommandActivity call this command directly
+        // and discard the result, so a throw alone fails silently for them.
+        await _stage.showModal(StageModal.fault, m);
+        throw Exception("Malformed family link");
+      }
+      if (_claimedLink != null) {
+        log(m).i("a link already awaits an answer, dropping the new one");
+        return;
+      }
+      _claimedLink = token;
+      await pendingLink.change(m, token);
+    });
+  }
+
+  /// Both answers carry the token the prompt was raised for, so an answer can
+  /// only ever consume the link it was shown for.
+  Future<void> cancelPendingLink(String token, Marker m) async {
+    return await log(m).trace("cancelPendingLink", (m) async {
+      if (_claimedLink != token) return;
+      _claimedLink = null;
+      await pendingLink.change(m, null);
+    });
+  }
+
+  Future<void> confirmPendingLink(String token, Marker m) async {
+    if (_claimedLink != token) return;
+    try {
+      await pendingLink.change(m, null);
+      return await _commitLink(token, m);
+    } finally {
+      // Held across the commit: useToken and setThisDeviceForLinked persist
+      // separately, so a link accepted mid-commit could pair one family's
+      // token with another's device tag.
+      _claimedLink = null;
+    }
+  }
+
+  Future<void> _commitLink(String token, Marker m) async {
     return await log(m).trace("link", (m) async {
       try {
-        final token = qrUrl.split("?token=").last;
         final deviceTag = await _auth.useToken(token, m);
-        log(m).i("received proper token for device: $deviceTag: $token");
-        await _device.setThisDeviceForLinked(deviceTag, token, m);
+        log(m).i("received proper token for device: $deviceTag");
+        await _device.setThisDeviceForLinked(deviceTag, token, m,
+            confirmed: true);
+        await _wasSetUp.change(m, true);
         _auth.startHeartbeat();
         linkedTokenOk = true;
         linkedMode.now = true;

--- a/common/lib/src/app_variants/family/module/family/value.dart
+++ b/common/lib/src/app_variants/family/module/family/value.dart
@@ -23,3 +23,12 @@ class ParentDeviceProtectionOwnerValue extends Value<ParentDeviceProtectionOwner
 class FamilyLinkedMode extends Value<bool> {
   FamilyLinkedMode() : super(load: () => false);
 }
+
+/// The enrolment token from an incoming link, parked until the UI is mounted
+/// and the user has answered. Deliberately in-memory: a link the user never
+/// answered must not survive an app restart.
+class PendingLinkValue extends NullableAsyncValue<String> {
+  PendingLinkValue() : super(sensitive: true) {
+    load = (Marker m) async => null;
+  }
+}

--- a/common/lib/src/app_variants/family/widget/home/home_screen.dart
+++ b/common/lib/src/app_variants/family/widget/home/home_screen.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:common/src/shared/navigation.dart';
 import 'package:common/src/features/home/ui/header/header.dart';
 import 'package:common/src/core/core.dart';
 import 'package:common/src/app_variants/family/module/family/family.dart';
 import 'package:common/src/app_variants/family/widget/home/home_devices.dart';
+import 'package:common/src/app_variants/family/widget/home/link_confirm.dart';
 import 'package:common/src/app_variants/family/widget/home/smart_onboard.dart';
 import 'package:common/src/platform/app/app.dart';
 import 'package:common/src/platform/stage/stage.dart';
@@ -23,6 +26,9 @@ class FamilyHomeScreenState extends State<FamilyHomeScreen>
   late final _phase = Core.get<FamilyPhaseValue>();
   late final _devices = Core.get<FamilyDevicesValue>();
   late final _parentDeviceProtectionOwner = Core.get<ParentDeviceProtectionOwnerValue>();
+  late final _pendingLink = Core.get<PendingLinkValue>();
+  late final _link = Core.get<LinkActor>();
+  String? _promptedFor;
 
   @override
   void initState() {
@@ -33,6 +39,63 @@ class FamilyHomeScreenState extends State<FamilyHomeScreen>
     disposeLater(_parentDeviceProtectionOwner.onChange.listen(rebuild));
     reactionOnStore((_) => _stage.route, rebuild);
     reactionOnStore((_) => _stage.isReady, rebuild);
+    disposeLater(_pendingLink.onChange.listen((_) => _resolvePendingLink()));
+    // A link parked before this screen mounted (cold start from a QR scan or
+    // a tapped link) emits no change event, so check once on mount too.
+    WidgetsBinding.instance.addPostFrameCallback((_) => _resolvePendingLink());
+  }
+
+  Future<void> _resolvePendingLink() async {
+    final token = _pendingLink.present;
+    if (token == null) {
+      _promptedFor = null;
+      return;
+    }
+    // Both the value listener and the post-frame callback can reach here for
+    // the same token. Key the guard on the token so the dialog shows once.
+    if (_promptedFor == token) return;
+    _promptedFor = token;
+
+    await log(Markers.ui).trace("resolvePendingLink", (m) async {
+      final needsConfirm = await _link.needsConfirmation(m);
+      // A newer link can replace the pending value while the predicate runs.
+      // Only the resolve that still owns it may prompt or commit, so two links
+      // never raise two prompts.
+      if (_pendingLink.present != token) return;
+
+      if (!needsConfirm) {
+        await _finishPendingLink((m) => _link.confirmPendingLink(token, m));
+        return;
+      }
+      // Unmounted before the prompt: release the link so a later scan of the
+      // same token is not swallowed by an unanswerable parked value.
+      if (!mounted) {
+        await _link.cancelPendingLink(token, m);
+        return;
+      }
+      // Not awaited on purpose: the dialog outlives this trace, and it resolves
+      // its own outcome, treating a barrier dismissal as a cancel.
+      unawaited(showLinkConfirmDialog(
+        context,
+        onConfirm: () =>
+            _finishPendingLink((m) => _link.confirmPendingLink(token, m)),
+        onCancel: () =>
+            _finishPendingLink((m) => _link.cancelPendingLink(token, m)),
+      ));
+    });
+  }
+
+  // The dialog callbacks are fire-and-forget, so a throwing commit would raise
+  // an unhandled async error. _commitLink already surfaces a fault modal.
+  Future<void> _finishPendingLink(Future<void> Function(Marker) action) async {
+    try {
+      await log(Markers.ui).trace("finishPendingLink", (m) async {
+        await action(m);
+      });
+    } catch (e) {
+      // _commitLink already showed a fault modal, but never stay silent.
+      log(Markers.ui).e(msg: "finishPendingLink failed", err: e);
+    }
   }
 
   @override

--- a/common/lib/src/app_variants/family/widget/home/link_confirm.dart
+++ b/common/lib/src/app_variants/family/widget/home/link_confirm.dart
@@ -1,0 +1,46 @@
+import 'package:common/src/core/core.dart';
+import 'package:common/src/shared/ui/dialog.dart';
+import 'package:flutter/material.dart';
+
+/// Confirmation shown before an incoming link re-homes an already set up
+/// device. The confirm action is red, matching the delete confirms. The dialog
+/// is barrier dismissible, so an unanswered close counts as a cancel.
+Future<void> showLinkConfirmDialog(
+  BuildContext context, {
+  required Function() onConfirm,
+  required Function() onCancel,
+}) async {
+  var answered = false;
+
+  await showDefaultDialog(
+    context,
+    title: Text("family link confirm header".i18n),
+    content: (context) => Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text("family link confirm body".i18n),
+      ],
+    ),
+    actions: (context) => [
+      TextButton(
+        onPressed: () {
+          answered = true;
+          Navigator.of(context).pop();
+          onCancel();
+        },
+        child: Text("universal action cancel".i18n),
+      ),
+      TextButton(
+        onPressed: () {
+          answered = true;
+          Navigator.of(context).pop();
+          onConfirm();
+        },
+        child: Text("family link confirm action".i18n,
+            style: const TextStyle(color: Colors.red)),
+      ),
+    ],
+  );
+
+  if (!answered) onCancel();
+}

--- a/common/lib/src/app_variants/family/widget/home/qr_scan_sheet_macos.dart
+++ b/common/lib/src/app_variants/family/widget/home/qr_scan_sheet_macos.dart
@@ -58,26 +58,29 @@ class QrScanSheetMacosState extends State<QrScanSheetMacos> with Logging {
   Future<void> _handleLink(String url) async {
     if (url.isEmpty) return;
 
+    // Validated before the sheet closes, so a malformed link still gets the
+    // inline error. Past this point requestLink can raise the confirmation
+    // dialog, and the pop below would then close that dialog instead.
+    if (parseFamilyLinkToken(url) == null) {
+      setState(() {
+        _errorMessage = "Invalid link. Please check and try again.".i18n;
+      });
+      return;
+    }
+
     setState(() {
       _isProcessing = true;
       _errorMessage = null;
     });
 
+    Navigator.of(context).pop();
     try {
       await log(Markers.userTap).trace("macosLinkSubmit", (m) async {
-        await _familyLink.link(url, m);
+        await _familyLink.requestLink(url, m);
       });
-
-      if (mounted) {
-        Navigator.of(context).pop();
-      }
     } catch (e) {
-      if (mounted) {
-        setState(() {
-          _errorMessage = "Invalid link. Please check and try again.".i18n;
-          _isProcessing = false;
-        });
-      }
+      // The sheet is gone, so there is nowhere left to show this.
+      log(Markers.userTap).e(msg: "macosLinkSubmit failed", err: e);
     }
   }
 

--- a/common/lib/src/core/config.dart
+++ b/common/lib/src/core/config.dart
@@ -12,7 +12,9 @@ class CoreConfig {
   Duration refreshVeryFrequent = const Duration(seconds: 5);
   Duration refreshOnHome = const Duration(seconds: 15);
 
-  bool obfuscateSensitiveParams = false;
+  // Starts on in release so a cold start cannot log a token before ConfigActor
+  // resolves the log level. ConfigActor only ever relaxes this.
+  bool obfuscateSensitiveParams = kReleaseMode;
 
   CoreConfig();
 

--- a/common/lib/src/platform/account/account.dart
+++ b/common/lib/src/platform/account/account.dart
@@ -264,6 +264,19 @@ abstract class AccountStoreBase with Store, Logging, Actor, Emitter {
     }
   }
 
+  /// Whether an active account is stored on this device, read from
+  /// persistence rather than from the loaded state. Callers that must decide
+  /// before startup has resolved the account cannot use [type], which reports
+  /// libre while unresolved.
+  Future<bool> hasActivePersistedAccount(Marker m) async {
+    try {
+      return (await _readPersistedAccount(m)).type.isActive();
+    } catch (e) {
+      // Nothing stored, or unreadable: this device has no account of its own.
+      return false;
+    }
+  }
+
   Future<AccountState> _readPersistedAccount(Marker m) async {
     final accJson = await _persistence.loadJson(m, keyAccount, isBackup: true);
     final jsonAccount = JsonAccount.fromJson(accJson);

--- a/common/lib/src/platform/command/command.dart
+++ b/common/lib/src/platform/command/command.dart
@@ -172,14 +172,8 @@ class CommandStore with Logging, Actor implements CommandEvents {
   _executeUrl(String url, Marker m) async {
     try {
       if (url.startsWith(familyLinkBase)) {
-        // Family link device
-        final tag = url.split("tag=").last.split("&").first.trim();
-        final name = url.split("name=").last.urlDecode.trim();
-        if (tag.isEmpty || name.isEmpty) {
-          throw Exception("Unknown familyLink token parameters");
-        }
-
-        return await onCommandWithParam("FAMILYLINK", tag, m);
+        // Validated properly in LinkActor; here we only route.
+        return await onCommandWithParam("FAMILYLINK", url, m);
         // } else if (url.startsWith(onboardLinkBase)) {
         //   // Show onboard
         //   final screen = url.split("screen=").last.trim();

--- a/common/lib/src/shared/ui/dialog.dart
+++ b/common/lib/src/shared/ui/dialog.dart
@@ -507,13 +507,15 @@ void showErrorDialog(BuildContext context, String? description) {
   );
 }
 
-void showDefaultDialog(
+// Returns when the dialog closes, including a barrier dismissal that answered
+// neither action, so callers that must react to "no answer" can await it.
+Future<void> showDefaultDialog(
   context, {
   required Text title,
   required Widget Function(BuildContext) content,
   required List<Widget> Function(BuildContext) actions,
 }) {
-  io.Platform.isIOS || io.Platform.isMacOS
+  return io.Platform.isIOS || io.Platform.isMacOS
       ? showCupertinoDialog<String>(
           context: context,
           barrierDismissible: true,

--- a/common/test/app_variants/family/module/device_v3/actor_test.dart
+++ b/common/test/app_variants/family/module/device_v3/actor_test.dart
@@ -21,7 +21,10 @@ JsonDevice _device({
       modeUntil: modeUntil,
       retention: '24h',
       profileId: profileId,
-    );
+    )
+      // late field, only assigned by fromJson. Persisting calls toJson, so a
+      // constructor-built fixture needs it set explicitly.
+      ..lastHeartbeat = '2026-01-01T00:00:00Z';
 
 JsonProfile _profile(String id) => JsonProfile(
       profileId: id,
@@ -98,4 +101,93 @@ void main() {
       });
     });
   });
+  group('DeviceActor.setThisDeviceForLinked re-home guard', () {
+    test('refuses an unconfirmed re-home onto a different account', () async {
+      await withTrace((m) async {
+        Core.register<DeviceApi>(_ListingDeviceApi([_device(tag: 'attacker-tag')]));
+
+        Core.register<Persistence>(Persistence(isSecure: false));
+        final thisDevice = ThisDevice();
+        Core.register<ThisDevice>(thisDevice);
+        // This device already belongs to another family account. That tag is
+        // absent from the incoming account's list, which is exactly the case
+        // the old guard could not see.
+        await thisDevice.change(m, _device(tag: 'victim-tag'));
+
+        final actor = DeviceActor();
+
+        await expectLater(
+          actor.setThisDeviceForLinked('attacker-tag', 'token', m),
+          throwsA(isA<AlreadyLinkedException>()),
+        );
+
+        final after = await thisDevice.fetch(m);
+        expect(after?.deviceTag, 'victim-tag');
+      });
+    });
+
+    test('allows a confirmed re-home', () async {
+      await withTrace((m) async {
+        Core.register<DeviceApi>(_ListingDeviceApi([_device(tag: 'new-tag')]));
+
+        Core.register<Persistence>(Persistence(isSecure: false));
+        final thisDevice = ThisDevice();
+        Core.register<ThisDevice>(thisDevice);
+        await thisDevice.change(m, _device(tag: 'old-tag'));
+
+        final actor = DeviceActor();
+        await actor.setThisDeviceForLinked('new-tag', 'token', m, confirmed: true);
+
+        final after = await thisDevice.fetch(m);
+        expect(after?.deviceTag, 'new-tag');
+      });
+    });
+
+    test('is idempotent for the tag already persisted', () async {
+      await withTrace((m) async {
+        final same = _device(tag: 'same-tag');
+        Core.register<DeviceApi>(_ListingDeviceApi([same]));
+
+        Core.register<Persistence>(Persistence(isSecure: false));
+        final thisDevice = ThisDevice();
+        Core.register<ThisDevice>(thisDevice);
+        await thisDevice.change(m, same);
+
+        final actor = DeviceActor();
+        await actor.setThisDeviceForLinked('same-tag', 'token', m);
+
+        final after = await thisDevice.fetch(m);
+        expect(after?.deviceTag, 'same-tag');
+      });
+    });
+
+    test('links a fresh device with no confirmation', () async {
+      await withTrace((m) async {
+        Core.register<DeviceApi>(_ListingDeviceApi([_device(tag: 'fresh-tag')]));
+
+        Core.register<Persistence>(Persistence(isSecure: false));
+        final thisDevice = ThisDevice();
+        Core.register<ThisDevice>(thisDevice);
+
+        final actor = DeviceActor();
+        await actor.setThisDeviceForLinked('fresh-tag', 'token', m);
+
+        final after = await thisDevice.fetch(m);
+        expect(after?.deviceTag, 'fresh-tag');
+      });
+    });
+  });
+
+}
+
+/// Returns a fixed device list for fetchByToken, standing in for the account
+/// that the incoming enrolment token belongs to.
+class _ListingDeviceApi extends DeviceApi {
+  final List<JsonDevice> devices;
+  _ListingDeviceApi(this.devices);
+
+  @override
+  Future<List<JsonDevice>> fetchByToken(
+          DeviceTag tag, String token, Marker m) async =>
+      devices;
 }

--- a/common/test/app_variants/family/module/family/link_actor_test.dart
+++ b/common/test/app_variants/family/module/family/link_actor_test.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
 import 'package:common/src/app_variants/family/module/auth/auth.dart';
 import 'package:common/src/app_variants/family/module/device_v3/device.dart';
 import 'package:common/src/app_variants/family/module/family/family.dart';
 import 'package:common/src/app_variants/family/module/profile/profile.dart';
 import 'package:common/src/core/core.dart';
+import 'package:common/src/platform/account/account.dart';
+import 'package:common/src/platform/stage/channel.pg.dart';
+import 'package:common/src/platform/stage/stage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -12,6 +16,9 @@ import '../../../../tools.dart';
 @GenerateNiceMocks([
   MockSpec<DeviceActor>(),
   MockSpec<AuthActor>(),
+  MockSpec<StageStore>(),
+  MockSpec<AccountStore>(),
+  MockSpec<AccountState>(),
 ])
 import 'link_actor_test.mocks.dart';
 
@@ -189,6 +196,369 @@ void main() {
       });
     });
   });
+
+  group('LinkActor pending link', () {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJkZXZpY2VfdGFnIjoiYWJjIn0.c2lnbmF0dXJl';
+    const otherJwt =
+        'eyJhbGciOiJIUzI1NiJ9.eyJkZXZpY2VfdGFnIjoieHl6In0.b3RoZXJzaWc';
+
+    Future<LinkActor> setUpActor({
+      required MockDeviceActor device,
+      required MockAuthActor auth,
+      JsonDevice? persistedThisDevice,
+      String? persistedToken,
+      AccountType accountType = AccountType.libre,
+      bool persistedAccountActive = false,
+      bool wasSetUp = false,
+      required Marker m,
+    }) async {
+      Core.register<DeviceActor>(device);
+      Core.register<AuthActor>(auth);
+      Core.register<StageStore>(MockStageStore());
+      final account = MockAccountStore();
+      when(account.type).thenReturn(accountType);
+      when(account.hasActivePersistedAccount(any))
+          .thenAnswer((_) async => persistedAccountActive);
+      Core.register<AccountStore>(account);
+      // ThisDevice and CurrentToken read through Persistence, which withTrace
+      // does not register. The channel it registers is an in-memory map.
+      Core.register<Persistence>(Persistence(isSecure: false));
+
+      final thisDevice = ThisDevice();
+      Core.register<ThisDevice>(thisDevice);
+      if (persistedThisDevice != null) {
+        await thisDevice.change(m, persistedThisDevice);
+      }
+
+      final setUpFlag = WasSetUp();
+      Core.register<WasSetUp>(setUpFlag);
+      if (wasSetUp) await setUpFlag.change(m, true);
+
+      final currentToken = CurrentToken();
+      Core.register<CurrentToken>(currentToken);
+      if (persistedToken != null) {
+        await currentToken.change(m, persistedToken);
+      }
+
+      Core.register<FamilyLinkedMode>(FamilyLinkedMode());
+      Core.register<PendingLinkValue>(PendingLinkValue());
+      return LinkActor();
+    }
+
+    test('an active family account needs confirmation with no local state',
+        () async {
+      await withTrace((m) async {
+        // Regression: an iOS reinstall restores the account id from the
+        // keychain while ThisDevice and CurrentToken go with the sandbox. The
+        // device is a set up parent but looks fresh to persistence, and the
+        // link used to commit with no prompt.
+        final actor = await setUpActor(
+            device: MockDeviceActor(),
+            auth: MockAuthActor(),
+            accountType: AccountType.family,
+            m: m);
+        expect(await actor.needsConfirmation(m), isTrue);
+      });
+    });
+
+    test('a stored account needs confirmation before startup loads it',
+        () async {
+      await withTrace((m) async {
+        // A link can arrive before bootstrap resolves the account, and type
+        // reports libre until it does. The stored account is the iOS reinstall
+        // case: it survives the wipe that clears the device state.
+        final actor = await setUpActor(
+            device: MockDeviceActor(),
+            auth: MockAuthActor(),
+            persistedAccountActive: true,
+            m: m);
+        expect(await actor.needsConfirmation(m), isTrue);
+      });
+    });
+
+    test('a device set up before needs confirmation after a token wipe',
+        () async {
+      await withTrace((m) async {
+        // A failed token refresh clears ThisDevice and CurrentToken, and a
+        // linked child holds a libre account, so WasSetUp is the only signal
+        // left that this device has something to lose.
+        final actor = await setUpActor(
+            device: MockDeviceActor(),
+            auth: MockAuthActor(),
+            wasSetUp: true,
+            m: m);
+        expect(await actor.needsConfirmation(m), isTrue);
+      });
+    });
+
+    test('token expiry backfills the setup flag on an upgraded install',
+        () async {
+      await withTrace((m) async {
+        // Installs predating WasSetUp carry the flag false while holding a
+        // device and token. Expiry wipes both, so the flag has to be recorded
+        // while we still know the device was set up.
+        final auth = MockAuthActor();
+        final actor = await setUpActor(
+            device: MockDeviceActor(),
+            auth: auth,
+            persistedThisDevice: _device('kid-tag', 'Kid', 'child-profile'),
+            persistedToken: 'kid-token',
+            m: m);
+        await actor.onCreate(m);
+
+        final expire =
+            verify(auth.onTokenExpired = captureAny).captured.last as Function;
+        await expire(m);
+
+        expect(await Core.get<WasSetUp>().fetch(m), isTrue);
+      });
+    });
+
+    test('a second link while one awaits an answer is dropped', () async {
+      await withTrace((m) async {
+        // Replacing the pending value under an open prompt is what produced
+        // stacked dialogs and answers landing on the wrong token. One at a
+        // time removes that at the source.
+        final actor = await setUpActor(
+            device: MockDeviceActor(), auth: MockAuthActor(), m: m);
+
+        await actor.requestLink(jwt, m);
+        await actor.requestLink(otherJwt, m);
+
+        expect(Core.get<PendingLinkValue>().present, jwt);
+      });
+    });
+
+    test('concurrent links before the value resolves still claim once',
+        () async {
+      await withTrace((m) async {
+        // PendingLinkValue reports present == null until its first change
+        // resolves, so a null check on it lets two cold-start links through.
+        // The claim is synchronous and cannot interleave.
+        final actor = await setUpActor(
+            device: MockDeviceActor(), auth: MockAuthActor(), m: m);
+
+        await Future.wait([
+          actor.requestLink(jwt, m),
+          actor.requestLink(otherJwt, m),
+        ]);
+
+        expect(Core.get<PendingLinkValue>().present, jwt);
+      });
+    });
+
+    test('a link arriving mid-commit is dropped', () async {
+      await withTrace((m) async {
+        // The claim is held across _commitLink. useToken and
+        // setThisDeviceForLinked persist separately, so a link accepted while
+        // they are in flight could pair one family's token with another's tag.
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        final inFlight = Completer<DeviceTag>();
+        when(auth.useToken(any, any)).thenAnswer((_) => inFlight.future);
+
+        final actor = await setUpActor(device: device, auth: auth, m: m);
+
+        await actor.requestLink(jwt, m);
+        final commit = actor.confirmPendingLink(jwt, m);
+
+        await actor.requestLink(otherJwt, m);
+        expect(Core.get<PendingLinkValue>().present, isNull);
+
+        inFlight.complete('new-tag');
+        await commit;
+
+        verify(auth.useToken(jwt, any)).called(1);
+        verifyNever(auth.useToken(otherJwt, any));
+      });
+    });
+
+    test('confirming a stale prompt does not commit a newer link', () async {
+      await withTrace((m) async {
+        // Defence in depth behind the one-at-a-time rule: an answer only ever
+        // consumes the token its prompt was raised for.
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        when(auth.useToken(any, any)).thenAnswer((_) async => 'new-tag');
+
+        final actor = await setUpActor(
+            device: device, auth: auth, m: m);
+
+        await Core.get<PendingLinkValue>().change(m, otherJwt);
+        await actor.confirmPendingLink(jwt, m);
+
+        verifyNever(auth.useToken(any, any));
+        expect(Core.get<PendingLinkValue>().present, otherJwt);
+      });
+    });
+
+    test('a rejected first link does not mark a fresh device as set up',
+        () async {
+      await withTrace((m) async {
+        // useToken validates before persisting, so an expired or unreachable
+        // candidate reaches the expiry callback with nothing stored. Marking
+        // that device set up would put the re-home prompt on its first link.
+        final auth = MockAuthActor();
+        final actor = await setUpActor(
+            device: MockDeviceActor(), auth: auth, m: m);
+        await actor.onCreate(m);
+
+        final expire =
+            verify(auth.onTokenExpired = captureAny).captured.last as Function;
+        await expire(m);
+
+        expect(await Core.get<WasSetUp>().fetch(m), isFalse);
+      });
+    });
+
+    test('a fresh device needs no confirmation', () async {
+      await withTrace((m) async {
+        final actor = await setUpActor(
+            device: MockDeviceActor(), auth: MockAuthActor(), m: m);
+        expect(await actor.needsConfirmation(m), isFalse);
+      });
+    });
+
+    test('an already linked child needs confirmation', () async {
+      await withTrace((m) async {
+        final actor = await setUpActor(
+          device: MockDeviceActor(),
+          auth: MockAuthActor(),
+          persistedToken: 'existing-token',
+          m: m,
+        );
+        expect(await actor.needsConfirmation(m), isTrue);
+      });
+    });
+
+    test('a configured parent device needs confirmation', () async {
+      await withTrace((m) async {
+        final actor = await setUpActor(
+          device: MockDeviceActor(),
+          auth: MockAuthActor(),
+          persistedThisDevice: _device('parent-tag', 'Parent', 'p'),
+          m: m,
+        );
+        expect(await actor.needsConfirmation(m), isTrue);
+      });
+    });
+
+    test('requestLink parks the token without linking', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        final actor = await setUpActor(device: device, auth: auth, m: m);
+
+        await actor.requestLink('$familyLinkBase?token=$jwt', m);
+
+        expect(Core.get<PendingLinkValue>().present, jwt);
+        verifyNever(auth.useToken(any, any));
+        verifyNever(device.setThisDeviceForLinked(any, any, any,
+            confirmed: anyNamed('confirmed')));
+      });
+    });
+
+    test('requestLink rejects malformed input without parking it', () async {
+      await withTrace((m) async {
+        final actor = await setUpActor(
+            device: MockDeviceActor(), auth: MockAuthActor(), m: m);
+
+        await expectLater(actor.requestLink('not-a-token', m), throwsException);
+        expect(Core.get<PendingLinkValue>().present, isNull);
+        // Android's scanner and CommandActivity invoke FAMILYLINK directly and
+        // drop the result, so without this the scan fails with no feedback.
+        verify((Core.get<StageStore>() as MockStageStore)
+                .showModal(StageModal.fault, any))
+            .called(1);
+      });
+    });
+
+    test('cancelPendingLink persists nothing', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        final actor = await setUpActor(
+          device: device,
+          auth: auth,
+          persistedToken: 'existing-token',
+          m: m,
+        );
+
+        await actor.requestLink(jwt, m);
+        await actor.cancelPendingLink(jwt, m);
+
+        expect(Core.get<PendingLinkValue>().present, isNull);
+        // The regression found in manual testing: a rejected link must not
+        // have overwritten the persisted token on the way in.
+        expect(await Core.get<CurrentToken>().fetch(m), 'existing-token');
+        verifyNever(auth.useToken(any, any));
+        verifyNever(device.setThisDeviceForLinked(any, any, any,
+            confirmed: anyNamed('confirmed')));
+      });
+    });
+
+    test('confirmPendingLink commits with confirmed: true', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        when(auth.useToken(any, any)).thenAnswer((_) async => 'new-tag');
+
+        final actor = await setUpActor(
+          device: device,
+          auth: auth,
+          persistedThisDevice: _device('old-tag', 'Old', 'p'),
+          m: m,
+        );
+
+        await actor.requestLink(jwt, m);
+        await actor.confirmPendingLink(jwt, m);
+
+        verify(auth.useToken(jwt, any)).called(1);
+        verify(device.setThisDeviceForLinked('new-tag', jwt, any,
+                confirmed: true))
+            .called(1);
+        expect(Core.get<PendingLinkValue>().present, isNull);
+      });
+    });
+
+    test('a failed useToken leaves nothing behind', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        when(auth.useToken(any, any)).thenThrow(Exception('inactive account'));
+
+        final actor = await setUpActor(
+          device: device,
+          auth: auth,
+          persistedToken: 'existing-token',
+          m: m,
+        );
+
+        await actor.requestLink(jwt, m);
+        await expectLater(actor.confirmPendingLink(jwt, m), throwsException);
+
+        expect(Core.get<PendingLinkValue>().present, isNull);
+        verifyNever(device.setThisDeviceForLinked(any, any, any,
+            confirmed: anyNamed('confirmed')));
+      });
+    });
+
+    test('cmdLink parks the link instead of linking immediately', () async {
+      await withTrace((m) async {
+        final device = MockDeviceActor();
+        final auth = MockAuthActor();
+        final actor = await setUpActor(device: device, auth: auth, m: m);
+        Core.register<LinkActor>(actor);
+
+        final command = FamilyCommand();
+        await command.cmdLink(m, ['$familyLinkBase?token=$jwt']);
+
+        expect(Core.get<PendingLinkValue>().present, jwt);
+        verifyNever(auth.useToken(any, any));
+      });
+    });
+  });
+
 }
 
 JsonDevice _device(String tag, String alias, String profileId) {
@@ -198,7 +568,10 @@ JsonDevice _device(String tag, String alias, String profileId) {
     mode: JsonDeviceMode.on,
     retention: '24h',
     profileId: profileId,
-  );
+  )
+    // late field, only assigned by fromJson. Persisting calls toJson, so a
+    // constructor-built fixture needs it set explicitly.
+    ..lastHeartbeat = '2026-01-01T00:00:00Z';
 }
 
 JsonProfile _profile(String id, String alias) {

--- a/common/test/app_variants/family/module/family/link_parse_test.dart
+++ b/common/test/app_variants/family/module/family/link_parse_test.dart
@@ -1,0 +1,54 @@
+import 'package:common/src/app_variants/family/module/family/family.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// A structurally valid JWT: three base64url segments. Not signed, not real.
+const _jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJkZXZpY2VfdGFnIjoiYWJjIn0.c2lnbmF0dXJl';
+
+void main() {
+  group('parseFamilyLinkToken', () {
+    test('extracts the token from a canonical link', () {
+      expect(parseFamilyLinkToken('$familyLinkBase?token=$_jwt'), _jwt);
+    });
+
+    test('accepts a bare token, as delivered by Android CommandActivity', () {
+      expect(parseFamilyLinkToken(_jwt), _jwt);
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(parseFamilyLinkToken('  $_jwt  '), _jwt);
+    });
+
+    test('ignores extra query parameters but still requires token', () {
+      expect(parseFamilyLinkToken('$familyLinkBase?name=Kid&token=$_jwt'), _jwt);
+    });
+
+    test('rejects a link on another host', () {
+      expect(
+        parseFamilyLinkToken(
+            'https://evil.example/family/link_device?token=$_jwt'),
+        isNull,
+      );
+    });
+
+    test('rejects a link with no token parameter', () {
+      expect(parseFamilyLinkToken('$familyLinkBase?tag=abc&name=Kid'), isNull);
+    });
+
+    test('rejects an empty token parameter', () {
+      expect(parseFamilyLinkToken('$familyLinkBase?token='), isNull);
+    });
+
+    test('rejects a bare string that is not a JWT', () {
+      expect(parseFamilyLinkToken('not-a-token'), isNull);
+    });
+
+    test('rejects empty input', () {
+      expect(parseFamilyLinkToken(''), isNull);
+      expect(parseFamilyLinkToken('   '), isNull);
+    });
+
+    test('rejects an unparseable uri', () {
+      expect(parseFamilyLinkToken('https://['), isNull);
+    });
+  });
+}

--- a/common/test/app_variants/family/widget/home/qr_scan_sheet_macos_test.dart
+++ b/common/test/app_variants/family/widget/home/qr_scan_sheet_macos_test.dart
@@ -1,0 +1,122 @@
+import 'package:common/src/app_variants/family/module/family/family.dart';
+import 'package:common/src/app_variants/family/widget/home/qr_scan_sheet_macos.dart';
+import 'package:common/src/core/core.dart';
+import 'package:common/src/shared/ui/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import '../../../../tools.dart';
+
+@GenerateNiceMocks([
+  MockSpec<LinkActor>(),
+])
+import 'qr_scan_sheet_macos_test.mocks.dart';
+
+const _validLink =
+    "https://go.blokada.org/family/link_device?token=aaa.bbb.ccc";
+
+const _dialogKey = Key('link-confirm-stand-in');
+
+Widget _wrap(GlobalKey<NavigatorState> navKey) => MaterialApp(
+      navigatorKey: navKey,
+      theme: ThemeData(
+        extensions: const [
+          BlokadaTheme(
+            bgColor: Colors.black,
+            bgColorHome1: Colors.black,
+            bgColorHome2: Colors.black,
+            bgColorHome3: Colors.black,
+            bgColorCard: Colors.black,
+            panelBackground: Colors.black,
+            cloud: Colors.blue,
+            accent: Colors.blue,
+            freemium: Colors.orange,
+            shadow: Colors.black,
+            bgMiniCard: Colors.black,
+            textPrimary: Colors.white,
+            textSecondary: Colors.white70,
+            divider: Colors.grey,
+          ),
+        ],
+      ),
+      home: const Scaffold(body: SizedBox.shrink()),
+    );
+
+// Pushes the sheet the way the home screen does, on top of a base route, so
+// the test can tell "the sheet closed" apart from "the navigator emptied".
+Future<void> _pushSheet(
+    WidgetTester tester, GlobalKey<NavigatorState> navKey) async {
+  navKey.currentState!.push(
+    MaterialPageRoute(builder: (_) => const QrScanSheetMacos()),
+  );
+  await tester.pumpAndSettle();
+}
+
+// Pumps fixed frames rather than settling: the sheet swaps its buttons for a
+// CupertinoActivityIndicator while processing, and that spins forever, so
+// pumpAndSettle would time out instead of reporting the assertion that failed.
+Future<void> _submit(WidgetTester tester, String text) async {
+  await tester.enterText(find.byType(TextField), text);
+  await tester.testTextInput.receiveAction(TextInputAction.done);
+  for (var i = 0; i < 4; i++) {
+    await tester.pump(const Duration(milliseconds: 300));
+  }
+}
+
+void main() {
+  group('QrScanSheetMacos', () {
+    testWidgets('a valid link closes the sheet without closing the '
+        'confirmation raised while it commits', (tester) async {
+      await withTrace((_) async {
+        final navKey = GlobalKey<NavigatorState>();
+        final link = MockLinkActor();
+        Core.register<LinkActor>(link);
+        Core.register<FamilyLinkedMode>(FamilyLinkedMode());
+
+        // Stands in for the home screen, which raises the confirmation as soon
+        // as requestLink publishes the pending link. Popping after this point
+        // would take the dialog instead of the sheet.
+        when(link.requestLink(any, any)).thenAnswer((_) async {
+          navKey.currentState!.push(DialogRoute<void>(
+            context: navKey.currentContext!,
+            builder: (_) => const SizedBox(key: _dialogKey),
+          ));
+        });
+
+        await tester.pumpWidget(_wrap(navKey));
+        await _pushSheet(tester, navKey);
+        expect(find.byType(QrScanSheetMacos), findsOneWidget);
+
+        await _submit(tester, _validLink);
+
+        verify(link.requestLink(_validLink, any)).called(1);
+        expect(find.byType(QrScanSheetMacos), findsNothing);
+        expect(find.byKey(_dialogKey), findsOneWidget);
+      });
+    });
+
+    testWidgets('a malformed link keeps the sheet open and is never published',
+        (tester) async {
+      await withTrace((_) async {
+        final navKey = GlobalKey<NavigatorState>();
+        final link = MockLinkActor();
+        Core.register<LinkActor>(link);
+        Core.register<FamilyLinkedMode>(FamilyLinkedMode());
+
+        await tester.pumpWidget(_wrap(navKey));
+        await _pushSheet(tester, navKey);
+
+        await _submit(tester, "https://example.com/not-a-family-link");
+
+        verifyNever(link.requestLink(any, any));
+        expect(find.byType(QrScanSheetMacos), findsOneWidget);
+        expect(
+          find.text("Invalid link. Please check and try again."),
+          findsOneWidget,
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
Closes the gap where a `link_device` link, QR code or intent moved this device onto the account in the incoming token with no user confirmation.

Ref: blokadaorg/issue-tracker#346

## Problem

Two independent defects, both on `main` before this change:

1. **The link committed before it was validated.** `LinkActor.link` called `AuthActor.useToken` (which persists `CurrentToken` and fires `onTokenRefreshed`) *before* `setThisDeviceForLinked` could throw. A rejected link had already overwritten local state, which is why linking with a token from an inactive account showed an error and linked anyway. An ordering defect, not a heartbeat one.
2. **The already-linked guard could not fire across accounts.** It fetched the device list with the *incoming* token and asked that account whether it knew this device's tag, which it never does. The guard only ever fired when re-scanning a different device's QR from the same account.

## Change

- Incoming links park in `PendingLinkValue` (in memory, so an unanswered link does not survive a restart). Nothing is persisted until the user answers.
- The re-home guard compares against the locally persisted `ThisDevice`, and `setThisDeviceForLinked` requires `confirmed: true`, which only the post-confirmation path passes. Any future caller fails closed.
- A confirmation with a red confirm action is shown when the device is already set up. A genuinely fresh device still links with no friction, so child onboarding is unchanged.
- The dialog resolves from `FamilyHomeScreen`, which has a `BuildContext` and cannot be silently deferred the way a `StageModal` is when the stage is not yet foreground. Barrier dismissal and unmount both count as cancel.
- Input parsing accepts the canonical URL with a `token` parameter or the bare token `CommandActivity` delivers, both required to be structurally a JWT. This replaces `tag=`/`name=` parsing that never matched a real link.
- The fixed 3s sleep in `cmdLink` is gone; it started before `runApp` and was never a readiness signal.

### The confirmation predicate

ORs four signals: `WasSetUp`, an active account, `ThisDevice`, `CurrentToken`.

`WasSetUp` is new and persisted, set on a completed link and on parent setup, and never cleared on token expiry. It is load-bearing: a failed token refresh clears both `ThisDevice` and `CurrentToken`, and a linked child holds a `libre` account, so without it a device with plenty to lose reads as fresh. An unresolved account also counts as set up, because `AccountStore.type` reports `libre` before it loads and that is indistinguishable from a real free account.

`FamilyPhase`, `linkedMode` and `DnsPerm` are deliberately not used. They default to the "not set up" value early in boot and would fail open.

## Entry channels

iOS universal link, iOS and Android QR, Android `CommandActivity` intent, and the macOS paste sheet all route through `requestLink`. `CommandActivity` keeps its export and intent filters, so App Store and go.blokada.org links keep working.

## Also fixed

The enrolment token reached the shareable support log in cleartext at info level from two sites that bypassed the `sensitive:` obfuscation. That obfuscation now starts on in release rather than being switched on once `ConfigActor` resolves the log level, which a cold start could beat.

## Verification

463 tests pass, `flutter analyze` reports 0 errors.

On a physical Android device: fresh install links with no dialog, an already-linked child prompts, cancel leaves `this_device` untouched in `shared_prefs`, confirm re-homes, a cold start still prompts, and a barrier dismissal releases the link so a re-scan prompts again.

On a physical iPhone: a reinstalled parent, whose account survives in the keychain while local device state does not, now prompts. That case was found on device and is what the `WasSetUp` and account signals exist for.

## Follow-ups, not in this PR

- `AuthActor._refreshToken` treats any exception, including a network error, as an expired token and discards it (it already carries a `// TODO: may be too aggressive`). That is the root cause of the state-wipe this PR defends against, and changing when auth discards a token deserves its own change.
- A second link parked while the dialog is open stacks a second identical dialog. No privilege gain, but the UX is wrong.
- Inactive-account enforcement at link time is deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EmNq3GBfy9hU3Q8bGk6xSF