### PR TITLE
fix(account): show the account-expired notification once per lapse

### DIFF
--- a/common/lib/src/core/config.dart
+++ b/common/lib/src/core/config.dart
@@ -8,9 +8,10 @@ class CoreConfig {
   // How long one lapse owns the "account expired" notification. The backend
   // restamps active_until on every repeat webhook for a lapsed account, so the
   // expiry cannot key the guard; this floor does. Longer than any restamp
-  // burst, far shorter than the shortest paid plan, and a renewal clears the
-  // mark anyway.
-  Duration accountExpiredNotificationCooldown = const Duration(days: 7);
+  // burst, and short enough that it cannot reach the next lapse of the shortest
+  // billing period sold, which is weekly. A renewal clears the mark anyway, but
+  // only if the app sees it, so the floor does not lean on that.
+  Duration accountExpiredNotificationCooldown = const Duration(hours: 72);
   Duration deviceRefreshCooldown = const Duration(seconds: 60);
   Duration plusLeaseRefreshCooldown = const Duration(seconds: 60);
   Duration plusGatewayRefreshCooldown = const Duration(seconds: 60);

--- a/common/lib/src/core/config.dart
+++ b/common/lib/src/core/config.dart
@@ -4,6 +4,13 @@ class CoreConfig {
   Duration appStartFailWait = const Duration(seconds: 5);
   Duration accountExpiringTimeSpan = const Duration(seconds: 30);
   Duration accountRefreshCooldown = const Duration(seconds: 60);
+
+  // How long one lapse owns the "account expired" notification. The backend
+  // restamps active_until on every repeat webhook for a lapsed account, so the
+  // expiry cannot key the guard; this floor does. Longer than any restamp
+  // burst, far shorter than the shortest paid plan, and a renewal clears the
+  // mark anyway.
+  Duration accountExpiredNotificationCooldown = const Duration(days: 7);
   Duration deviceRefreshCooldown = const Duration(seconds: 60);
   Duration plusLeaseRefreshCooldown = const Duration(seconds: 60);
   Duration plusGatewayRefreshCooldown = const Duration(seconds: 60);

--- a/common/lib/src/core/config.dart
+++ b/common/lib/src/core/config.dart
@@ -5,13 +5,13 @@ class CoreConfig {
   Duration accountExpiringTimeSpan = const Duration(seconds: 30);
   Duration accountRefreshCooldown = const Duration(seconds: 60);
 
-  // How long one lapse owns the "account expired" notification. The backend
-  // restamps active_until on every repeat webhook for a lapsed account, so the
-  // expiry cannot key the guard; this floor does. Longer than any restamp
-  // burst, and short enough that it cannot reach the next lapse of the shortest
-  // billing period sold, which is weekly. A renewal clears the mark anyway, but
-  // only if the app sees it, so the floor does not lean on that.
-  Duration accountExpiredNotificationCooldown = const Duration(hours: 72);
+  // How long after an expiry the OS notification scheduled for it is assumed to
+  // have been delivered, so the push announcing the same expiry stays quiet.
+  // Bounded because arming an alarm is not delivering one: Android drops
+  // pending alarms on reboot and nothing re-arms them for an account that has
+  // already expired, leaving the push as the only thing that can announce that
+  // lapse. Past this window it does, rather than trusting the record.
+  Duration accountExpiryScheduledGrace = const Duration(hours: 6);
   Duration deviceRefreshCooldown = const Duration(seconds: 60);
   Duration plusLeaseRefreshCooldown = const Duration(seconds: 60);
   Duration plusGatewayRefreshCooldown = const Duration(seconds: 60);

--- a/common/lib/src/core/config.dart
+++ b/common/lib/src/core/config.dart
@@ -4,14 +4,6 @@ class CoreConfig {
   Duration appStartFailWait = const Duration(seconds: 5);
   Duration accountExpiringTimeSpan = const Duration(seconds: 30);
   Duration accountRefreshCooldown = const Duration(seconds: 60);
-
-  // How long after an expiry the OS notification scheduled for it is assumed to
-  // have been delivered, so the push announcing the same expiry stays quiet.
-  // Bounded because arming an alarm is not delivering one: Android drops
-  // pending alarms on reboot and nothing re-arms them for an account that has
-  // already expired, leaving the push as the only thing that can announce that
-  // lapse. Past this window it does, rather than trusting the record.
-  Duration accountExpiryScheduledGrace = const Duration(hours: 6);
   Duration deviceRefreshCooldown = const Duration(seconds: 60);
   Duration plusLeaseRefreshCooldown = const Duration(seconds: 60);
   Duration plusGatewayRefreshCooldown = const Duration(seconds: 60);

--- a/common/lib/src/platform/account/refresh/json.dart
+++ b/common/lib/src/platform/account/refresh/json.dart
@@ -4,20 +4,43 @@ class JsonAccRefreshMeta {
   late AccountType? previousAccountType;
   late bool seenExpiredDialog;
 
+  /// When the immediate expiry notification was last shown, ISO-8601.
+  ///
+  /// Not keyed by the expiry itself: the backend restamps active_until to now
+  /// on every repeat webhook for a lapsed account, so a per-expiry key would be
+  /// a different value every time. A time floor is what actually dedupes.
+  late String? expiryNotifiedAt;
+
+  /// The expiry the OS notification was last scheduled for, ISO-8601.
+  ///
+  /// The scheduled notification and the immediate one are the same lapse seen
+  /// twice, so the immediate path checks this too.
+  late String? expiryScheduledFor;
+
   JsonAccRefreshMeta({
     this.previousAccountType,
     this.seenExpiredDialog = false,
+    this.expiryNotifiedAt,
+    this.expiryScheduledFor,
   });
 
   JsonAccRefreshMeta.fromJson(Map<String, dynamic> json) {
     previousAccountType = accountTypeFromName(json['previousAccountType']);
     seenExpiredDialog = json['seenExpiredDialog'] ?? false;
+    expiryNotifiedAt = _string(json['expiryNotifiedAt']);
+    expiryScheduledFor = _string(json['expiryScheduledFor']);
   }
 
   Map<String, dynamic> toJson() {
     final data = <String, dynamic>{};
     data['previousAccountType'] = previousAccountType?.toSimpleString();
     data['seenExpiredDialog'] = seenExpiredDialog;
+    data['expiryNotifiedAt'] = expiryNotifiedAt;
+    data['expiryScheduledFor'] = expiryScheduledFor;
     return data;
   }
+
+  // Stored metadata predates both timestamps, and a bad value must not brick
+  // the guard, so anything that is not a string reads as absent.
+  static String? _string(dynamic value) => value is String ? value : null;
 }

--- a/common/lib/src/platform/account/refresh/json.dart
+++ b/common/lib/src/platform/account/refresh/json.dart
@@ -11,24 +11,16 @@ class JsonAccRefreshMeta {
   /// next lapse re-arms itself by carrying a different active_until.
   late String? expiryNotifiedFor;
 
-  /// The expiry the OS notification was last scheduled for, ISO-8601.
-  ///
-  /// The scheduled notification and the immediate one are the same lapse seen
-  /// twice, so the immediate path checks this too.
-  late String? expiryScheduledFor;
-
   JsonAccRefreshMeta({
     this.previousAccountType,
     this.seenExpiredDialog = false,
     this.expiryNotifiedFor,
-    this.expiryScheduledFor,
   });
 
   JsonAccRefreshMeta.fromJson(Map<String, dynamic> json) {
     previousAccountType = accountTypeFromName(json['previousAccountType']);
     seenExpiredDialog = json['seenExpiredDialog'] ?? false;
     expiryNotifiedFor = _string(json['expiryNotifiedFor']);
-    expiryScheduledFor = _string(json['expiryScheduledFor']);
   }
 
   Map<String, dynamic> toJson() {
@@ -36,11 +28,10 @@ class JsonAccRefreshMeta {
     data['previousAccountType'] = previousAccountType?.toSimpleString();
     data['seenExpiredDialog'] = seenExpiredDialog;
     data['expiryNotifiedFor'] = expiryNotifiedFor;
-    data['expiryScheduledFor'] = expiryScheduledFor;
     return data;
   }
 
-  // Stored metadata predates both timestamps, and a bad value must not brick
+  // Stored metadata predates this timestamp, and a bad value must not brick
   // the guard, so anything that is not a string reads as absent.
   static String? _string(dynamic value) => value is String ? value : null;
 }

--- a/common/lib/src/platform/account/refresh/json.dart
+++ b/common/lib/src/platform/account/refresh/json.dart
@@ -4,12 +4,12 @@ class JsonAccRefreshMeta {
   late AccountType? previousAccountType;
   late bool seenExpiredDialog;
 
-  /// When the immediate expiry notification was last shown, ISO-8601.
+  /// The expiry the immediate notification last announced, ISO-8601.
   ///
-  /// Not keyed by the expiry itself: the backend restamps active_until to now
-  /// on every repeat webhook for a lapsed account, so a per-expiry key would be
-  /// a different value every time. A time floor is what actually dedupes.
-  late String? expiryNotifiedAt;
+  /// Keyed by what was announced rather than when, so one lapse gets one
+  /// notification however many times the server dispatches for it, and the
+  /// next lapse re-arms itself by carrying a different active_until.
+  late String? expiryNotifiedFor;
 
   /// The expiry the OS notification was last scheduled for, ISO-8601.
   ///
@@ -20,14 +20,14 @@ class JsonAccRefreshMeta {
   JsonAccRefreshMeta({
     this.previousAccountType,
     this.seenExpiredDialog = false,
-    this.expiryNotifiedAt,
+    this.expiryNotifiedFor,
     this.expiryScheduledFor,
   });
 
   JsonAccRefreshMeta.fromJson(Map<String, dynamic> json) {
     previousAccountType = accountTypeFromName(json['previousAccountType']);
     seenExpiredDialog = json['seenExpiredDialog'] ?? false;
-    expiryNotifiedAt = _string(json['expiryNotifiedAt']);
+    expiryNotifiedFor = _string(json['expiryNotifiedFor']);
     expiryScheduledFor = _string(json['expiryScheduledFor']);
   }
 
@@ -35,7 +35,7 @@ class JsonAccRefreshMeta {
     final data = <String, dynamic>{};
     data['previousAccountType'] = previousAccountType?.toSimpleString();
     data['seenExpiredDialog'] = seenExpiredDialog;
-    data['expiryNotifiedAt'] = expiryNotifiedAt;
+    data['expiryNotifiedFor'] = expiryNotifiedFor;
     data['expiryScheduledFor'] = expiryScheduledFor;
     return data;
   }

--- a/common/lib/src/platform/account/refresh/refresh.dart
+++ b/common/lib/src/platform/account/refresh/refresh.dart
@@ -118,6 +118,7 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
   bool _initSuccessful = false;
 
   JsonAccRefreshMeta _metadata = JsonAccRefreshMeta();
+  bool _metadataLoaded = false;
 
   // Init the account with a retry loop. Can be called multiple times if failed.
   @override
@@ -174,14 +175,11 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
         log(m).i("creating new account");
         await _account.createAccount(m);
         _metadata = JsonAccRefreshMeta();
+        _metadataLoaded = true;
         await _persistence.delete(m, _keyRefresh);
         await syncAccount(_account.account, m);
       } else {
-        final metadataJson = await _persistence.load(m, _keyRefresh);
-        if (metadataJson != null) {
-          _metadata = JsonAccRefreshMeta.fromJson(jsonDecode(metadataJson));
-        }
-
+        await _ensureMetadataLoaded(m);
         await syncAccount(_account.account ?? cachedAccount, m);
       }
 
@@ -224,7 +222,7 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       final hasExp = account.jsonAccount.activeUntil != null;
       DateTime? exp = hasExp ? DateTime.parse(account.jsonAccount.activeUntil!) : null;
       expiration = expiration.update(expiration: exp);
-      _updateTimer(m);
+      await _updateTimer(m);
 
       // Track the previous account type so that we can notice when user upgrades
       final prev = _metadata.previousAccountType;
@@ -292,7 +290,7 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       } else {
         // Even when not refreshing, recheck the expiration on foreground
         expiration = expiration.update();
-        _updateTimer(m);
+        await _updateTimer(m);
       }
     });
   }
@@ -300,6 +298,9 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
   @action
   Future<void> onAccountExpiryEvent(Marker m) async {
     return await log(m).trace("onAccountExpiryEvent", (m) async {
+      // A background FCM can land before init() ran, and the guard below must
+      // not read (or save over) defaults.
+      await _ensureMetadataLoaded(m);
       // Account-expiry FCM events signal that account state changed remotely.
       await _account.fetch(m);
       await syncAccount(_account.account, m);
@@ -308,13 +309,67 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
   }
 
   Future<void> _maybeShowImmediateAccountExpiryNotification(Marker m) async {
+    // Leaving linked mode has to re-arm this, so never record anything here.
     if (_shouldSkipExpiryNotification()) return;
 
     final activeUntil = _account.account?.jsonAccount.activeUntil;
-    final scheduledAt = resolveAccountExpirySchedule(activeUntil, DateTime.now());
-    if (scheduledAt != null) return;
+    final now = DateTime.now();
+    final parsed = _parseDate(activeUntil);
+    // No usable expiry means no expiry to announce.
+    if (parsed == null) {
+      log(m).i("accountExpiry:skipNotification:noExpiry");
+      return;
+    }
+    // Still active, the scheduled notification owns this one.
+    if (parsed.isAfter(now)) return;
+
+    final reason = _expiryNotificationSkipReason(now);
+    if (reason != null) {
+      log(m).pair("skipNotification", reason);
+      return;
+    }
 
     await _notification.show(_accountExpiryNotificationId(), m);
+    _metadata.expiryNotifiedAt = now.toIso8601String();
+    await _saveMetadata(m);
+  }
+
+  // One lapse gets one notification. The backend restamps active_until on every
+  // repeat webhook for a lapsed account, so the expiry itself cannot key this;
+  // a time floor can, and a renewal clears the mark in _updateTimer.
+  String? _expiryNotificationSkipReason(DateTime now) {
+    final cooldown = Core.config.accountExpiredNotificationCooldown;
+
+    final notifiedAt = _parseDate(_metadata.expiryNotifiedAt);
+    if (notifiedAt != null && now.difference(notifiedAt) < cooldown) {
+      return "alreadyNotified";
+    }
+
+    // The scheduled notification for this lapse has already been delivered by
+    // the OS, so an immediate one now would be the same lapse announced twice.
+    final scheduledFor = _parseDate(_metadata.expiryScheduledFor);
+    if (scheduledFor != null &&
+        !scheduledFor.isAfter(now) &&
+        now.difference(scheduledFor) < cooldown) {
+      return "alreadyScheduled";
+    }
+
+    return null;
+  }
+
+  Future<void> _ensureMetadataLoaded(Marker m) async {
+    if (_metadataLoaded) return;
+    final metadataJson = await _persistence.load(m, _keyRefresh);
+    if (metadataJson != null) {
+      _metadata = JsonAccRefreshMeta.fromJson(jsonDecode(metadataJson));
+    }
+    _metadataLoaded = true;
+  }
+
+  static DateTime? _parseDate(String? value) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.isEmpty) return null;
+    return DateTime.tryParse(trimmed);
   }
 
   NotificationId _accountExpiryNotificationId() {
@@ -325,7 +380,7 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
     return Core.act.isFamily && _linkedMode.now;
   }
 
-  void _updateTimer(Marker m) async {
+  Future<void> _updateTimer(Marker m) async {
     final id = _accountExpiryNotificationId();
     final shouldSkipNotification = _shouldSkipExpiryNotification();
 
@@ -342,6 +397,12 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       _notification.show(id, when: expiration.expiration, m);
       log(m).pair("notificationId", id);
       log(m).pair("notificationDate", expiration.expiration);
+
+      // A future expiry means the previous lapse is over, which is what
+      // re-arms the immediate notification after a renewal.
+      _metadata.expiryScheduledFor = expiration.expiration.toIso8601String();
+      _metadata.expiryNotifiedAt = null;
+      await _saveMetadata(m);
     } else {
       await _scheduler.stop(m, _keyTimer);
       log(m).pair("timer", null);

--- a/common/lib/src/platform/account/refresh/refresh.dart
+++ b/common/lib/src/platform/account/refresh/refresh.dart
@@ -119,6 +119,7 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
 
   JsonAccRefreshMeta _metadata = JsonAccRefreshMeta();
   bool _metadataLoaded = false;
+  Future<void>? _metadataLoading;
 
   // Init the account with a retry loop. Can be called multiple times if failed.
   @override
@@ -329,8 +330,11 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       return;
     }
 
+    // Claim this lapse before awaiting anything. Nothing serializes the FCM
+    // handler, so a burst of pushes would otherwise all pass the check above
+    // while the first one is still waiting on the channel.
+    _metadata.expiryNotifiedAt = now.toUtc().toIso8601String();
     await _notification.show(_accountExpiryNotificationId(), m);
-    _metadata.expiryNotifiedAt = now.toIso8601String();
     await _saveMetadata(m);
   }
 
@@ -357,13 +361,29 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
     return null;
   }
 
-  Future<void> _ensureMetadataLoaded(Marker m) async {
-    if (_metadataLoaded) return;
-    final metadataJson = await _persistence.load(m, _keyRefresh);
-    if (metadataJson != null) {
-      _metadata = JsonAccRefreshMeta.fromJson(jsonDecode(metadataJson));
+  Future<void> _ensureMetadataLoaded(Marker m) {
+    if (_metadataLoaded) return Future.value();
+    return _metadataLoading ??= _loadMetadata(m);
+  }
+
+  Future<void> _loadMetadata(Marker m) async {
+    try {
+      final metadataJson = await _persistence.load(m, _keyRefresh);
+      // A new account may have been created while this load was in flight; its
+      // fresh metadata wins over the blob we just read.
+      if (_metadataLoaded) return;
+      if (metadataJson != null) {
+        _metadata = JsonAccRefreshMeta.fromJson(jsonDecode(metadataJson));
+      }
+    } catch (e) {
+      // A corrupt blob must not take down the expiry event with it: start over
+      // rather than throw before the account is even refreshed.
+      log(m).w("could not read refresh metadata, starting fresh: $e");
+      _metadata = JsonAccRefreshMeta();
+    } finally {
+      _metadataLoaded = true;
+      _metadataLoading = null;
     }
-    _metadataLoaded = true;
   }
 
   static DateTime? _parseDate(String? value) {
@@ -394,14 +414,26 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
         callback: onTimerFired,
       ));
 
-      _notification.show(id, when: expiration.expiration, m);
       log(m).pair("notificationId", id);
       log(m).pair("notificationDate", expiration.expiration);
 
-      // A future expiry means the previous lapse is over, which is what
-      // re-arms the immediate notification after a renewal.
-      _metadata.expiryScheduledFor = expiration.expiration.toIso8601String();
-      _metadata.expiryNotifiedAt = null;
+      try {
+        await _notification.show(id, when: expiration.expiration, m);
+      } catch (e) {
+        // Nothing was scheduled, so do not record one: the immediate
+        // notification is the fallback for exactly this case.
+        log(m).w("could not schedule expiry notification: $e");
+        return;
+      }
+
+      _metadata.expiryScheduledFor = expiration.expiration.toUtc().toIso8601String();
+      // Only a genuinely future expiry ends the lapse and re-arms the immediate
+      // notification. An "expiring" account is seconds from lapsing, and a
+      // restamped active_until can land there on a slow device clock; clearing
+      // the mark then would announce the same lapse twice.
+      if (expiration.status == AccountStatus.active) {
+        _metadata.expiryNotifiedAt = null;
+      }
       await _saveMetadata(m);
     } else {
       await _scheduler.stop(m, _keyTimer);
@@ -418,15 +450,4 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
   _saveMetadata(Marker m) async {
     await _persistence.save(m, _keyRefresh, jsonEncode(_metadata.toJson()));
   }
-}
-
-DateTime? resolveAccountExpirySchedule(String? activeUntil, DateTime now) {
-  final value = activeUntil?.trim();
-  if (value == null || value.isEmpty) return null;
-
-  final parsed = DateTime.tryParse(value);
-  if (parsed == null) return null;
-  if (!parsed.isAfter(now)) return null;
-
-  return parsed;
 }

--- a/common/lib/src/platform/account/refresh/refresh.dart
+++ b/common/lib/src/platform/account/refresh/refresh.dart
@@ -324,9 +324,15 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
     // Still active, the scheduled notification owns this one.
     if (parsed.isAfter(now)) return;
 
-    final reason = _expiryNotificationSkipReason(parsed, now);
-    if (reason != null) {
-      log(m).pair("skipNotification", reason);
+    // One lapse gets one notification, keyed by the expiry it announces rather
+    // than by when it was announced. The value is stable for a lapse and, by
+    // construction, different for the next one, so nothing needs re-arming on
+    // renewal and the client is indifferent to how often the server dispatches.
+    // Instants, not the raw strings: a formatting change on the server side
+    // must not defeat the match.
+    final notifiedFor = _parseDate(_metadata.expiryNotifiedFor);
+    if (notifiedFor != null && notifiedFor.isAtSameMomentAs(parsed)) {
+      log(m).pair("skipNotification", "alreadyNotified");
       return;
     }
 
@@ -344,34 +350,6 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       rethrow;
     }
     await _saveMetadata(m);
-  }
-
-  // One lapse gets one notification, keyed by the expiry it announces rather
-  // than by when it was announced. The value is stable for a lapse and, by
-  // construction, different for the next one, so nothing needs re-arming on
-  // renewal and the client is indifferent to how often the server dispatches.
-  String? _expiryNotificationSkipReason(DateTime expiry, DateTime now) {
-    // Instants, not the raw strings: a formatting change on the server side
-    // must not defeat the match.
-    final notifiedFor = _parseDate(_metadata.expiryNotifiedFor);
-    if (notifiedFor != null && notifiedFor.isAtSameMomentAs(expiry)) {
-      return "alreadyNotified";
-    }
-
-    // The OS notification scheduled for this same expiry has just fired, so
-    // announcing it again now would be the one lapse seen twice. Bounded,
-    // because arming an alarm is not delivering one: Android drops pending
-    // alarms on reboot and _updateTimer will not re-arm an account that has
-    // already expired, which leaves this push as the only thing that can
-    // announce that lapse.
-    final scheduledFor = _parseDate(_metadata.expiryScheduledFor);
-    if (scheduledFor != null &&
-        scheduledFor.isAtSameMomentAs(expiry) &&
-        now.difference(expiry) < Core.config.accountExpiryScheduledGrace) {
-      return "alreadyScheduled";
-    }
-
-    return null;
   }
 
   Future<void> _ensureMetadataLoaded(Marker m) {
@@ -433,14 +411,10 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       try {
         await _notification.show(id, when: expiration.expiration, m);
       } catch (e) {
-        // Nothing was scheduled, so do not record one: the immediate
-        // notification is the fallback for exactly this case.
+        // Awaited so a failed schedule is at least visible; it used to be
+        // dropped on the floor. The immediate notification is the fallback.
         log(m).w("could not schedule expiry notification: $e");
-        return;
       }
-
-      _metadata.expiryScheduledFor = expiration.expiration.toUtc().toIso8601String();
-      await _saveMetadata(m);
     } else {
       await _scheduler.stop(m, _keyTimer);
       log(m).pair("timer", null);

--- a/common/lib/src/platform/account/refresh/refresh.dart
+++ b/common/lib/src/platform/account/refresh/refresh.dart
@@ -324,7 +324,7 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
     // Still active, the scheduled notification owns this one.
     if (parsed.isAfter(now)) return;
 
-    final reason = _expiryNotificationSkipReason(now);
+    final reason = _expiryNotificationSkipReason(parsed, now);
     if (reason != null) {
       log(m).pair("skipNotification", reason);
       return;
@@ -333,28 +333,41 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
     // Claim this lapse before awaiting anything. Nothing serializes the FCM
     // handler, so a burst of pushes would otherwise all pass the check above
     // while the first one is still waiting on the channel.
-    _metadata.expiryNotifiedAt = now.toUtc().toIso8601String();
-    await _notification.show(_accountExpiryNotificationId(), m);
+    final claimed = _metadata.expiryNotifiedFor;
+    _metadata.expiryNotifiedFor = parsed.toUtc().toIso8601String();
+    try {
+      await _notification.show(_accountExpiryNotificationId(), m);
+    } catch (e) {
+      // Nothing was shown, so give the claim back. Left standing it would be
+      // persisted by the next _saveMetadata and silence this lapse for good.
+      _metadata.expiryNotifiedFor = claimed;
+      rethrow;
+    }
     await _saveMetadata(m);
   }
 
-  // One lapse gets one notification. The backend restamps active_until on every
-  // repeat webhook for a lapsed account, so the expiry itself cannot key this;
-  // a time floor can, and a renewal clears the mark in _updateTimer.
-  String? _expiryNotificationSkipReason(DateTime now) {
-    final cooldown = Core.config.accountExpiredNotificationCooldown;
-
-    final notifiedAt = _parseDate(_metadata.expiryNotifiedAt);
-    if (notifiedAt != null && now.difference(notifiedAt) < cooldown) {
+  // One lapse gets one notification, keyed by the expiry it announces rather
+  // than by when it was announced. The value is stable for a lapse and, by
+  // construction, different for the next one, so nothing needs re-arming on
+  // renewal and the client is indifferent to how often the server dispatches.
+  String? _expiryNotificationSkipReason(DateTime expiry, DateTime now) {
+    // Instants, not the raw strings: a formatting change on the server side
+    // must not defeat the match.
+    final notifiedFor = _parseDate(_metadata.expiryNotifiedFor);
+    if (notifiedFor != null && notifiedFor.isAtSameMomentAs(expiry)) {
       return "alreadyNotified";
     }
 
-    // The scheduled notification for this lapse has already been delivered by
-    // the OS, so an immediate one now would be the same lapse announced twice.
+    // The OS notification scheduled for this same expiry has just fired, so
+    // announcing it again now would be the one lapse seen twice. Bounded,
+    // because arming an alarm is not delivering one: Android drops pending
+    // alarms on reboot and _updateTimer will not re-arm an account that has
+    // already expired, which leaves this push as the only thing that can
+    // announce that lapse.
     final scheduledFor = _parseDate(_metadata.expiryScheduledFor);
     if (scheduledFor != null &&
-        !scheduledFor.isAfter(now) &&
-        now.difference(scheduledFor) < cooldown) {
+        scheduledFor.isAtSameMomentAs(expiry) &&
+        now.difference(expiry) < Core.config.accountExpiryScheduledGrace) {
       return "alreadyScheduled";
     }
 
@@ -427,13 +440,6 @@ abstract class AccountRefreshStoreBase with Store, Logging, Actor, Cooldown, Emi
       }
 
       _metadata.expiryScheduledFor = expiration.expiration.toUtc().toIso8601String();
-      // Only a genuinely future expiry ends the lapse and re-arms the immediate
-      // notification. An "expiring" account is seconds from lapsing, and a
-      // restamped active_until can land there on a slow device clock; clearing
-      // the mark then would announce the same lapse twice.
-      if (expiration.status == AccountStatus.active) {
-        _metadata.expiryNotifiedAt = null;
-      }
       await _saveMetadata(m);
     } else {
       await _scheduler.stop(m, _keyTimer);

--- a/common/test/platform/account/refresh/refresh_test.dart
+++ b/common/test/platform/account/refresh/refresh_test.dart
@@ -5,6 +5,7 @@ import 'package:common/src/features/api/domain/api.dart';
 import 'package:common/src/core/core.dart';
 import 'package:common/src/platform/account/account.dart';
 import 'package:common/src/platform/account/api.dart';
+import 'package:common/src/platform/account/refresh/json.dart';
 import 'package:common/src/platform/account/refresh/refresh.dart';
 import 'package:common/src/platform/stage/channel.pg.dart';
 import 'package:common/src/platform/stage/stage.dart';
@@ -400,6 +401,162 @@ void main() {
         ));
       });
     });
