### PR TITLE
Revert cached_network_image 4.0.0 (breaks on-device navigation)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
         # with the ignore when the pigeon 26 native migration is scheduled.
         exclude-patterns:
           - "pigeon"
+          - "cached_network_image"
         update-types:
           - "minor"
           - "patch"
@@ -36,6 +37,12 @@ updates:
       # dev-only codegen tool; held — see closed PR #1106. Remove this when
       # that migration is scheduled.
       - dependency-name: "pigeon"
+        update-types: ["version-update:semver-major"]
+      # cached_network_image 4.0.0 breaks on-device navigation (settings screen
+      # never renders; smoke red on run #… 2026-09-02) and drags in the new
+      # material_ui / cupertino_ui split-out packages. Held at 3.x until 4.x is
+      # dep-validated on device. Remove when that lands. See the #1238 revert.
+      - dependency-name: "cached_network_image"
         update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "gradle"

--- a/common/pubspec.lock
+++ b/common/pubspec.lock
@@ -116,26 +116,26 @@ packages:
     dependency: "direct main"
     description:
       name: cached_network_image
-      sha256: "03d9cff3f68ded9e7c5588ebe7fc8650a669192685e59d2d2413d7813b286d6b"
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "3.4.1"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
-      sha256: ff60d021d5a013490368cd9efdcbe35df4227fdb6c5971d15b4bc6e3d0172fe0
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "4.1.1"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
-      sha256: c8edf00f48d91bc469731e4fb095350b0162e18efe2cf0054cb40c62d1a1f70a
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -224,14 +224,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
-  cupertino_ui:
-    dependency: transitive
-    description:
-      name: cupertino_ui
-      sha256: "2137c0d41f3b62cc4d3d2495e6c354bd6b6133cd21c6bb155736cc31dbd49a11"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   dart_style:
     dependency: transitive
     description:
@@ -596,14 +588,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.0"
-  material_ui:
-    dependency: transitive
-    description:
-      name: material_ui
-      sha256: "7ba1ca315d50a004791dbab290417c52a61466d56db2822fe3c5c2994903110c"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.0"
   meta:
     dependency: "direct main"
     description:

--- a/common/pubspec.yaml
+++ b/common/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   logger: ^2.4.0
   adapty_flutter: 4.0.4
   flutter_linkify: ^6.0.0
-  cached_network_image: ">=3.3.1 <5.0.0"
+  cached_network_image: ">=3.3.1 <4.0.0" # 4.0.0 breaks navigation on device (drags material_ui/cupertino_ui); see #1238 revert
   web_socket_channel: ^3.0.3
   meta: ^1.15.0
 


### PR DESCRIPTION
The iOS physical-device smoke went red on **every** spec on the commit that merged #1238 (`build(deps): bump cached_network_image 3.4.1 → 4.0.0`), green on the commit immediately before it. Failure is identical across all 11 specs: the Settings screen never renders after the home gear is tapped (`element ("~automation.screen_settings") still not existing after 15000ms`), so no spec can seed its account — a build/app break, not a flaky element. [Failing run](https://github.com/blokadaorg/blokada/actions/runs/33667221904).

`cached_network_image` 4.0.0 is a brand-new major (published 2026-08-28; Baseflow's GitHub shows no 4.0.0 release), pulls in the new `material_ui` / `cupertino_ui` split-out packages, and bumps `cached_network_image_platform_interface` to 5.0.0. CI is build + lint only, so it merged green; the device smoke is the first thing that exercised it.

## What this does
- Reverts #1238 (pubspec + lock back to `cached_network_image` 3.4.1; `material_ui` / `cupertino_ui` gone from the lock).
- Tightens the constraint to `">=3.3.1 <4.0.0"` so `pub get` can't re-pick 4.x.
- Holds the 4.x major in Dependabot: an `ignore` on `cached_network_image` semver-major plus a `flutter-dependencies` group exclusion (same trap as pigeon — a group recreation would otherwise re-widen it). Drop both once 4.x is dep-validated on device.

Not related to the retention feature (issue-tracker#300) — that code is intact on `main`; this just unblocks cutting a release build with a green smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019jZQTfdiZFeRcZEWApW4nd