+
+    test("onAccountExpiryEvent notifies once for repeated events", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
+
+        await subject.store.onAccountExpiryEvent(m);
+        await subject.store.onAccountExpiryEvent(m);
+
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+      });
+    });
+
+    // The backend restamps active_until to now on every repeat webhook for a
+    // lapsed account, so each event carries a different expiry string. This is
+    // the actual reported bug.
+    test("onAccountExpiryEvent does not renotify when active_until is restamped", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 2)));
+
+        await subject.store.onAccountExpiryEvent(m);
+        subject.account.account = _accountState(
+          activeUntil: _agoUtc(const Duration(seconds: 1)),
+          type: AccountType.libre,
+          active: false,
+        );
+        await subject.store.onAccountExpiryEvent(m);
+
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+      });
+    });
+
+    test(
+      "onAccountExpiryEvent skips the immediate notification after the scheduled one fired",
+      () async {
+        await withTrace((m) async {
+          final subject = _expirySubject(
+            expiredAt: _agoUtc(const Duration(minutes: 5)),
+            metadata: {"expiryScheduledFor": _agoUtc(const Duration(minutes: 5)).toIso8601String()},
+          );
+
+          await subject.store.onAccountExpiryEvent(m);
+
+          verifyNever(subject.notification.show(NotificationId.accountExpired, any));
+        });
+      },
+    );
+
+    test("onAccountExpiryEvent notifies again once the cooldown elapsed", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(
+          expiredAt: _agoUtc(const Duration(days: 30)),
+          metadata: {
+            "expiryNotifiedAt": _agoUtc(const Duration(days: 8)).toIso8601String(),
+            "expiryScheduledFor": _agoUtc(const Duration(days: 30)).toIso8601String(),
+          },
+        );
+
+        await subject.store.onAccountExpiryEvent(m);
+
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+      });
+    });
+
+    test("onAccountExpiryEvent notifies again after a renewal and a later expiry", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
+
+        await subject.store.onAccountExpiryEvent(m);
+
+        // Renewed: a future expiry is scheduled, which ends the lapse.
+        subject.account.account = _accountState(
+          activeUntil: DateTime.now().toUtc().add(const Duration(days: 30)),
+          type: AccountType.plus,
+          active: true,
+        );
+        await subject.store.onAccountExpiryEvent(m);
+
+        // Lapsed again.
+        subject.account.account = _accountState(
+          activeUntil: _agoUtc(const Duration(minutes: 1)),
+          type: AccountType.libre,
+          active: false,
+        );
+        await subject.store.onAccountExpiryEvent(m);
+
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(2);
+      });
+    });
+
+    test("onAccountExpiryEvent does not notify when active_until is missing", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
+        subject.account.account = AccountState(
+          Fixtures.accountId,
+          JsonAccount(
+            id: Fixtures.accountId,
+            activeUntil: null,
+            type: AccountType.libre.name,
+            active: false,
+          ),
+        );
+
+        await subject.store.onAccountExpiryEvent(m);
+
+        verifyNever(subject.notification.show(NotificationId.accountExpired, any));
+      });
+    });
+
+    test("syncAccount records the expiry the notification was scheduled for", () async {
+      await withTrace((m) async {
+        final expiry = DateTime.now().toUtc().add(const Duration(days: 3));
+        final subject = _expirySubject(expiredAt: expiry, type: AccountType.plus, active: true);
+
+        await subject.store.syncAccount(subject.account.account, m);
+
+        final saved = verify(
+          subject.persistence.save(any, "account:refresh", captureAny),
+        ).captured.map((json) => jsonDecode(json as String) as Map<String, dynamic>).toList();
+        expect(saved, isNotEmpty);
+        expect(saved.last["expiryScheduledFor"], expiry.toIso8601String());
+      });
+    });
+  });
+
+  group("JsonAccRefreshMeta", () {
+    test("round trips the expiry guard fields", () {
+      final meta = JsonAccRefreshMeta(
+        previousAccountType: AccountType.plus,
+        seenExpiredDialog: true,
+        expiryNotifiedAt: "2026-02-23T11:30:00.000Z",
+        expiryScheduledFor: "2026-02-20T11:30:00.000Z",
+      );
+
+      final decoded = JsonAccRefreshMeta.fromJson(jsonDecode(jsonEncode(meta.toJson())));
+
+      expect(decoded.previousAccountType, AccountType.plus);
+      expect(decoded.seenExpiredDialog, true);
+      expect(decoded.expiryNotifiedAt, "2026-02-23T11:30:00.000Z");
+      expect(decoded.expiryScheduledFor, "2026-02-20T11:30:00.000Z");
+    });
+
+    test("reads metadata that predates the expiry guard fields", () {
+      final decoded = JsonAccRefreshMeta.fromJson({
+        "previousAccountType": AccountType.plus.toSimpleString(),
+        "seenExpiredDialog": true,
+      });
+
+      expect(decoded.expiryNotifiedAt, isNull);
+      expect(decoded.expiryScheduledFor, isNull);
+    });
+
+    test("treats a non-string stored timestamp as absent", () {
+      final decoded = JsonAccRefreshMeta.fromJson({"expiryNotifiedAt": 42});
+
+      expect(decoded.expiryNotifiedAt, isNull);
+    });
   });
 
   group("resolveAccountExpirySchedule", () {
@@ -492,6 +649,44 @@ Future<void> _expectInvalidCachedAccountCreatesFreshAccount(int code) async {
     expect(account.account?.id, newAccountId);
     expect(account.account?.type, AccountType.libre);
   });
+}
+
+DateTime _agoUtc(Duration ago) => DateTime.now().toUtc().subtract(ago);
+
+class _ExpirySubject {
+  final AccountRefreshStore store;
+  final _TestAccountStore account;
+  final MockNotificationActor notification;
+  final MockPersistence persistence;
+
+  _ExpirySubject(this.store, this.account, this.notification, this.persistence);
+}
+
+// A store wired for the expiry-notification paths, with persistence that
+// answers with the given stored metadata.
+_ExpirySubject _expirySubject({
+  required DateTime expiredAt,
+  AccountType type = AccountType.libre,
+  bool active = false,
+  Map<String, dynamic>? metadata,
+}) {
+  final account = _TestAccountStore();
+  account.account = _accountState(activeUntil: expiredAt, type: type, active: active);
+  when(account.fetch(any)).thenAnswer((_) async {});
+  Core.register<AccountStore>(account);
+
+  final notification = MockNotificationActor();
+  final persistence = MockPersistence();
+  when(
+    persistence.load(any, "account:refresh"),
+  ).thenAnswer((_) async => metadata == null ? null : jsonEncode(metadata));
+  Core.register<NotificationActor>(notification);
+  Core.register<Persistence>(persistence);
+  Core.register<StageStore>(MockStageStore());
+  Core.register<Scheduler>(MockScheduler());
+  Core.register<PlusActor>(MockPlusActor());
+
+  return _ExpirySubject(AccountRefreshStore(), account, notification, persistence);
 }
 
 class _TestAccountStore extends MockAccountStore {

--- a/common/test/platform/account/refresh/refresh_test.dart
+++ b/common/test/platform/account/refresh/refresh_test.dart
@@ -509,6 +509,80 @@ void main() {
       });
     });
 
+    // Nothing serializes the FCM handler, so a burst must not slip two
+    // notifications past the check while the first is still in flight.
+    test("onAccountExpiryEvent notifies once for events that overlap", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
+
+        await Future.wait([
+          subject.store.onAccountExpiryEvent(m),
+          subject.store.onAccountExpiryEvent(m),
+        ]);
+
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+      });
+    });
+
+    // A restamped active_until can land seconds in the future on a slow device
+    // clock, which makes the account "expiring" rather than expired. That must
+    // not count as a renewal.
+    test("onAccountExpiryEvent does not renotify when a restamp lands just in the future",
+        () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
+        await subject.store.onAccountExpiryEvent(m);
+
+        subject.account.account = _accountState(
+          activeUntil: DateTime.now().toUtc().add(const Duration(seconds: 5)),
+          type: AccountType.libre,
+          active: false,
+        );
+        await subject.store.onAccountExpiryEvent(m);
+        subject.account.account = _accountState(
+          activeUntil: _agoUtc(const Duration(seconds: 1)),
+          type: AccountType.libre,
+          active: false,
+        );
+        await subject.store.onAccountExpiryEvent(m);
+
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+      });
+    });
+
+    test("onAccountExpiryEvent survives corrupt stored metadata", () async {
+      await withTrace((m) async {
+        final subject = _expirySubject(
+          expiredAt: _agoUtc(const Duration(hours: 1)),
+          rawMetadata: "{not json",
+        );
+
+        await subject.store.onAccountExpiryEvent(m);
+
+        verify(subject.account.fetch(any)).called(1);
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+      });
+    });
+
+    // The immediate notification is the fallback for a schedule that never
+    // landed, so a failed schedule must not record one.
+    test("syncAccount does not record a scheduled expiry when scheduling failed", () async {
+      await withTrace((m) async {
+        final expiry = DateTime.now().toUtc().add(const Duration(days: 3));
+        final subject = _expirySubject(expiredAt: expiry, type: AccountType.plus, active: true);
+        when(subject.notification.show(any, any, when: anyNamed('when')))
+            .thenAnswer((_) async => throw Exception("no permission"));
+
+        await subject.store.syncAccount(subject.account.account, m);
+
+        final saved = verify(subject.persistence.save(any, "account:refresh", captureAny))
+            .captured
+            .map((json) => jsonDecode(json as String) as Map<String, dynamic>)
+            .toList();
+        expect(saved.every((entry) => entry["expiryScheduledFor"] == null), isTrue);
+      });
+    });
+
     test("syncAccount records the expiry the notification was scheduled for", () async {
       await withTrace((m) async {
         final expiry = DateTime.now().toUtc().add(const Duration(days: 3));
@@ -556,26 +630,6 @@ void main() {
       final decoded = JsonAccRefreshMeta.fromJson({"expiryNotifiedAt": 42});
 
       expect(decoded.expiryNotifiedAt, isNull);
-    });
-  });
-
-  group("resolveAccountExpirySchedule", () {
-    final now = DateTime.utc(2026, 2, 24, 10, 0, 0);
-
-    test("returns date when active_until is in the future", () {
-      final scheduled = resolveAccountExpirySchedule("2026-02-24T12:00:00Z", now);
-      expect(scheduled?.toUtc(), DateTime.utc(2026, 2, 24, 12, 0, 0));
-    });
-
-    test("returns null when active_until is now or in the past", () {
-      expect(resolveAccountExpirySchedule("2026-02-24T10:00:00Z", now), isNull);
-      expect(resolveAccountExpirySchedule("2026-02-24T09:59:59Z", now), isNull);
-    });
-
-    test("returns null when active_until is absent or invalid", () {
-      expect(resolveAccountExpirySchedule(null, now), isNull);
-      expect(resolveAccountExpirySchedule("", now), isNull);
-      expect(resolveAccountExpirySchedule("invalid", now), isNull);
     });
   });
 }
@@ -669,6 +723,7 @@ _ExpirySubject _expirySubject({
   AccountType type = AccountType.libre,
   bool active = false,
   Map<String, dynamic>? metadata,
+  String? rawMetadata,
 }) {
   final account = _TestAccountStore();
   account.account = _accountState(activeUntil: expiredAt, type: type, active: active);
@@ -679,7 +734,9 @@ _ExpirySubject _expirySubject({
   final persistence = MockPersistence();
   when(
     persistence.load(any, "account:refresh"),
-  ).thenAnswer((_) async => metadata == null ? null : jsonEncode(metadata));
+  ).thenAnswer(
+    (_) async => rawMetadata ?? (metadata == null ? null : jsonEncode(metadata)),
+  );
   Core.register<NotificationActor>(notification);
   Core.register<Persistence>(persistence);
   Core.register<StageStore>(MockStageStore());

--- a/common/test/platform/account/refresh/refresh_test.dart
+++ b/common/test/platform/account/refresh/refresh_test.dart
@@ -402,6 +402,8 @@ void main() {
       });
     });
 
+    // The reported bug: repeat dispatches for one lapse, all carrying the same
+    // active_until, each showing the notification again.
     test("onAccountExpiryEvent notifies once for repeated events", () async {
       await withTrace((m) async {
         final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
@@ -413,22 +415,22 @@ void main() {
       });
     });
 
-    // The backend restamps active_until to now on every repeat webhook for a
-    // lapsed account, so each event carries a different expiry string. This is
-    // the actual reported bug.
-    test("onAccountExpiryEvent does not renotify when active_until is restamped", () async {
+    // The mark is the expiry, not the string carrying it.
+    test("onAccountExpiryEvent matches a stored expiry written in another offset", () async {
       await withTrace((m) async {
-        final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 2)));
+        final expiry = _agoUtc(const Duration(hours: 1));
+        // The same instant, expressed as +02:00 instead of Z.
+        final shifted = expiry.add(const Duration(hours: 2)).toIso8601String();
+        final sameInstant = "${shifted.replaceFirst("Z", "")}+02:00";
 
-        await subject.store.onAccountExpiryEvent(m);
-        subject.account.account = _accountState(
-          activeUntil: _agoUtc(const Duration(seconds: 1)),
-          type: AccountType.libre,
-          active: false,
+        final subject = _expirySubject(
+          expiredAt: expiry,
+          metadata: {"expiryNotifiedFor": sameInstant},
         );
+
         await subject.store.onAccountExpiryEvent(m);
 
-        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+        verifyNever(subject.notification.show(NotificationId.accountExpired, any));
       });
     });
 
@@ -436,9 +438,10 @@ void main() {
       "onAccountExpiryEvent skips the immediate notification after the scheduled one fired",
       () async {
         await withTrace((m) async {
+          final expiry = _agoUtc(const Duration(minutes: 5));
           final subject = _expirySubject(
-            expiredAt: _agoUtc(const Duration(minutes: 5)),
-            metadata: {"expiryScheduledFor": _agoUtc(const Duration(minutes: 5)).toIso8601String()},
+            expiredAt: expiry,
+            metadata: {"expiryScheduledFor": expiry.toIso8601String()},
           );
 
           await subject.store.onAccountExpiryEvent(m);
@@ -448,14 +451,17 @@ void main() {
       },
     );
 
-    test("onAccountExpiryEvent notifies again once the cooldown elapsed", () async {
+    // Having armed the alarm is not proof it was delivered: Android drops
+    // pending alarms on reboot and never re-arms them for an expired account.
+    // Past the grace window the push announces the lapse rather than trusting
+    // the record.
+    test("onAccountExpiryEvent notifies when the scheduled alarm is too old to vouch for",
+        () async {
       await withTrace((m) async {
+        final expiry = _agoUtc(const Duration(days: 2));
         final subject = _expirySubject(
-          expiredAt: _agoUtc(const Duration(days: 30)),
-          metadata: {
-            "expiryNotifiedAt": _agoUtc(const Duration(days: 8)).toIso8601String(),
-            "expiryScheduledFor": _agoUtc(const Duration(days: 30)).toIso8601String(),
-          },
+          expiredAt: expiry,
+          metadata: {"expiryScheduledFor": expiry.toIso8601String()},
         );
 
         await subject.store.onAccountExpiryEvent(m);
@@ -524,29 +530,21 @@ void main() {
       });
     });
 
-    // A restamped active_until can land seconds in the future on a slow device
-    // clock, which makes the account "expiring" rather than expired. That must
-    // not count as a renewal.
-    test("onAccountExpiryEvent does not renotify when a restamp lands just in the future",
-        () async {
+    // The mark must not survive a notification that was never shown, or the
+    // lapse is silenced for good.
+    test("onAccountExpiryEvent retries after the notification failed to show", () async {
       await withTrace((m) async {
         final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
+        when(subject.notification.show(NotificationId.accountExpired, any))
+            .thenAnswer((_) async => throw Exception("no permission"));
+
+        await expectLater(subject.store.onAccountExpiryEvent(m), throwsA(isA<Exception>()));
+
+        when(subject.notification.show(NotificationId.accountExpired, any))
+            .thenAnswer((_) async {});
         await subject.store.onAccountExpiryEvent(m);
 
-        subject.account.account = _accountState(
-          activeUntil: DateTime.now().toUtc().add(const Duration(seconds: 5)),
-          type: AccountType.libre,
-          active: false,
-        );
-        await subject.store.onAccountExpiryEvent(m);
-        subject.account.account = _accountState(
-          activeUntil: _agoUtc(const Duration(seconds: 1)),
-          type: AccountType.libre,
-          active: false,
-        );
-        await subject.store.onAccountExpiryEvent(m);
-
-        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
+        verify(subject.notification.show(NotificationId.accountExpired, any)).called(2);
       });
     });
 
@@ -604,7 +602,7 @@ void main() {
       final meta = JsonAccRefreshMeta(
         previousAccountType: AccountType.plus,
         seenExpiredDialog: true,
-        expiryNotifiedAt: "2026-02-23T11:30:00.000Z",
+        expiryNotifiedFor: "2026-02-23T11:30:00.000Z",
         expiryScheduledFor: "2026-02-20T11:30:00.000Z",
       );
 
@@ -612,7 +610,7 @@ void main() {
 
       expect(decoded.previousAccountType, AccountType.plus);
       expect(decoded.seenExpiredDialog, true);
-      expect(decoded.expiryNotifiedAt, "2026-02-23T11:30:00.000Z");
+      expect(decoded.expiryNotifiedFor, "2026-02-23T11:30:00.000Z");
       expect(decoded.expiryScheduledFor, "2026-02-20T11:30:00.000Z");
     });
 
@@ -622,14 +620,14 @@ void main() {
         "seenExpiredDialog": true,
       });
 
-      expect(decoded.expiryNotifiedAt, isNull);
+      expect(decoded.expiryNotifiedFor, isNull);
       expect(decoded.expiryScheduledFor, isNull);
     });
 
     test("treats a non-string stored timestamp as absent", () {
-      final decoded = JsonAccRefreshMeta.fromJson({"expiryNotifiedAt": 42});
+      final decoded = JsonAccRefreshMeta.fromJson({"expiryNotifiedFor": 42});
 
-      expect(decoded.expiryNotifiedAt, isNull);
+      expect(decoded.expiryNotifiedFor, isNull);
     });
   });
 }

--- a/common/test/platform/account/refresh/refresh_test.dart
+++ b/common/test/platform/account/refresh/refresh_test.dart
@@ -434,42 +434,6 @@ void main() {
       });
     });
 
-    test(
-      "onAccountExpiryEvent skips the immediate notification after the scheduled one fired",
-      () async {
-        await withTrace((m) async {
-          final expiry = _agoUtc(const Duration(minutes: 5));
-          final subject = _expirySubject(
-            expiredAt: expiry,
-            metadata: {"expiryScheduledFor": expiry.toIso8601String()},
-          );
-
-          await subject.store.onAccountExpiryEvent(m);
-
-          verifyNever(subject.notification.show(NotificationId.accountExpired, any));
-        });
-      },
-    );
-
-    // Having armed the alarm is not proof it was delivered: Android drops
-    // pending alarms on reboot and never re-arms them for an expired account.
-    // Past the grace window the push announces the lapse rather than trusting
-    // the record.
-    test("onAccountExpiryEvent notifies when the scheduled alarm is too old to vouch for",
-        () async {
-      await withTrace((m) async {
-        final expiry = _agoUtc(const Duration(days: 2));
-        final subject = _expirySubject(
-          expiredAt: expiry,
-          metadata: {"expiryScheduledFor": expiry.toIso8601String()},
-        );
-
-        await subject.store.onAccountExpiryEvent(m);
-
-        verify(subject.notification.show(NotificationId.accountExpired, any)).called(1);
-      });
-    });
-
     test("onAccountExpiryEvent notifies again after a renewal and a later expiry", () async {
       await withTrace((m) async {
         final subject = _expirySubject(expiredAt: _agoUtc(const Duration(hours: 1)));
@@ -562,9 +526,9 @@ void main() {
       });
     });
 
-    // The immediate notification is the fallback for a schedule that never
-    // landed, so a failed schedule must not record one.
-    test("syncAccount does not record a scheduled expiry when scheduling failed", () async {
+    // Scheduling used to be unawaited, so a failure was dropped on the floor.
+    // It is now visible, and must still not take syncAccount down with it.
+    test("syncAccount survives a scheduled notification that could not be armed", () async {
       await withTrace((m) async {
         final expiry = DateTime.now().toUtc().add(const Duration(days: 3));
         final subject = _expirySubject(expiredAt: expiry, type: AccountType.plus, active: true);
@@ -573,37 +537,17 @@ void main() {
 
         await subject.store.syncAccount(subject.account.account, m);
 
-        final saved = verify(subject.persistence.save(any, "account:refresh", captureAny))
-            .captured
-            .map((json) => jsonDecode(json as String) as Map<String, dynamic>)
-            .toList();
-        expect(saved.every((entry) => entry["expiryScheduledFor"] == null), isTrue);
-      });
-    });
-
-    test("syncAccount records the expiry the notification was scheduled for", () async {
-      await withTrace((m) async {
-        final expiry = DateTime.now().toUtc().add(const Duration(days: 3));
-        final subject = _expirySubject(expiredAt: expiry, type: AccountType.plus, active: true);
-
-        await subject.store.syncAccount(subject.account.account, m);
-
-        final saved = verify(
-          subject.persistence.save(any, "account:refresh", captureAny),
-        ).captured.map((json) => jsonDecode(json as String) as Map<String, dynamic>).toList();
-        expect(saved, isNotEmpty);
-        expect(saved.last["expiryScheduledFor"], expiry.toIso8601String());
+        expect(subject.store.expiration.status, AccountStatus.active);
       });
     });
   });
 
   group("JsonAccRefreshMeta", () {
-    test("round trips the expiry guard fields", () {
+    test("round trips the expiry guard field", () {
       final meta = JsonAccRefreshMeta(
         previousAccountType: AccountType.plus,
         seenExpiredDialog: true,
         expiryNotifiedFor: "2026-02-23T11:30:00.000Z",
-        expiryScheduledFor: "2026-02-20T11:30:00.000Z",
       );
 
       final decoded = JsonAccRefreshMeta.fromJson(jsonDecode(jsonEncode(meta.toJson())));
@@ -611,17 +555,15 @@ void main() {
       expect(decoded.previousAccountType, AccountType.plus);
       expect(decoded.seenExpiredDialog, true);
       expect(decoded.expiryNotifiedFor, "2026-02-23T11:30:00.000Z");
-      expect(decoded.expiryScheduledFor, "2026-02-20T11:30:00.000Z");
     });
 
-    test("reads metadata that predates the expiry guard fields", () {
+    test("reads metadata that predates the expiry guard field", () {
       final decoded = JsonAccRefreshMeta.fromJson({
         "previousAccountType": AccountType.plus.toSimpleString(),
         "seenExpiredDialog": true,
       });
 
       expect(decoded.expiryNotifiedFor, isNull);
-      expect(decoded.expiryScheduledFor, isNull);
     });
 
     test("treats a non-string stored timestamp as absent", () {
@@ -709,9 +651,8 @@ class _ExpirySubject {
   final AccountRefreshStore store;
   final _TestAccountStore account;
   final MockNotificationActor notification;
-  final MockPersistence persistence;
 
-  _ExpirySubject(this.store, this.account, this.notification, this.persistence);
+  _ExpirySubject(this.store, this.account, this.notification);
 }
 
 // A store wired for the expiry-notification paths, with persistence that
@@ -741,7 +682,7 @@ _ExpirySubject _expirySubject({
   Core.register<Scheduler>(MockScheduler());
   Core.register<PlusActor>(MockPlusActor());
 
-  return _ExpirySubject(AccountRefreshStore(), account, notification, persistence);
+  return _ExpirySubject(AccountRefreshStore(), account, notification);
 }
 
 class _TestAccountStore extends MockAccountStore {


### PR DESCRIPTION
## Why

blokadaorg/issue-tracker#344 — an expired v6 account gets the "account expired" notification
more than once, days apart.

Every `account_expiry` FCM event runs `_maybeShowImmediateAccountExpiryNotification`, whose
only guards were family-linked mode and "the expiry is in the future". A repeat event for an
already-expired account showed the notification again.

The server-side cause is fixed in blokadaorg/api#69. This is the client half: it holds
regardless of how often the server dispatches for one lapse.

## What

**One notification per expiry, keyed by the expiry itself.** `JsonAccRefreshMeta` gains
`expiryNotifiedFor` — the expiry the notification announced, not the time it was shown. The
immediate path skips when it matches the expiry now in hand. Instants are compared, not the
raw strings, so a formatting change on the server cannot defeat the match.

The next lapse carries a different `active_until` by construction, so nothing needs re-arming
on renewal and there is no window to tune. This depends on `active_until` staying stable for a
lapse, which blokadaorg/api#69 fixed and is merged — a future change that restamps a lapsed
account's expiry would silently re-open this bug.

The lapse is claimed before the `show()` await, since nothing serializes the FCM handler and
a burst would otherwise slip several notifications past the check. A failed `show()` gives the
claim back, so a mark can never outlive a notification that was not delivered.

**Behaviour change:** an account with no parsable `active_until` no longer shows the
notification at all. It previously fell through the same branch as an expired one and
announced an expiry with no date.

**Also fixed:** metadata now loads through `_ensureMetadataLoaded`, called from
`onAccountExpiryEvent` as well as `init()`. A background FCM can land before `init()` ran —
`handleFcmEvent` only requires `_account.account != null`, which the bootstrap preload can
satisfy first — and the guard must not read defaults or save over the stored
`previousAccountType` / `seenExpiredDialog`. A corrupt blob falls back to fresh metadata
instead of throwing before the account is even refreshed. `_updateTimer` now awaits its
`show()`, so a scheduling failure is logged rather than dropped on the floor.

## Not in scope

An earlier revision also suppressed the immediate notification when an OS notification had
been scheduled for the same expiry. That is removed: after keying on the expiry it no longer
catches the pair it was written for, and it was the only part of the guard that could leave a
real lapse unannounced. Reasoning in `84918106`.

The duplicate it was aiming at is a stale alarm, not a dedupe problem, and fixing it properly
needs Android-side work — an alarm-only cancel, a delivery marker in
`NotificationAlarmReceiver.onReceive`, and re-arming in `BootReceiver`, which currently only
logs. That is one coherent change in one layer and belongs in its own issue.

## Tests

Six cases in `refresh_test.dart` plus three `JsonAccRefreshMeta` cases, including stored
metadata that predates the field. The load-bearing one is `notifies once for repeated events`.

Verified by falsification: neutralising the expiry match fails the two dedupe tests and the
concurrency one, comparing raw strings instead of instants fails only the offset test,
dropping the claim restore fails only the retry test, and dropping the schedule catch fails
only the arming test.

`make test` green (479 tests). `flutter analyze` reports the same 441 issues as `main`, zero
errors.

## Not verified here

Push delivery itself is not covered by the Appium suite. Worth a device check before release:
let an account lapse, send two `account_expiry` pushes a minute apart, confirm one
notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NC1HnqYRypEd6ZGhAwgSyM
